### PR TITLE
Add exit_on_error configuration for command steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standardized evaluation of Ruby expressions in iteration constructs using `{{}}` syntax
 - Support for using bash commands, step names, and Ruby expressions in iteration conditions and collections
 - Intelligent LLM response to boolean conversion with pattern-based recognition for natural language responses
+- `exit_on_error` configuration option for command steps to continue workflow on failure (resolving issue #71)
 
 ### Fixed
 - Automatically add `.gitignore` file to cache directory when created (completing issue #22)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ Roast supports several types of steps:
    ```
    This will execute the command and store the result in the workflow output hash. Explicit key name is optional (`rubocop` in the second line of the example).
 
+   By default, commands that exit with non-zero status will halt the workflow. You can configure steps to continue on error:
+   ```yaml
+   steps:
+     - lint_check: $(rubocop {{file}})
+     - fix_issues
+   
+   # Step configuration
+   lint_check:
+     exit_on_error: false  # Continue workflow even if command fails
+   ```
+   When `exit_on_error: false`, the command output will include the exit status, allowing subsequent steps to process error information.
+
 4. **Raw prompt step**: Simple text prompts for the model without tools
    ```yaml
    steps:

--- a/examples/exit_on_error/README.md
+++ b/examples/exit_on_error/README.md
@@ -1,0 +1,50 @@
+# Exit on Error Example
+
+This example demonstrates how to use the `exit_on_error` configuration option to continue workflow execution even when a command fails.
+
+## Use Case
+
+When running a linter like RuboCop on a file with syntax errors or style violations, the command will exit with a non-zero status. By default, this would halt the workflow. However, we often want to:
+
+1. Capture the linter output (including errors)
+2. Analyze what went wrong
+3. Apply fixes based on the analysis
+
+## Configuration
+
+The key configuration is in the step configuration section:
+
+```yaml
+lint_check:
+  exit_on_error: false
+```
+
+This tells Roast to:
+- Continue workflow execution even if the command fails
+- Capture the full output (stdout and stderr)
+- Append the exit status to the output
+
+## Output Format
+
+When a command fails with `exit_on_error: false`, the output will look like:
+
+```
+lib/example.rb:5:3: C: Style/StringLiterals: Prefer double-quoted strings
+  'hello'
+  ^^^^^^^
+[Exit status: 1]
+```
+
+This allows subsequent steps to process both the error output and the exit status.
+
+## Running the Example
+
+```bash
+roast execute workflow.yml path/to/file.rb
+```
+
+The workflow will:
+1. Run RuboCop on the file
+2. Continue even if RuboCop finds issues
+3. Analyze the linter output
+4. Apply fixes based on the analysis

--- a/examples/exit_on_error/workflow.yml
+++ b/examples/exit_on_error/workflow.yml
@@ -1,0 +1,36 @@
+name: Linting with Error Recovery
+tools:
+  - Roast::Tools::ReadFile
+  - Roast::Tools::WriteFile
+  - Roast::Tools::CodingAgent
+
+steps:
+  # Run linter on the file - may fail if there are syntax errors
+  - lint_check: $(rubocop {{file}})
+  
+  # Analyze linter output and fix issues even if linter failed
+  - analyze_lint_output
+  
+  # Apply fixes based on the analysis
+  - apply_fixes
+
+# Step configuration
+lint_check:
+  exit_on_error: false  # Continue even if rubocop exits with non-zero status
+
+analyze_lint_output:
+  prompt: |
+    The linter output from the previous step shows issues with the code.
+    Please analyze the output and identify the specific problems that need to be fixed.
+    
+    Focus on:
+    - Syntax errors
+    - Style violations
+    - Best practice violations
+    
+    Provide a structured list of issues found.
+
+apply_fixes:
+  prompt: |
+    Based on the analysis, please generate the fixes for the identified issues.
+    Use the CodingAgent tool to apply the necessary changes to the file.

--- a/test/roast/workflow/exit_on_error_test.rb
+++ b/test/roast/workflow/exit_on_error_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "roast/workflow/workflow_executor"
+
+module Roast
+  module Workflow
+    class ExitOnErrorTest < Minitest::Test
+      include FixtureHelpers
+
+      def setup
+        @workflow = BaseWorkflow.new(nil, name: "test_workflow")
+        @workflow.output = {}
+        @context_path = File.expand_path("../../fixtures/steps", __dir__)
+        @config_hash = {}
+      end
+
+      def test_command_fails_by_default
+        executor = WorkflowExecutor.new(@workflow, @config_hash, @context_path)
+
+        assert_raises(WorkflowExecutor::CommandExecutionError) do
+          executor.execute_step("$(exit 1)")
+        end
+      end
+
+      def test_command_continues_with_exit_on_error_false
+        @config_hash = {
+          "failing_command" => {
+            "exit_on_error" => false,
+          },
+        }
+
+        executor = WorkflowExecutor.new(@workflow, @config_hash, @context_path)
+
+        # Execute a hash step with a failing command
+        step = { "failing_command" => "$(exit 42)" }
+        executor.send(:execute_hash_step, step)
+
+        # Should not raise and should capture output with exit status
+        assert(@workflow.output["failing_command"])
+        assert_match(/\[Exit status: 42\]/, @workflow.output["failing_command"])
+      end
+
+      def test_command_output_includes_stdout_and_exit_status
+        @config_hash = {
+          "test_command" => {
+            "exit_on_error" => false,
+          },
+        }
+
+        executor = WorkflowExecutor.new(@workflow, @config_hash, @context_path)
+
+        # Execute a command that outputs text and fails
+        step = { "test_command" => "$(echo 'Error: Something went wrong' && exit 1)" }
+        executor.send(:execute_hash_step, step)
+
+        output = @workflow.output["test_command"]
+        assert_match(/Error: Something went wrong/, output)
+        assert_match(/\[Exit status: 1\]/, output)
+      end
+
+      def test_command_succeeds_regardless_of_exit_on_error
+        @config_hash = {
+          "good_command" => {
+            "exit_on_error" => false,
+          },
+        }
+
+        executor = WorkflowExecutor.new(@workflow, @config_hash, @context_path)
+
+        # Execute a successful command
+        step = { "good_command" => "$(echo 'Success')" }
+        executor.send(:execute_hash_step, step)
+
+        # Should capture output normally without exit status
+        assert_equal("Success\n", @workflow.output["good_command"])
+        refute_match(/\[Exit status:/, @workflow.output["good_command"])
+      end
+
+      def test_strip_and_execute_with_exit_on_error_true
+        executor = WorkflowExecutor.new(@workflow, @config_hash, @context_path)
+
+        # Test that it raises on failure when exit_on_error is true (default)
+        assert_raises(WorkflowExecutor::CommandExecutionError) do
+          executor.send(:strip_and_execute, "$(exit 1)", exit_on_error: true)
+        end
+      end
+
+      def test_strip_and_execute_with_exit_on_error_false
+        executor = WorkflowExecutor.new(@workflow, @config_hash, @context_path)
+
+        # Test that it returns output with exit status when exit_on_error is false
+        result = executor.send(:strip_and_execute, "$(echo 'Failed' && exit 5)", exit_on_error: false)
+
+        assert_match(/Failed/, result)
+        assert_match(/\[Exit status: 5\]/, result)
+      end
+
+      def test_command_exception_handling_with_exit_on_error_false
+        @config_hash = {
+          "bad_command" => {
+            "exit_on_error" => false,
+          },
+        }
+
+        executor = WorkflowExecutor.new(@workflow, @config_hash, @context_path)
+
+        # Mock a command that throws an exception
+        executor.stub(:interpolate, ->(x) { x }) do
+          # This should handle exceptions gracefully when exit_on_error is false
+          result = executor.send(:strip_and_execute, "$(this_command_does_not_exist_12345)", exit_on_error: false)
+
+          assert_match(/Error executing command:/, result)
+          assert_match(/\[Exit status: error\]/, result)
+        end
+      end
+
+      def test_direct_command_step_always_exits_on_error
+        executor = WorkflowExecutor.new(@workflow, @config_hash, @context_path)
+
+        # Direct command steps (without names) should always exit on error
+        assert_raises(WorkflowExecutor::CommandExecutionError) do
+          executor.send(:execute_string_step, "$(exit 1)")
+        end
+      end
+
+      def test_warning_logged_when_continuing_after_error
+        @config_hash = {
+          "warning_test" => {
+            "exit_on_error" => false,
+          },
+        }
+
+        executor = WorkflowExecutor.new(@workflow, @config_hash, @context_path)
+
+        # Capture stderr to verify warning is logged
+        _, err = capture_io do
+          step = { "warning_test" => "$(exit 3)" }
+          executor.send(:execute_hash_step, step)
+        end
+
+        assert_match(/WARNING: Command.*exited with non-zero status \(3\), continuing execution/, err)
+      end
+    end
+  end
+end

--- a/test/roast/workflow/workflow_executor_test.rb
+++ b/test/roast/workflow/workflow_executor_test.rb
@@ -15,13 +15,13 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
 
   # String steps tests
   test "executes string steps" do
-    @executor.expects(:execute_step).with("step1")
+    @executor.expects(:execute_step).with("step1", exit_on_error: true)
     @executor.execute_steps(["step1"])
   end
 
   test "execute with pause flag will pause on the matching step" do
     @workflow.stubs(pause_step_name: "step1")
-    @executor.expects(:execute_step).with("step1")
+    @executor.expects(:execute_step).with("step1", exit_on_error: true)
     mock_binding = mock("mock_binding")
     Kernel.stubs(:binding).returns(mock_binding)
     mock_binding.expects(:irb)
@@ -30,27 +30,27 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
 
   test "executes string steps with interpolation" do
     @workflow.expects(:instance_eval).with("file").returns("test.rb")
-    @executor.expects(:execute_step).with("step test.rb")
+    @executor.expects(:execute_step).with("step test.rb", exit_on_error: true)
     @executor.execute_steps(["step {{file}}"])
   end
 
   # Hash steps tests
   test "executes hash steps" do
-    @executor.expects(:execute_step).with("command1").returns("result")
+    @executor.expects(:execute_step).with("command1", exit_on_error: true).returns("result")
     @executor.execute_steps([{ "var1" => "command1" }])
     assert_equal "result", @output["var1"]
   end
 
   test "executes hash steps with interpolation in key" do
     @workflow.expects(:instance_eval).with("var_name").returns("test_var")
-    @executor.expects(:execute_step).with("command1").returns("result")
+    @executor.expects(:execute_step).with("command1", exit_on_error: true).returns("result")
     @executor.execute_steps([{ "{{var_name}}" => "command1" }])
     assert_equal "result", @output["test_var"]
   end
 
   test "executes hash steps with interpolation in value" do
     @workflow.expects(:instance_eval).with("cmd").returns("test_command")
-    @executor.expects(:execute_step).with("test_command").returns("result")
+    @executor.expects(:execute_step).with("test_command", exit_on_error: true).returns("result")
     @executor.execute_steps([{ "var1" => "{{cmd}}" }])
     assert_equal "result", @output["var1"]
   end
@@ -58,7 +58,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
   test "executes hash steps with interpolation in both key and value" do
     @workflow.expects(:instance_eval).with("var_name").returns("test_var")
     @workflow.expects(:instance_eval).with("cmd").returns("test_command")
-    @executor.expects(:execute_step).with("test_command").returns("result")
+    @executor.expects(:execute_step).with("test_command", exit_on_error: true).returns("result")
     @executor.execute_steps([{ "{{var_name}}" => "{{cmd}}" }])
     assert_equal "result", @output["test_var"]
   end
@@ -134,7 +134,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
 
   # Bash expression tests
   test "executes shell command for bash expression" do
-    @executor.expects(:strip_and_execute).with("$(ls)").returns("file1\nfile2")
+    @executor.expects(:strip_and_execute).with("$(ls)", exit_on_error: true).returns("file1\nfile2")
     @workflow.expects(:transcript).returns([]).twice
 
     result = @executor.execute_step("$(ls)")
@@ -175,7 +175,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
 
   test "interpolates expressions in shell commands" do
     @workflow.expects(:instance_eval).with("file").returns("test.rb")
-    @executor.expects(:strip_and_execute).with("$(rubocop -A test.rb)").returns("Shell output")
+    @executor.expects(:strip_and_execute).with("$(rubocop -A test.rb)", exit_on_error: true).returns("Shell output")
     @workflow.expects(:transcript).returns([]).at_least(1)
 
     # First interpolate is called in execute_string_step (via execute_steps),


### PR DESCRIPTION
## Summary
- Implements `exit_on_error` configuration option for command steps to allow workflows to continue when commands fail
- Fixes #71

## Implementation Details

This PR adds the ability for workflow steps to continue execution even when commands fail by introducing an `exit_on_error` configuration option. When set to `false`, failed commands will:

1. Log a warning message instead of raising an error
2. Include the exit status in the output (e.g., `[Exit status: 42]`)
3. Allow the workflow to continue to the next step

### Key Changes

- Modified `WorkflowExecutor` to accept and handle `exit_on_error` parameter throughout the execution chain
- Updated `strip_and_execute` to conditionally raise errors based on the configuration
- Added comprehensive test coverage in a new test file
- Updated existing tests to handle the new parameter
- Added documentation and example workflow

### Usage Example

```yaml
steps:
  - lint_check: $(rubocop {{file}})
  - fix_issues: |
      echo "Linting output:"
      echo "{{lint_check}}"
      # Process linting errors...

# Step configuration
lint_check:
  exit_on_error: false  # Continue even if rubocop finds issues
```

This is particularly useful for:
- Linting steps where you want to collect all issues before stopping
- Validation checks that should report problems without halting execution
- Multi-step analysis workflows where partial failures are acceptable

## Test plan
- [x] Run test suite with `shadowenv exec -- bundle exec rake`
- [x] Verify new tests pass
- [x] Verify existing tests still pass
- [x] Test example workflow manually
- [x] Ensure backwards compatibility (default behavior unchanged)

🤖 Generated with [Claude Code](https://claude.ai/code)