### PR TITLE
Targetless fixes

### DIFF
--- a/lib/roast/workflow/base_workflow.rb
+++ b/lib/roast/workflow/base_workflow.rb
@@ -34,7 +34,11 @@ module Roast
         @session_name = session_name || @name
         @session_timestamp = nil
         @configuration = configuration
-        transcript << { system: read_sidecar_prompt }
+        read_sidecar_prompt.then do |prompt|
+          next unless prompt
+
+          transcript << { system: prompt }
+        end
         Roast::Tools.setup_interrupt_handler(transcript)
         Roast::Tools.setup_exit_handler(self)
       end

--- a/lib/roast/workflow/session_manager.rb
+++ b/lib/roast/workflow/session_manager.rb
@@ -7,6 +7,8 @@ module Roast
   module Workflow
     # Manages session creation, timestamping, and directory management
     class SessionManager
+      TARGETLESS_FILE_PATH = "notarget"
+
       def initialize
         @session_mutex = Mutex.new
         @session_timestamps = {}
@@ -66,6 +68,7 @@ module Roast
       private
 
       def workflow_directory(session_name, file_path)
+        file_path ||= TARGETLESS_FILE_PATH
         workflow_dir_name = session_name.parameterize.underscore
         file_id = Digest::MD5.hexdigest(file_path)
         file_basename = File.basename(file_path).parameterize.underscore


### PR DESCRIPTION
There are some issues I've encountered while playing with a targetless workflow:

- `null` system prompt:

```
Chat completion failed!!!!!!!!!!!!!!!!: {"error"=>{"message"=>"Invalid value for 'content': expected a string, got null.", "type"=>"invalid_request_error", "param"=>"messages.[0].content", "code"=>nil}}
```

That happens when no workflow prompt exists and no target specified.

- Saving state for targetless executions failed because there is no `file_path`

Fixed both in this PR.