### PR TITLE
Fix loading custom tools

### DIFF
--- a/lib/roast/workflow/configuration_parser.rb
+++ b/lib/roast/workflow/configuration_parser.rb
@@ -22,8 +22,8 @@ module Roast
         @options = options
         @files = files
         @replay_processed = false # Initialize replay tracking
-        include_tools
         load_roast_initializers
+        include_tools
         configure_api_client
       end
 


### PR DESCRIPTION
We try to initialize the tools specified in the workflow in the `#include_tools` method but currently it's called after `#load_roast_initializers`—so, we observe `NameError`-s (no constant defined). Changing the load order fixes the issues.