### PR TITLE
Add pause flag

### DIFF
--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -19,6 +19,8 @@ module Roast
     option :verbose, type: :boolean, aliases: "-v", desc: "Show output from all steps as they are executed"
     option :target, type: :string, aliases: "-t", desc: "Override target files. Can be file path, glob pattern, or $(shell command)"
     option :replay, type: :string, aliases: "-r", desc: "Resume workflow from a specific step. Format: step_name or session_timestamp:step_name"
+    option :pause, type: :string, aliases: "-p", desc: "Pause workflow after a specific step. Format: step_name"
+
     def execute(*paths)
       raise Thor::Error, "Workflow configuration file is required" if paths.empty?
 

--- a/lib/roast/workflow/base_workflow.rb
+++ b/lib/roast/workflow/base_workflow.rb
@@ -16,6 +16,7 @@ module Roast
       attr_accessor :file,
         :concise,
         :output_file,
+        :pause_step_name,
         :verbose,
         :name,
         :context_path,

--- a/lib/roast/workflow/configuration_parser.rb
+++ b/lib/roast/workflow/configuration_parser.rb
@@ -87,6 +87,7 @@ module Roast
           workflow.output_file = options[:output] if options[:output].present?
           workflow.verbose = options[:verbose] if options[:verbose].present?
           workflow.concise = options[:concise] if options[:concise].present?
+          workflow.pause_step_name = options[:pause] if options[:pause].present?
         end
       end
 

--- a/lib/roast/workflow/workflow_executor.rb
+++ b/lib/roast/workflow/workflow_executor.rb
@@ -27,6 +27,7 @@ module Roast
             execute_parallel_steps(step)
           when String
             execute_string_step(step)
+            Kernel.binding.irb if workflow.pause_step_name == step # rubocop:disable Lint/Debugger
           else
             raise "Unknown step type: #{step.inspect}"
           end

--- a/lib/roast/workflow/workflow_executor.rb
+++ b/lib/roast/workflow/workflow_executor.rb
@@ -18,18 +18,18 @@ module Roast
         @context_path = context_path
       end
 
-      def execute_steps(steps)
-        steps.each do |step|
-          case step
+      def execute_steps(workflow_steps)
+        workflow_steps.each do |workflow_step|
+          case workflow_step
           when Hash
-            execute_hash_step(step)
+            execute_hash_step(workflow_step)
           when Array
-            execute_parallel_steps(step)
+            execute_parallel_steps(workflow_step)
           when String
-            execute_string_step(step)
-            Kernel.binding.irb if workflow.pause_step_name == step # rubocop:disable Lint/Debugger
+            execute_string_step(workflow_step)
+            Kernel.binding.irb if workflow.pause_step_name == workflow_step # rubocop:disable Lint/Debugger
           else
-            raise "Unknown step type: #{step.inspect}"
+            raise "Unknown step type: #{workflow_step.inspect}"
           end
         end
       end

--- a/test/roast/workflow/workflow_executor_test.rb
+++ b/test/roast/workflow/workflow_executor_test.rb
@@ -7,7 +7,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
   def setup
     @workflow = mock("workflow")
     @output = {}
-    @workflow.stubs(output: @output)
+    @workflow.stubs(output: @output, pause_step_name: nil)
     @config_hash = { "step1" => { "model" => "test-model" } }
     @context_path = "/tmp/test"
     @executor = Roast::Workflow::WorkflowExecutor.new(@workflow, @config_hash, @context_path)
@@ -16,6 +16,15 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
   # String steps tests
   test "executes string steps" do
     @executor.expects(:execute_step).with("step1")
+    @executor.execute_steps(["step1"])
+  end
+
+  test "execute with pause flag will pause on the matching step" do
+    @workflow.stubs(pause_step_name: "step1")
+    @executor.expects(:execute_step).with("step1")
+    mock_binding = mock("mock_binding")
+    Kernel.stubs(:binding).returns(mock_binding)
+    mock_binding.expects(:irb)
     @executor.execute_steps(["step1"])
   end
 


### PR DESCRIPTION
This PR adds support for a `pause` flag that takes a step name. When that step name comes up it triggers a `binding.irb` session. Fun fact prior to this PR that location had a local variable name called `step` - can you guess what happened when attempting to reference that var? That's right it.....stepped to the next line. 😝 

So in order to mitigate that I also reworked the locals in that method so that there were no collisions. 

Paired on this with @nfgrep 🍐 

Closes #16 