### PR TITLE
Add separate CI rake task

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,5 +25,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rake
+      - run: bundle exec rake ci
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,11 @@ end
 
 task test: [:minitest]
 
-RuboCop::RakeTask.new do |task|
+RuboCop::RakeTask.new(:rubocop_ci)
+
+task ci: [:test, :rubocop_ci]
+
+RuboCop::RakeTask.new(:rubocop) do |task|
   task.options = ["--autocorrect"]
 end
 


### PR DESCRIPTION
This PR adds a new Rake task called `ci` to use for testing PRs. This new task is the same as the default one except that it skips the `autocorrect` flag on RuboCop so that any violations would fail the CI job.