### PR TITLE
Improve search tool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gemspec
 
 gem "cgi"
 gem "dotenv"
-gem "guard-rspec"
 gem "guard"
 gem "mocha"
 gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,6 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    diff-lcs (1.6.1)
     dotenv (3.1.8)
     drb (2.2.1)
     event_stream_parser (1.0.0)
@@ -65,11 +64,6 @@ GEM
       pry (>= 0.13.0)
       shellany (~> 0.0)
       thor (>= 0.18.1)
-    guard-compat (1.2.1)
-    guard-rspec (4.7.3)
-      guard (~> 2.1)
-      guard-compat (~> 1.1)
-      rspec (>= 2.99.0, < 4.0)
     hashdiff (1.1.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
@@ -123,19 +117,6 @@ GEM
       ffi (~> 1.0)
     regexp_parser (2.10.0)
     rexml (3.4.1)
-    rspec (3.13.0)
-      rspec-core (~> 3.13.0)
-      rspec-expectations (~> 3.13.0)
-      rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.3)
-      rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.3)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.2)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.13.0)
-    rspec-support (3.13.2)
     rubocop (1.75.3)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -182,7 +163,6 @@ DEPENDENCIES
   cgi
   dotenv
   guard
-  guard-rspec
   mocha
   pry
   rake

--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -29,6 +29,11 @@ module Roast
       Roast::Workflow::ConfigurationParser.new(expanded_workflow_path, files, options.transform_keys(&:to_sym)).begin!
     end
 
+    desc "version", "Display the current version of Roast"
+    def version
+      puts "Roast version #{Roast::VERSION}"
+    end
+
     class << self
       def exit_on_failure?
         true

--- a/lib/roast/initializers.rb
+++ b/lib/roast/initializers.rb
@@ -30,6 +30,7 @@ module Roast
           require file
         end
       rescue => e
+        puts "ERROR: Error loading initializers: #{e.message}"
         Roast::Helpers::Logger.error("Error loading initializers: #{e.message}")
         # Don't fail the workflow if initializers can't be loaded
       end

--- a/lib/roast/tools/search_file.rb
+++ b/lib/roast/tools/search_file.rb
@@ -26,7 +26,7 @@ module Roast
       end
 
       def call(glob_pattern, path = ".")
-        Roast::Helpers::Logger.info("🔍 Searching for file: #{glob_pattern}\n")
+        Roast::Helpers::Logger.info("🔍 Searching for: '#{glob_pattern}' in '#{path}'\n")
         search_for(glob_pattern, path).then do |results|
           return "No results found for #{glob_pattern} in #{path}" if results.empty?
           return read_contents(results.first) if results.size == 1
@@ -34,7 +34,7 @@ module Roast
           results.join("\n") # purposely give the AI list of actual paths so that it can read without searching first
         end
       rescue StandardError => e
-        "Error searching for file: #{e.message}".tap do |error_message|
+        "Error searching for '#{glob_pattern}' in '#{path}': #{e.message}".tap do |error_message|
           Roast::Helpers::Logger.error(error_message + "\n")
           Roast::Helpers::Logger.debug(e.backtrace.join("\n") + "\n") if ENV["DEBUG"]
         end

--- a/test/roast/tools/search_file_test.rb
+++ b/test/roast/tools/search_file_test.rb
@@ -31,58 +31,86 @@ class RoastToolsSearchFileTest < ActiveSupport::TestCase
     FileUtils.remove_entry(@temp_dir) if File.exist?(@temp_dir)
   end
 
-  test ".search_for returns matching files" do
+  test ".search_for returns matching files with glob patterns" do
     rel_file1 = @test_file1.sub("#{@temp_dir}/", "")
     rel_file2 = @test_file2.sub("#{@temp_dir}/", "")
     rel_file3 = @test_file3.sub("#{@temp_dir}/", "")
 
-    # Test exact match
-    results = Roast::Tools::SearchFile.search_for("test_file1.txt")
+    # Test exact match with glob
+    results = Roast::Tools::SearchFile.search_for("test_file1.txt", ".")
     assert_includes results, rel_file1
 
-    # Test partial match
-    results = Roast::Tools::SearchFile.search_for("test_file")
+    # Test wildcard pattern
+    results = Roast::Tools::SearchFile.search_for("**/*file*.txt", ".")
     assert_includes results, rel_file1
     assert_includes results, rel_file2
-    assert_includes results, rel_file3
+    refute_includes results, rel_file3
 
     # Test extension match
-    results = Roast::Tools::SearchFile.search_for(".rb")
+    results = Roast::Tools::SearchFile.search_for("**/*.rb", ".")
     assert_includes results, rel_file3
     refute_includes results, rel_file1
     refute_includes results, rel_file2
 
     # Test directory match
-    results = Roast::Tools::SearchFile.search_for("nested")
+    results = Roast::Tools::SearchFile.search_for("nested/**/*", ".")
     assert_includes results, rel_file2
     assert_includes results, rel_file3
     refute_includes results, rel_file1
   end
 
+  test ".search_for with custom path parameter" do
+    rel_file1 = @test_file1.sub("#{@temp_dir}/", "")
+    rel_file2 = @test_file2.sub("#{@temp_dir}/", "")
+    rel_file3 = @test_file3.sub("#{@temp_dir}/", "")
+
+    # Test with nested path
+    nested_dir = File.join("nested")
+    results = Roast::Tools::SearchFile.search_for("**/*file*.txt", nested_dir)
+    assert_includes results, "test_file2.txt"
+    refute_includes results, rel_file1
+    refute_includes results, rel_file3
+
+    # Test with deep nested path
+    deep_dir = File.join("nested", "deep")
+    results = Roast::Tools::SearchFile.search_for("**/*.rb", deep_dir)
+    assert_includes results, "test_file3.rb"
+    refute_includes results, rel_file1
+    refute_includes results, rel_file2
+  end
+
   test ".call returns file content for single match" do
-    Roast::Tools::SearchFile.stubs(:search_for).returns(["test_file1.txt"])
-    Roast::Tools::ReadFile.stubs(:call).returns("file content")
+    Roast::Tools::SearchFile.stubs(:search_for).with("test_file1.txt", ".").returns(["test_file1.txt"])
+    Roast::Tools::SearchFile.stubs(:read_contents).with("test_file1.txt").returns("file content")
 
     result = Roast::Tools::SearchFile.call("test_file1.txt")
     assert_equal "file content", result
   end
 
+  test ".call with path parameter passes path to search_for" do
+    Roast::Tools::SearchFile.expects(:search_for).with("test_file", "nested/dir").returns(["nested/dir/test_file.txt"])
+    Roast::Tools::SearchFile.stubs(:read_contents).with("nested/dir/test_file.txt").returns("file content")
+
+    result = Roast::Tools::SearchFile.call("test_file", "nested/dir")
+    assert_equal "file content", result
+  end
+
   test ".call returns file list for multiple matches" do
-    Roast::Tools::SearchFile.stubs(:search_for).returns(["file1.txt", "file2.txt"])
+    Roast::Tools::SearchFile.stubs(:search_for).with("file", ".").returns(["file1.txt", "file2.txt"])
 
     result = Roast::Tools::SearchFile.call("file")
-    assert_equal ["file1.txt", "file2.txt"].inspect, result
+    assert_equal "file1.txt\nfile2.txt", result
   end
 
   test ".call returns no results message when empty" do
-    Roast::Tools::SearchFile.stubs(:search_for).returns([])
+    Roast::Tools::SearchFile.stubs(:search_for).with("nonexistent", ".").returns([])
 
     result = Roast::Tools::SearchFile.call("nonexistent")
-    assert_equal "No results found for nonexistent", result
+    assert_equal "No results found for nonexistent in .", result
   end
 
   test ".call handles errors gracefully" do
-    Roast::Tools::SearchFile.stubs(:search_for).raises(StandardError, "Search failed")
+    Roast::Tools::SearchFile.stubs(:search_for).with("test_file", ".").raises(StandardError, "Search failed")
 
     result = Roast::Tools::SearchFile.call("test_file")
     assert_equal "Error searching for file: Search failed", result
@@ -106,5 +134,7 @@ class RoastToolsSearchFileTest < ActiveSupport::TestCase
     Roast::Tools::SearchFile.included(DummyBaseClass)
     assert_equal true, DummyBaseClass.function_called
     assert_equal :search_for_file, DummyBaseClass.function_name
+    assert_equal({ type: "string", description: "A glob pattern to search for. Example: 'test/**/*_test.rb'" }, DummyBaseClass.function_params[:glob_pattern])
+    assert_equal({ type: "string", description: "path to search from" }, DummyBaseClass.function_params[:path])
   end
 end


### PR DESCRIPTION
This PR changes the search tool from using `find` to a glob pattern. It also fixes some bugs I found while testing.

- Replaced `find` command with native Ruby `Dir.glob` in SearchFile tool for improved cross-platform compatibility
- Updated SearchFile API to use glob patterns instead of shell pattern matching
- Added ability to specify a search path in SearchFile tool
- Improved error messages in SearchFile with more context about the search
- Changed multiple file results format to use newline-separated paths for better readability