### PR TITLE
Fix plain text prompts configuration

### DIFF
--- a/lib/roast/workflow/workflow_executor.rb
+++ b/lib/roast/workflow/workflow_executor.rb
@@ -143,7 +143,7 @@ module Roast
       def find_and_load_step(step_name)
         # First check for a prompt step
         if step_name.strip.include?(" ")
-          return Roast::Workflow::PromptStep.new(workflow, name: step_name, auto_loop: false)
+          return setup_step(Roast::Workflow::PromptStep, step_name, nil)
         end
 
         # First check for a ruby file with the step name

--- a/test/roast/workflow/workflow_executor_test.rb
+++ b/test/roast/workflow/workflow_executor_test.rb
@@ -25,6 +25,22 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
     @executor.execute_steps(["step {{file}}"])
   end
 
+  test "executes string steps with correct configuration" do
+    @executor = Roast::Workflow::WorkflowExecutor.new(
+      @workflow,
+      # Use a non-default model to ensure we pass it through
+      @config_hash.merge("model" => "gpt-4-mini"),
+      @context_path,
+    )
+
+    @workflow.stubs(resource: nil, append_to_final_output: nil, openai?: true)
+    @workflow.expects(:transcript).returns([])
+    @workflow.stubs(:chat_completion).with(openai: "gpt-4-mini", model: "gpt-4-mini", loop: false, json: false, params: {})
+      .returns("Test chat completion response")
+    result = @executor.execute_step("execute step")
+    assert_equal "Test chat completion response", result
+  end
+
   # Hash steps tests
   test "executes hash steps" do
     @executor.expects(:execute_step).with("command1").returns("result")


### PR DESCRIPTION
This fixes the bug with the model not being passed to the prompt step (so, the default `anthropic:claude-sonnet-3.7` is always used by text steps).

The `auto_loop: false` seems unnecessary since we set `auto_loop: false` in the PromptStep explicitly.

I decided to use the same `#step_setup` method so we can do all the configuration tweaks uniformly.