### PR TITLE
`roast init`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 gem "cgi"
+gem "cli-ui"
 gem "dotenv"
 gem "guard"
 gem "guard-minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     cgi (0.4.2)
+    cli-ui (2.3.1)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.1)
@@ -168,6 +169,7 @@ PLATFORMS
 
 DEPENDENCIES
   cgi
+  cli-ui
   dotenv
   guard
   guard-minitest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     roast-ai (0.1.7)
       activesupport (~> 8.0)
+      cli-ui
       diff-lcs (~> 1.5)
       faraday-retry
       json-schema

--- a/examples/workflow_generator/README.md
+++ b/examples/workflow_generator/README.md
@@ -1,0 +1,27 @@
+# Workflow Generator
+
+This workflow generates new Roast workflows based on user descriptions. It's the engine behind the "New from prompt" option in `roast init`.
+
+## How It Works
+
+The workflow generator takes a user description and workflow name, then:
+
+1. **Analyzes the request** - Understands what type of workflow is needed, what steps are required, and what tools should be used
+2. **Generates structure** - Creates a complete workflow configuration including YAML and step prompts
+3. **Creates files** - Writes all the necessary files and directories to disk
+
+## Usage
+
+This workflow is typically invoked automatically by the `roast init` command, but can also be run directly:
+
+```bash
+# Run the generator workflow
+roast execute examples/workflow_generator/workflow.yml
+```
+
+## Generated Output
+
+The workflow creates a new directory with:
+- `workflow.yml` - Main workflow configuration
+- `step_name/prompt.md` - Individual step prompts
+- `README.md` - Documentation for the generated workflow

--- a/examples/workflow_generator/analyze_user_request/prompt.md
+++ b/examples/workflow_generator/analyze_user_request/prompt.md
@@ -1,0 +1,34 @@
+You are an assistant that analyzes user requests to understand what kind of workflow they want to create.
+
+Based on the user input from the previous step:
+<%= workflow.output["get_user_input"] %>
+
+Roast information from previous step:
+<%= workflow.output["info_from_roast"] %>
+
+First, explore existing workflow examples in the examples directory to understand common patterns and structures. Look for ones that may be related to the user's intention.
+
+Then analyze the user's request and determine:
+
+1. **Required Steps**: Break down the workflow into logical steps. Each step should be a discrete task that can be accomplished with an AI prompt.
+
+2. **Tools Needed**: What Roast tools will be needed? Base this on the actual tools you read from info provided above. 
+
+3. **Target Strategy**: Will this workflow:
+   - Process specific files (needs target configuration)
+   - Be targetless (works without specific input files)
+   - Use shell commands to find targets dynamically
+
+4. **Model Requirements**: Should this use a specific model, or is the default (gpt-4o-mini) sufficient?
+
+Respond with a structured analysis in this format:
+
+```
+STEPS: [list of 3-5 logical steps]
+TOOLS: [list of required tools]
+TARGET_STRATEGY: [targetless/files/dynamic]
+MODEL: [model recommendation]
+COMPLEXITY: [simple/moderate/complex]
+```
+
+Be specific and actionable in your analysis.

--- a/examples/workflow_generator/create_workflow_files/prompt.md
+++ b/examples/workflow_generator/create_workflow_files/prompt.md
@@ -1,0 +1,32 @@
+You are an assistant that creates the actual workflow files in the filesystem.
+
+Based on the user input:
+<%= workflow.output["get_user_input"] %>
+
+And the generated workflow structure from the previous step:
+<%= workflow.output["analyze_user_request"] %>
+
+And info from roast:
+<%= workflow.output["info_from_roast"] %>
+
+Your task is to create all the necessary files and directories for the workflow.
+
+Extract the workflow name from the user input JSON and create the workflow in the current directory under that folder name.
+
+Steps to complete:
+
+1. **Create the main directory**: Use Cmd to create the "{{ workflow_name }}" directory
+2. **Create step directories**: Create subdirectories for each workflow step  
+3. **Create workflow.yml**: Write the main workflow configuration file
+4. **Create step prompt files**: Write each step's prompt.md file
+5. **Create README.md**: Generate a helpful README explaining the workflow
+
+When writing files, extract the content from the structured response and write each file separately.
+
+Important notes:
+- Make sure all directories exist before writing files to them
+- Follow the exact structure specified in the previous step
+- Include helpful comments in the workflow.yml file
+- Make the README.md informative and include usage instructions
+
+At the end, confirm that all files have been created by listing the directory structure.

--- a/examples/workflow_generator/get_user_input/prompt.md
+++ b/examples/workflow_generator/get_user_input/prompt.md
@@ -1,0 +1,14 @@
+You need to collect user input for generating a new workflow.
+
+Step 1: Ask for the workflow description using ask_user tool with prompt: "What should your workflow do?"
+
+Step 2: Ask for the workflow name using ask_user tool with prompt: "Enter workflow directory name:"
+
+Step 3: Return the result in JSON format:
+
+<json>
+{
+  "user_description": "what the user wants the workflow to do", 
+  "workflow_name": "directory_name_provided_by_user"
+}
+</json>

--- a/examples/workflow_generator/info_from_roast.rb
+++ b/examples/workflow_generator/info_from_roast.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class InfoFromRoast < Roast::Workflow::BaseStep
+  def call
+    examples_path = File.join(Roast::ROOT, "examples")
+    tools_path = File.join(Roast::ROOT, "lib", "roast", "tools")
+
+    # Get list of available tools
+    available_tools = Dir.entries(tools_path)
+      .select { |file| file.end_with?(".rb") }
+      .map { |file| file.gsub(".rb", "") }
+      .reject { |tool| tool == "." || tool == ".." }
+      .sort
+
+    {
+      examples_directory: examples_path,
+      tools_directory: tools_path,
+      available_tools: available_tools,
+      message: "Examples directory and available tools provided for analysis step",
+    }
+  end
+end

--- a/examples/workflow_generator/workflow.yml
+++ b/examples/workflow_generator/workflow.yml
@@ -1,0 +1,35 @@
+# Workflow Generator
+#
+# This workflow generates new Roast workflows based on user descriptions.
+# It gets user input, analyzes the request, generates an appropriate workflow structure,
+# and creates all necessary files in a new directory.
+
+name: Workflow Generator
+model: gpt-4o-mini
+
+tools:
+  - Roast::Tools::WriteFile
+  - Roast::Tools::ReadFile
+  - Roast::Tools::Cmd
+  - Roast::Tools::AskUser
+
+steps:
+  - get_user_input
+  - info_from_roast
+  - analyze_user_request
+  - create_workflow_files
+
+# Step configurations
+get_user_input:
+  print_response: false
+  json: true
+  auto_loop: false
+
+analyze_user_request:
+  print_response: true
+
+generate_workflow_structure:
+  print_response: true
+
+create_workflow_files:
+  print_response: false

--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -59,7 +59,7 @@ module Roast
       end
 
       puts "Select an option:"
-      choices = ["Pick from examples", "New from prompt (coming soon)"]
+      choices = ["Pick from examples", "New from prompt (beta)"]
 
       selected = run_picker(choices, "Select initialization method:")
 
@@ -67,8 +67,8 @@ module Roast
       when "Pick from examples"
         example_choice = run_picker(examples, "Select an example:")
         copy_example(example_choice) if example_choice
-      when "New from prompt (coming soon)"
-        puts "This feature is not yet implemented."
+      when "New from prompt (beta)"
+        create_from_prompt
       end
     end
 
@@ -106,6 +106,24 @@ module Roast
 
       FileUtils.cp_r(source_path, target_path)
       puts "Successfully copied example '#{example_name}' to current directory."
+    end
+
+    def create_from_prompt
+      puts("Create a new workflow from a description")
+      puts
+
+      # Execute the workflow generator
+      generator_path = File.join(Roast::ROOT, "examples", "workflow_generator", "workflow.yml")
+
+      begin
+        # Execute the workflow generator (it will handle user input)
+        Roast::Workflow::ConfigurationParser.new(generator_path, [], {}).begin!
+
+        puts
+        puts("Workflow generation complete!")
+      rescue => e
+        puts("Error generating workflow: #{e.message}")
+      end
     end
 
     class << self

--- a/lib/roast/tools.rb
+++ b/lib/roast/tools.rb
@@ -10,6 +10,7 @@ require "roast/tools/write_file"
 require "roast/tools/update_files"
 require "roast/tools/cmd"
 require "roast/tools/coding_agent"
+require "roast/tools/ask_user"
 
 module Roast
   module Tools

--- a/lib/roast/tools/ask_user.rb
+++ b/lib/roast/tools/ask_user.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "roast/helpers/logger"
+
+module Roast
+  module Tools
+    module AskUser
+      extend self
+
+      class << self
+        # Add this method to be included in other classes
+        def included(base)
+          base.class_eval do
+            function(
+              :ask_user,
+              "Ask the user for input with a specific prompt. Returns the user's response.",
+              prompt: { type: "string", description: "The prompt to show the user" },
+            ) do |params|
+              Roast::Tools::AskUser.call(params[:prompt])
+            end
+          end
+        end
+      end
+
+      def call(prompt)
+        Roast::Helpers::Logger.info("💬 Asking user: #{prompt}\n")
+
+        response = ::CLI::UI::Prompt.ask(prompt)
+
+        Roast::Helpers::Logger.info("User responded: #{response}\n")
+        response
+      rescue StandardError => e
+        "Error getting user input: #{e.message}".tap do |error_message|
+          Roast::Helpers::Logger.error(error_message + "\n")
+          Roast::Helpers::Logger.debug(e.backtrace.join("\n") + "\n") if ENV["DEBUG"]
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/tools/cmd.rb
+++ b/lib/roast/tools/cmd.rb
@@ -28,7 +28,7 @@ module Roast
         Roast::Helpers::Logger.info("🔧 Running command: #{command}\n")
 
         # Validate the command starts with one of the allowed prefixes
-        allowed_prefixes = ["pwd", "find", "ls", "rake", "ruby", "dev"]
+        allowed_prefixes = ["pwd", "find", "ls", "rake", "ruby", "dev", "mkdir"]
         command_prefix = command.split(" ").first
 
         err = "Error: Command not allowed. Only commands starting with #{allowed_prefixes.join(", ")} are permitted."

--- a/roast.gemspec
+++ b/roast.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency("activesupport", "~> 8.0")
+  spec.add_dependency("cli-ui")
   spec.add_dependency("diff-lcs", "~> 1.5")
   spec.add_dependency("faraday-retry")
   spec.add_dependency("json-schema")


### PR DESCRIPTION
# TLDR:

You can either:
- Select an existing example from `examples/`.
- Write a prompt for it to generate you a new workflow (currently "beta").

# !TLDR

- Added cli-ui as a dependency, was faster+easier than trying to write our own picker TUI.
- Added an `ask_user` tool which prompts the user for some input. Needed this for the "from prompt" workflow to get a prompt from user.

