### PR TITLE
Remove RuboCop autocorrect from default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,8 +12,6 @@ end
 
 task test: [:minitest]
 
-RuboCop::RakeTask.new do |task|
-  task.options = ["--autocorrect"]
-end
+RuboCop::RakeTask.new
 
 task default: [:test, :rubocop]


### PR DESCRIPTION
While the autocorrect flag is convienent for the default Rake task it has the unintended side effect of causing RuboCop violations in CI to be corrected instead of failing a PR! This PR just removes the flag so that we can rest assured that CI will fail as expected. 😅 

See also: https://github.com/Shopify/roast/pull/27