### PR TITLE
Specify correct gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,13 +423,13 @@ your-project/
 ## Installation
 
 ```bash
-$ gem install roast
+$ gem install roast-ai
 ```
 
 Or add to your Gemfile:
 
 ```ruby
-gem 'roast'
+gem 'roast-ai'
 ```
 
 ## Development


### PR DESCRIPTION
Roast is published to https://rubygems.org/gems/roast-ai