### PR TITLE
Feat: Add support for OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,26 @@ Individual steps can override this setting with their own model parameter:
 
 ```yaml
 analyze_data:
-  model: anthropic:claude-3-haiku  # Takes precedence over the global model
+  model: anthropic/claude-3-haiku  # Takes precedence over the global model
 ```
+
+#### API Provider Configuration
+
+Roast supports both OpenAI and OpenRouter as API providers. By default, Roast uses OpenAI, but you can specify OpenRouter:
+
+```yaml
+name: My Workflow
+api_provider: openrouter
+api_token: $(echo $OPENROUTER_API_KEY)
+model: anthropic/claude-3-opus-20240229
+```
+
+Benefits of using OpenRouter:
+- Access to multiple model providers through a single API
+- Support for models from Anthropic, Meta, Mistral, and more
+- Consistent API interface across different model providers
+
+When using OpenRouter, specify fully qualified model names including the provider prefix (e.g., `anthropic/claude-3-opus-20240229`).
 
 #### Dynamic API Tokens
 
@@ -309,8 +327,12 @@ Roast allows you to dynamically fetch API tokens using shell commands directly i
 # This will execute the shell command and use the result as the API token
 api_token: $(print-token --key)
 
-# Or a simpler example for demonstration:
+# For OpenAI (default)
 api_token: $(echo $OPENAI_API_KEY)
+
+# For OpenRouter (requires api_provider setting)
+api_provider: openrouter
+api_token: $(echo $OPENROUTER_API_KEY)
 ```
 
 This makes it easy to use environment-specific tokens without hardcoding credentials, especially useful in development environments or CI/CD pipelines.

--- a/examples/openrouter_example/README.md
+++ b/examples/openrouter_example/README.md
@@ -1,0 +1,48 @@
+# OpenRouter Example
+
+This example demonstrates how to use OpenRouter with Roast to access models from different providers through a single API.
+
+## Setup
+
+1. Sign up for an account at [OpenRouter](https://openrouter.ai/)
+2. Get your API key from the OpenRouter dashboard
+3. Set the API key as an environment variable:
+   ```bash
+   export OPENROUTER_API_KEY=your_api_key_here
+   ```
+
+## Running the Example
+
+```bash
+# Run without a specific target (general analysis)
+roast execute workflow.yml
+
+# Run with a specific file to analyze
+roast execute workflow.yml path/to/your/file.txt
+```
+
+## How it Works
+
+This example configures Roast to use OpenRouter as the API provider:
+
+```yaml
+api_provider: openrouter
+api_token: $(echo $OPENROUTER_API_KEY)
+model: anthropic/claude-3-haiku-20240307
+```
+
+The workflow consists of two steps:
+1. `analyze_input`: Analyzes the provided content (or generates general insights if no target is provided)
+2. `generate_response`: Creates a structured response based on the analysis
+
+## Available Models
+
+When using OpenRouter, you can access models from multiple providers by specifying the fully qualified model name, including the provider prefix. Some examples:
+
+- `anthropic/claude-3-opus-20240229`
+- `anthropic/claude-3-sonnet-20240229`
+- `meta/llama-3-70b-instruct`
+- `google/gemini-1.5-pro-latest`
+- `mistral/mistral-large-latest`
+
+Check the [OpenRouter documentation](https://openrouter.ai/docs) for the complete list of supported models.

--- a/examples/openrouter_example/analyze_input/prompt.md
+++ b/examples/openrouter_example/analyze_input/prompt.md
@@ -1,0 +1,16 @@
+I'd like you to analyze the following input and provide your insights.
+
+<% if workflow.file && workflow.resource.content %>
+Here is the content to analyze:
+
+```
+<%= workflow.resource.content %>
+```
+<% else %>
+The workflow is running without a specific file target. Please provide general insights based on the context.
+<% end %>
+
+Please provide:
+1. A summary of the key points
+2. Any notable patterns or issues
+3. Recommendations based on your analysis

--- a/examples/openrouter_example/generate_response/prompt.md
+++ b/examples/openrouter_example/generate_response/prompt.md
@@ -1,0 +1,9 @@
+Based on the analysis from the previous step, please generate a response that addresses the findings.
+
+Your response should be well-structured and include:
+1. An introduction summarizing the analysis
+2. Detailed discussion of key points
+3. Clear recommendations for improvements
+4. A conclusion
+
+Format the response in markdown for better readability.

--- a/examples/openrouter_example/workflow.yml
+++ b/examples/openrouter_example/workflow.yml
@@ -1,0 +1,12 @@
+name: OpenRouter Example
+api_provider: openrouter
+api_token: $(echo $OPENROUTER_API_KEY)
+model: anthropic/claude-3-haiku-20240307
+
+tools:
+  - Roast::Tools::ReadFile
+  - Roast::Tools::WriteFile
+
+steps:
+  - analyze_input
+  - generate_response

--- a/lib/roast/workflow/configuration_parser.rb
+++ b/lib/roast/workflow/configuration_parser.rb
@@ -6,6 +6,7 @@ require_relative "../helpers/function_caching_interceptor"
 require "active_support"
 require "active_support/isolated_execution_state"
 require "active_support/notifications"
+require "raix"
 
 module Roast
   module Workflow
@@ -117,16 +118,16 @@ module Roast
         return unless configuration.api_token
 
         begin
-          require "raix"
+          case configuration.api_provider
+          when :openrouter
+            $stderr.puts "Configuring OpenRouter client with token from workflow"
+            require "open_router"
 
-          # Configure OpenAI client with the token
-          $stderr.puts "Configuring API client with token from workflow"
-
-          # Initialize the OpenAI client if it doesn't exist
-          if defined?(Raix.configuration.openai_client)
-            # Create a new client with the token
-            Raix.configuration.openai_client = OpenAI::Client.new(access_token: configuration.api_token)
+            Raix.configure do |config|
+              config.openrouter_client = OpenRouter::Client.new(api_key: configuration.api_token)
+            end
           else
+            $stderr.puts "Configuring OpenAI client with token from workflow"
             require "openai"
 
             Raix.configure do |config|

--- a/test/fixtures/files/openrouter_workflow.yml
+++ b/test/fixtures/files/openrouter_workflow.yml
@@ -1,0 +1,6 @@
+name: OpenRouter Workflow Test
+api_provider: openrouter
+api_token: test_openrouter_token
+model: anthropic/claude-3-opus-20240229
+steps:
+  - test_step

--- a/test/roast/workflow/configuration_openrouter_test.rb
+++ b/test/roast/workflow/configuration_openrouter_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Workflow
+    class ConfigurationOpenRouterTest < Minitest::Test
+      def setup
+        @workflow_path = File.expand_path("../../fixtures/files/openrouter_workflow.yml", __dir__)
+        @configuration = Configuration.new(@workflow_path)
+      end
+
+      def test_api_token
+        assert_equal("test_openrouter_token", @configuration.api_token)
+      end
+
+      def test_api_provider
+        assert_equal(:openrouter, @configuration.api_provider)
+      end
+
+      def test_openrouter_predicate
+        assert(@configuration.openrouter?)
+        refute(@configuration.openai?)
+      end
+
+      def test_model
+        assert_equal("anthropic/claude-3-opus-20240229", @configuration.model)
+      end
+    end
+  end
+end

--- a/test/roast/workflow/configuration_parser_openrouter_test.rb
+++ b/test/roast/workflow/configuration_parser_openrouter_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "mocha/minitest"
+
+module Roast
+  module Workflow
+    class ConfigurationParserOpenRouterTest < Minitest::Test
+      def setup
+        @workflow_path = File.expand_path("../../fixtures/files/openrouter_workflow.yml", __dir__)
+      end
+
+      def test_configure_openrouter_client
+        setup_openrouter_constants
+
+        mock_openrouter_client = mock
+        OpenRouter::Client.stubs(:new).with(api_key: "test_openrouter_token").returns(mock_openrouter_client)
+
+        ConfigurationParser.new(@workflow_path)
+      end
+
+      def setup_openrouter_constants
+        unless defined?(::OpenRouter)
+          Object.const_set(:OpenRouter, Module.new)
+        end
+
+        unless defined?(::OpenRouter::Client)
+          OpenRouter.const_set(:Client, Class.new)
+        end
+      end
+
+      def teardown
+        OpenRouter.send(:remove_const, :Client) if defined?(::OpenRouter) && defined?(::OpenRouter::Client)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to enable more than just OpenAI as a backend, this commit adds a new api_provider configuration option. This allows us to set openrouter or openai as the provider and correctly set up our model through Raix. It's worth mentioning that the default behavior of OpenAI is preserved and this configuration option should be only additive.

This closes #21 