### PR TITLE
Replace all require_relative with require statements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Add development dependencies to `Gemfile`.
 - Don't ever test private methods directly. Specs should test behavior, not implementation.
 - I do not like test-specific code embedded in production code, don't ever do that
-- Prefer `require` instead of `require_relative` unless the latter is absolutely necessary
+- **Do not use require_relative**
 - Require statements should always be in alphabetical order
 
 ## Git Workflow Practices

--- a/lib/roast/helpers/function_caching_interceptor.rb
+++ b/lib/roast/helpers/function_caching_interceptor.rb
@@ -4,7 +4,7 @@ require "active_support"
 require "active_support/isolated_execution_state"
 require "active_support/cache"
 require "active_support/notifications"
-require_relative "logger"
+require "roast/helpers/logger"
 
 module Roast
   module Helpers

--- a/lib/roast/helpers/minitest_coverage_runner.rb
+++ b/lib/roast/helpers/minitest_coverage_runner.rb
@@ -2,7 +2,7 @@
 
 require "coverage"
 require "minitest"
-require_relative "logger"
+require "roast/helpers/logger"
 
 # Disable the built-in `at_exit` hook for Minitest before anything else
 module Minitest

--- a/lib/roast/resources.rb
+++ b/lib/roast/resources.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require_relative "resources/base_resource"
-require_relative "resources/file_resource"
-require_relative "resources/directory_resource"
-require_relative "resources/url_resource"
-require_relative "resources/api_resource"
-require_relative "resources/none_resource"
+require "roast/resources/base_resource"
+require "roast/resources/file_resource"
+require "roast/resources/directory_resource"
+require "roast/resources/url_resource"
+require "roast/resources/api_resource"
+require "roast/resources/none_resource"
 require "uri"
 
 module Roast

--- a/lib/roast/workflow/base_iteration_step.rb
+++ b/lib/roast/workflow/base_iteration_step.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "workflow_executor"
-require_relative "llm_boolean_coercer"
+require "roast/workflow/workflow_executor"
+require "roast/workflow/llm_boolean_coercer"
 
 module Roast
   module Workflow

--- a/lib/roast/workflow/file_state_repository.rb
+++ b/lib/roast/workflow/file_state_repository.rb
@@ -2,8 +2,8 @@
 
 require "json"
 require "fileutils"
-require_relative "session_manager"
-require_relative "state_repository"
+require "roast/workflow/session_manager"
+require "roast/workflow/state_repository"
 
 module Roast
   module Workflow

--- a/lib/roast/workflow/replay_handler.rb
+++ b/lib/roast/workflow/replay_handler.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "step_finder"
-require_relative "file_state_repository"
+require "roast/workflow/step_finder"
+require "roast/workflow/file_state_repository"
 
 module Roast
   module Workflow

--- a/lib/roast/workflow/state_manager.rb
+++ b/lib/roast/workflow/state_manager.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "file_state_repository"
+require "roast/workflow/file_state_repository"
 
 module Roast
   module Workflow

--- a/lib/roast/workflow/step_executors/hash_step_executor.rb
+++ b/lib/roast/workflow/step_executors/hash_step_executor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "base_step_executor"
+require "roast/workflow/step_executors/base_step_executor"
 
 module Roast
   module Workflow

--- a/lib/roast/workflow/step_executors/parallel_step_executor.rb
+++ b/lib/roast/workflow/step_executors/parallel_step_executor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "base_step_executor"
+require "roast/workflow/step_executors/base_step_executor"
 
 module Roast
   module Workflow

--- a/lib/roast/workflow/step_executors/string_step_executor.rb
+++ b/lib/roast/workflow/step_executors/string_step_executor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "base_step_executor"
+require "roast/workflow/step_executors/base_step_executor"
 
 module Roast
   module Workflow

--- a/lib/roast/workflow/step_loader.rb
+++ b/lib/roast/workflow/step_loader.rb
@@ -2,8 +2,8 @@
 
 require "roast/value_objects/step_name"
 require "roast/workflow/workflow_context"
-require_relative "base_step"
-require_relative "prompt_step"
+require "roast/workflow/base_step"
+require "roast/workflow/prompt_step"
 
 module Roast
   module Workflow

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,8 +23,8 @@ module Minitest
 end
 
 # Require test helpers
-require_relative "support/fixture_helpers"
-require_relative "support/improved_assertions"
+require "support/fixture_helpers"
+require "support/improved_assertions"
 
 require "webmock/minitest"
 # Block all real HTTP requests in tests


### PR DESCRIPTION
## Summary

This PR eliminates all uses of `require_relative` throughout the codebase in favor of standard `require` statements with absolute paths. This change improves consistency and follows Ruby best practices for gem development.

## Changes

- ✅ Updated 13 library files to use absolute require paths
- ✅ Updated test_helper.rb to use standard require for support files  
- ✅ All require statements now use the full module path (e.g., `require "roast/workflow/base_step"`)
- ✅ Updated CLAUDE.md to make the guideline more explicit ("Do not use require_relative")

## Test plan

- [x] Run full test suite: `bundle exec rake`
- [x] Verify all tests pass
- [x] Confirm RuboCop has no offenses
- [x] Test that the gem loads properly

All tests continue to pass, confirming the changes maintain functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)