### PR TITLE
Feat: Remove test directory restriction from WriteTool

### DIFF
--- a/test/fixtures/workflow_with_write_file_config.yml
+++ b/test/fixtures/workflow_with_write_file_config.yml
@@ -1,0 +1,10 @@
+name: WriteFile Config Test
+tools:
+  - Roast::Tools::WriteFile
+steps:
+  - write_step
+functions:
+  write_file:
+    cached: true
+    params:
+      restrict: "src/"

--- a/test/roast/workflow/configuration_test.rb
+++ b/test/roast/workflow/configuration_test.rb
@@ -125,6 +125,23 @@ module Roast
           assert_equal({}, configuration.function_config("nonexistent"))
         end
       end
+
+      class WriteFileConfigTest < ActiveSupport::TestCase
+        FIXTURES = File.expand_path("../../../test/fixtures", __dir__)
+
+        def setup
+          @options = {}
+          @workflow_path = File.join(FIXTURES, "workflow_with_write_file_config.yml")
+        end
+
+        def test_write_file_function_config
+          configuration = Roast::Workflow::Configuration.new(@workflow_path, @options)
+          write_file_config = configuration.function_config("write_file")
+
+          assert_equal(true, write_file_config["cached"])
+          assert_equal("src/", write_file_config["params"]["restrict"])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
In order to enable more use cases for the WriteTool, this commit removes the `/tests` restriction on the WriteTool. It adds a configurable parameter that allows restricting where the WriteTool can actually write files to so we can preserve the existing behavior through configuration.