### PR TITLE
Fix running roast workflows with openrouter 

### DIFF
--- a/examples/openrouter_example/workflow.yml
+++ b/examples/openrouter_example/workflow.yml
@@ -1,7 +1,7 @@
 name: OpenRouter Example
 api_provider: openrouter
 api_token: $(echo $OPENROUTER_API_KEY)
-model: anthropic/claude-3-haiku-20240307
+model: google/gemini-2.0-flash-001
 
 tools:
   - Roast::Tools::ReadFile

--- a/lib/roast/workflow/base_step.rb
+++ b/lib/roast/workflow/base_step.rb
@@ -35,7 +35,7 @@ module Roast
       protected
 
       def chat_completion(print_response: false, auto_loop: true, json: false, params: {})
-        workflow.chat_completion(openai: model, loop: auto_loop, json:, params:).then do |response|
+        workflow.chat_completion(openai: workflow.openai? && model, loop: auto_loop, model: model, json:, params:).then do |response|
           case response
           in Array
             response.map(&:presence).compact.join("\n")

--- a/lib/roast/workflow/configuration_parser.rb
+++ b/lib/roast/workflow/configuration_parser.rb
@@ -112,7 +112,7 @@ module Roast
             require "open_router"
 
             Raix.configure do |config|
-              config.openrouter_client = OpenRouter::Client.new(api_key: configuration.api_token)
+              config.openrouter_client = OpenRouter::Client.new(access_token: configuration.api_token)
             end
           else
             $stderr.puts "Configuring OpenAI client with token from workflow"

--- a/lib/roast/workflow/session_manager.rb
+++ b/lib/roast/workflow/session_manager.rb
@@ -67,8 +67,9 @@ module Roast
 
       def workflow_directory(session_name, file_path)
         workflow_dir_name = session_name.parameterize.underscore
-        file_id = Digest::MD5.hexdigest(file_path)
-        file_basename = File.basename(file_path).parameterize.underscore
+        # For targetless sessions we don't have a file_path
+        file_id = Digest::MD5.hexdigest(file_path || Dir.pwd)
+        file_basename = File.basename(file_path || Dir.pwd).parameterize.underscore
         human_readable_id = "#{file_basename}_#{file_id[0..7]}"
         File.join(Dir.pwd, ".roast", "sessions", workflow_dir_name, human_readable_id)
       end

--- a/test/roast/workflow/base_step_test.rb
+++ b/test/roast/workflow/base_step_test.rb
@@ -37,6 +37,9 @@ class RoastWorkflowBaseStepTest < ActiveSupport::TestCase
     @workflow.stubs(:chat_completion)
       .returns("Test chat completion response")
 
+    @workflow.stubs(:openai?)
+      .returns(true)
+
     result = @step.call
     assert_equal({ user: "Test prompt" }, @workflow.transcript.last)
     assert_equal "Test chat completion response", result

--- a/test/roast/workflow/configuration_parser_openrouter_test.rb
+++ b/test/roast/workflow/configuration_parser_openrouter_test.rb
@@ -14,7 +14,7 @@ module Roast
         setup_openrouter_constants
 
         mock_openrouter_client = mock
-        OpenRouter::Client.stubs(:new).with(api_key: "test_openrouter_token").returns(mock_openrouter_client)
+        OpenRouter::Client.stubs(:new).with(access_token: "test_openrouter_token").returns(mock_openrouter_client)
 
         ConfigurationParser.new(@workflow_path)
       end


### PR DESCRIPTION
- Use access_token instead of api_key as an initalizer
- Use a model that exists on openrouter
- Fix passing models to the openrouter client

This fixes #53
