### PR TITLE
Fix model access errors unhelpful

### DIFF
--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -3,6 +3,7 @@
 require "raix"
 require "thor"
 require "roast/version"
+require "roast/errors"
 require "roast/tools"
 require "roast/helpers"
 require "roast/resources"

--- a/lib/roast/errors.rb
+++ b/lib/roast/errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Roast
+  # Custom error for API resource not found (404) responses
+  class ResourceNotFoundError < StandardError; end
+
+  # Custom error for when API authentication fails
+  class AuthenticationError < StandardError; end
+end

--- a/lib/roast/workflow/base_workflow.rb
+++ b/lib/roast/workflow/base_workflow.rb
@@ -105,17 +105,15 @@ module Roast
           })
           result
         end
+      rescue Faraday::ResourceNotFound => e
+        execution_time = Time.now - start_time
+        message = e.response.dig(:body, "error", "message") || e.message
+        error = Roast::ResourceNotFoundError.new(message)
+        e.set_backtrace([])
+        log_and_raise_error(error, message, step_model, kwargs, execution_time)
       rescue => e
         execution_time = Time.now - start_time
-
-        ActiveSupport::Notifications.instrument("roast.chat_completion.error", {
-          error: e.class.name,
-          message: e.message,
-          model: step_model,
-          parameters: kwargs.except(:openai, :model),
-          execution_time: execution_time,
-        })
-        raise
+        log_and_raise_error(e, e.message, step_model, kwargs, execution_time)
       end
 
       def workflow
@@ -123,6 +121,18 @@ module Roast
       end
 
       private
+
+      def log_and_raise_error(error, message, model, params, execution_time)
+        ActiveSupport::Notifications.instrument("roast.chat_completion.error", {
+          error: error.class.name,
+          message: message,
+          model: model,
+          parameters: params.except(:openai, :model),
+          execution_time: execution_time,
+        })
+
+        raise error
+      end
 
       # Determine the directory where the actual class is defined, not BaseWorkflow
       def determine_context_path

--- a/test/fixtures/files/workflow/workflow.yml
+++ b/test/fixtures/files/workflow/workflow.yml
@@ -1,4 +1,6 @@
 name: Grading current test changes
+api_provider: openai
+api_token: test_openai_token
 
 tools:
   - Roast::Tools::Grep

--- a/test/fixtures/targetless_workflow.yml
+++ b/test/fixtures/targetless_workflow.yml
@@ -1,4 +1,7 @@
 name: Targetless Workflow
+api_provider: openai
+api_token: test_openai_token
+
 tools: 
   - Roast::Tools::Grep
   - Roast::Tools::ReadFile

--- a/test/roast/helpers/prompt_loader_test.rb
+++ b/test/roast/helpers/prompt_loader_test.rb
@@ -7,6 +7,10 @@ class RoastHelpersPromptLoaderTest < ActiveSupport::TestCase
   def setup
     @workflow_file = fixture_file("workflow/workflow.yml")
     @test_file = fixture_file("test.rb")
+    mock_openai_client = mock
+    OpenAI::Client.stubs(:new).with(access_token: "test_openai_token").returns(mock_openai_client)
+    mock_openai_client.stubs(:models).returns(mock_openai_client)
+    mock_openai_client.stubs(:list).returns([])
     @workflow = build_workflow(@workflow_file, @test_file)
   end
 

--- a/test/roast/workflow/base_workflow_test.rb
+++ b/test/roast/workflow/base_workflow_test.rb
@@ -8,14 +8,28 @@ class RoastWorkflowBaseWorkflowTest < ActiveSupport::TestCase
   FILE_PATH = File.join(Dir.pwd, "test/fixtures/files/test.rb")
 
   def setup
-    # Use Mocha for stubbing/mocking
     Roast::Helpers::PromptLoader.stubs(:load_prompt).returns("Test prompt")
     Roast::Tools.stubs(:setup_interrupt_handler)
+    Roast::Tools.stubs(:setup_exit_handler)
+    ActiveSupport::Notifications.stubs(:instrument).returns(true)
+
+    @mock_client = mock("client")
+    mock_config = mock("config")
+    mock_config.stubs(:openrouter_client).returns(@mock_client)
+    mock_config.stubs(:openai_client).returns(@mock_client)
+    mock_config.stubs(:model).returns("gpt-4")
+    mock_config.stubs(:max_tokens).returns(1024)
+    mock_config.stubs(:max_completion_tokens).returns(1024)
+    mock_config.stubs(:temperature).returns(0.7)
+    Raix.stubs(:configuration).returns(mock_config)
   end
 
   def teardown
     Roast::Helpers::PromptLoader.unstub(:load_prompt)
     Roast::Tools.unstub(:setup_interrupt_handler)
+    Roast::Tools.unstub(:setup_exit_handler)
+    ActiveSupport::Notifications.unstub(:instrument)
+    Raix.unstub(:configuration)
   end
 
   test "initializes with file and sets up transcript" do
@@ -38,5 +52,45 @@ class RoastWorkflowBaseWorkflowTest < ActiveSupport::TestCase
     workflow = Roast::Workflow::BaseWorkflow.new(FILE_PATH)
     workflow.append_to_final_output("Test output")
     assert_equal "Test output", workflow.final_output
+  end
+
+  test "handles ResourceNotFoundError correctly when Faraday::ResourceNotFound is raised" do
+    workflow = Roast::Workflow::BaseWorkflow.new(FILE_PATH)
+
+    mock_response = { body: { "error" => { "message" => "Model not found" } } }
+    faraday_error = Faraday::ResourceNotFound.new(nil)
+    faraday_error.stubs(:response).returns(mock_response)
+
+    @mock_client.expects(:complete).raises(faraday_error)
+
+    ActiveSupport::Notifications.expects(:instrument).with("roast.chat_completion.start", anything).once
+    ActiveSupport::Notifications.expects(:instrument).with(
+      "roast.chat_completion.error",
+      has_entry(error: "Roast::ResourceNotFoundError"),
+    ).once
+
+    assert_raises(Roast::ResourceNotFoundError) do
+      workflow.chat_completion
+    end
+  end
+
+  test "handles other errors properly without conversion" do
+    workflow = Roast::Workflow::BaseWorkflow.new(FILE_PATH)
+
+    standard_error = StandardError.new("Some other error")
+
+    @mock_client.expects(:complete).raises(standard_error)
+
+    ActiveSupport::Notifications.expects(:instrument).with("roast.chat_completion.start", anything).once
+    ActiveSupport::Notifications.expects(:instrument).with(
+      "roast.chat_completion.error",
+      has_entry(error: "StandardError"),
+    ).once
+
+    error = assert_raises(StandardError) do
+      workflow.chat_completion
+    end
+
+    assert_equal "Some other error", error.message
   end
 end

--- a/test/roast/workflow/configuration_parser_openrouter_test.rb
+++ b/test/roast/workflow/configuration_parser_openrouter_test.rb
@@ -8,13 +8,14 @@ module Roast
     class ConfigurationParserOpenRouterTest < Minitest::Test
       def setup
         @workflow_path = File.expand_path("../../fixtures/files/openrouter_workflow.yml", __dir__)
+        mock_openrouter_client = mock
+        OpenRouter::Client.stubs(:new).with(access_token: "test_openrouter_token").returns(mock_openrouter_client)
+        mock_openrouter_client.stubs(:models).returns(mock_openrouter_client)
+        mock_openrouter_client.stubs(:list).returns([])
       end
 
       def test_configure_openrouter_client
         setup_openrouter_constants
-
-        mock_openrouter_client = mock
-        OpenRouter::Client.stubs(:new).with(access_token: "test_openrouter_token").returns(mock_openrouter_client)
 
         ConfigurationParser.new(@workflow_path)
       end
@@ -30,7 +31,7 @@ module Roast
       end
 
       def teardown
-        OpenRouter.send(:remove_const, :Client) if defined?(::OpenRouter) && defined?(::OpenRouter::Client)
+        OpenRouter::Client.unstub(:new) if OpenRouter::Client.respond_to?(:unstub)
       end
     end
   end

--- a/test/roast/workflow/targetless_workflow_test.rb
+++ b/test/roast/workflow/targetless_workflow_test.rb
@@ -10,6 +10,10 @@ require "roast/workflow/workflow_executor"
 class RoastWorkflowTargetlessWorkflowTest < ActiveSupport::TestCase
   def setup
     @workflow_path = fixture_file_path("targetless_workflow.yml")
+    mock_openai_client = mock
+    OpenAI::Client.stubs(:new).with(access_token: "test_openai_token").returns(mock_openai_client)
+    mock_openai_client.stubs(:models).returns(mock_openai_client)
+    mock_openai_client.stubs(:list).returns([])
     @parser = Roast::Workflow::ConfigurationParser.new(@workflow_path)
   end
 


### PR DESCRIPTION
In order to make errors more descriptive when things go wrong, this commit adds a few error types to handle api interactions more gracefully when things go wrong. Specifically, it currently handles when a model can't be found or is innaccesible with the api token provided. Also when an api token isn't provided, instead of an unhelpful NoMethodError, we let end users know the token wasn't provided or isn't valid.

This resolves #13 