### PR TITLE
Fixed failing test caused by out-of-date error message assertion

### DIFF
--- a/test/roast/tools/search_file_test.rb
+++ b/test/roast/tools/search_file_test.rb
@@ -113,7 +113,7 @@ class RoastToolsSearchFileTest < ActiveSupport::TestCase
     Roast::Tools::SearchFile.stubs(:search_for).with("test_file", ".").raises(StandardError, "Search failed")
 
     result = Roast::Tools::SearchFile.call("test_file")
-    assert_equal "Error searching for file: Search failed", result
+    assert_equal "Error searching for 'test_file' in '.': Search failed", result
   end
 
   class DummyBaseClass


### PR DESCRIPTION
Roast::Tools::SearchFile was updated with more specific error messaging, but the test was still testing for the old message.

Relevant code in the source file:

```
      rescue StandardError => e
        "Error searching for '#{glob_pattern}' in '#{path}': #{e.message}".tap do |error_message|
          Roast::Helpers::Logger.error(error_message + "\n")
          Roast::Helpers::Logger.debug(e.backtrace.join("\n") + "\n") if ENV["DEBUG"]
        end
```