### PR TITLE
Restore Minitest at_exit hook for Roast tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,12 @@ $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 # Require the main file
 require "roast"
 
+module Minitest
+  class << self
+    alias_method :at_exit, :original_at_exit
+  end
+end
+
 # Require test helpers
 require_relative "support/fixture_helpers"
 require_relative "support/improved_assertions"


### PR DESCRIPTION
This is a different take on #40 so that we just go back to Minitest's original implementation of `at_exit` so that the Roast test suite exits as expected.