### PR TITLE
Fix saving status for path/to/step.rb steps

### DIFF
--- a/lib/roast/workflow/file_state_repository.rb
+++ b/lib/roast/workflow/file_state_repository.rb
@@ -28,6 +28,7 @@ module Roast
             timestamp: workflow.session_timestamp,
           )
           step_file = File.join(session_dir, format_step_filename(state_data[:order], step_name))
+          FileUtils.mkdir_p(File.dirname(step_file))
           File.write(step_file, JSON.pretty_generate(state_data))
         end
       rescue => e


### PR DESCRIPTION
Steps can be stored in nested folders and named as `path/to/step.rb`, so we must create intermediate folder when saving the status.