### PR TITLE
Add more rubies to CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: ['3.4']
+        ruby: ['3.2', '3.3', '3.4']
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ matrix.ruby == 'ruby-head' }}
     steps:


### PR DESCRIPTION
Typically I see gems follow the list of [supported Rubies](https://www.ruby-lang.org/en/downloads/branches/) in their CI which is currently the list in this PR.