### PR TITLE
Allow initializer to set Raix client

### DIFF
--- a/lib/roast/workflow/configuration_parser.rb
+++ b/lib/roast/workflow/configuration_parser.rb
@@ -105,6 +105,9 @@ module Roast
       def configure_api_client
         return unless configuration.api_token
 
+        existing_client = !!(Raix.configuration.openrouter_client || Raix.configuration.openai_client)
+        return if existing_client
+
         begin
           case configuration.api_provider
           when :openrouter

--- a/test/roast/workflow/configuration_parser_test.rb
+++ b/test/roast/workflow/configuration_parser_test.rb
@@ -25,6 +25,13 @@ class RoastWorkflowConfigurationParserTest < ActiveSupport::TestCase
     assert_equal("run_coverage", @parser.configuration.steps.first)
   end
 
+  def test_with_existing_api_client_does_not_configure_new_api_client
+    openai_client = OpenAI::Client.new(access_token: "test")
+    Raix.configuration.openai_client = openai_client
+    Roast::Workflow::ConfigurationParser.new(@workflow_path)
+    assert_equal(openai_client, Raix.configuration.openai_client)
+  end
+
   def test_begin_without_files_or_target_runs_targetless_workflow
     executor = mock("WorkflowExecutor")
     executor.stubs(:execute_steps)


### PR DESCRIPTION
As of https://github.com/Shopify/roast/pull/56 we had a little regression where an initializer that set the Raix api client would get clobbered by the `configure_api_client` method because the guard was no longer short circuiting. What this PR does is establish in a test that when `Raix.configuration` has either an `openrouter_client` or an `openai_client` then we should bail on the `configure_api_client` method.

I did this by checking the state of the `Raix.configuration` but I also opened https://github.com/OlympiaAI/raix/pull/25 because it would be cool for this configuration object to answer the question of whether it has a client. LMK if there's a preferences on whether to merge this as-is or to merge that and then use that solution instead!