### PR TITLE
Do not disable Minitest exit hook

### DIFF
--- a/lib/roast/helpers/minitest_coverage_runner.rb
+++ b/lib/roast/helpers/minitest_coverage_runner.rb
@@ -4,16 +4,6 @@ require "coverage"
 require "minitest"
 require_relative "logger"
 
-# Disable the built-in `at_exit` hook for Minitest before anything else
-module Minitest
-  class << self
-    alias_method :original_at_exit, :at_exit
-    def at_exit(*)
-      # Do nothing to prevent autorun hooks
-    end
-  end
-end
-
 module Roast
   module Helpers
     class TestStatsCollector


### PR DESCRIPTION
I confess I do not have the context on why we wanted to disable normal Minitest exit behavior but this is causing our CI to always be green even with failing tests. See #26 for demonstration. All this PR does is remove that change to Minitest.