### PR TITLE
Show expanded path on Search tool logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Improved
+- Enhanced search file tool logging to show full expanded paths instead of relative paths
+
 ## [0.1.6] - 2024-05-15
 
 ### Added

--- a/lib/roast/tools/search_file.rb
+++ b/lib/roast/tools/search_file.rb
@@ -26,7 +26,7 @@ module Roast
       end
 
       def call(glob_pattern, path = ".")
-        Roast::Helpers::Logger.info("🔍 Searching for: '#{glob_pattern}' in '#{path}'\n")
+        Roast::Helpers::Logger.info("🔍 Searching for: '#{glob_pattern}' in '#{File.expand_path(path)}'\n")
         search_for(glob_pattern, path).then do |results|
           return "No results found for #{glob_pattern} in #{path}" if results.empty?
           return read_contents(results.first) if results.size == 1


### PR DESCRIPTION
## Search file tool enhancement

  This PR improves the search file tool's logging by displaying the full expanded path in the search message instead of the relative path. This makes it easier for users to understand
  exactly where files are being searched.

  ### Changes
  - Updated the search message in `search_file.rb` to show the absolute path using `File.expand_path`