### PR TITLE
Added configurable uri_base.

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,9 +398,9 @@ Benefits of using OpenRouter:
 
 When using OpenRouter, specify fully qualified model names including the provider prefix (e.g., `anthropic/claude-3-opus-20240229`).
 
-#### Dynamic API Tokens
+#### Dynamic API Tokens and URIs
 
-Roast allows you to dynamically fetch API tokens using shell commands directly in your workflow configuration:
+Roast allows you to dynamically fetch attributes such as API token and URI base (to use with a proxy) via shell commands directly in your workflow configuration:
 
 ```yaml
 # This will execute the shell command and use the result as the API token
@@ -412,8 +412,13 @@ api_token: $(echo $OPENAI_API_KEY)
 # For OpenRouter (requires api_provider setting)
 api_provider: openrouter
 api_token: $(echo $OPENROUTER_API_KEY)
-```
 
+# Static Proxy URI
+uri_base: https://proxy.example.com/v1
+
+# Dynamic Proxy URI
+uri_base: $(echo $AI_PROXY_URI_BASE)
+```
 
 This makes it easy to use environment-specific tokens without hardcoding credentials, especially useful in development environments or CI/CD pipelines. Alternatively, Roast will fall back to `OPENROUTER_API_KEY` or `OPENAI_API_KEY` environment variables based on the specified provider.
 

--- a/lib/roast/value_objects.rb
+++ b/lib/roast/value_objects.rb
@@ -3,3 +3,4 @@
 require "roast/value_objects/api_token"
 require "roast/value_objects/step_name"
 require "roast/value_objects/workflow_path"
+require "roast/value_objects/uri_base"

--- a/lib/roast/value_objects/uri_base.rb
+++ b/lib/roast/value_objects/uri_base.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Roast
+  module ValueObjects
+    # Value object representing a URI base with validation
+    class UriBase
+      class InvalidUriBaseError < StandardError; end
+
+      attr_reader :value
+
+      def initialize(value)
+        @value = value&.to_s
+        validate!
+        freeze
+      end
+
+      def present?
+        !blank?
+      end
+
+      def blank?
+        @value.nil? || @value.strip.empty?
+      end
+
+      def to_s
+        @value
+      end
+
+      def ==(other)
+        return false unless other.is_a?(UriBase)
+
+        value == other.value
+      end
+      alias_method :eql?, :==
+
+      def hash
+        [self.class, @value].hash
+      end
+
+      private
+
+      def validate!
+        return if @value.nil? # Allow nil URI base, just not empty strings
+
+        raise InvalidUriBaseError, "URI base cannot be an empty string" if @value.strip.empty?
+      end
+    end
+  end
+end

--- a/lib/roast/workflow/api_configuration.rb
+++ b/lib/roast/workflow/api_configuration.rb
@@ -2,12 +2,13 @@
 
 require "roast/factories/api_provider_factory"
 require "roast/workflow/resource_resolver"
+require "roast/value_objects/uri_base"
 
 module Roast
   module Workflow
     # Handles API-related configuration including tokens and providers
     class ApiConfiguration
-      attr_reader :api_token, :api_provider
+      attr_reader :api_token, :api_provider, :uri_base
 
       def initialize(config_hash)
         @config_hash = config_hash
@@ -37,6 +38,7 @@ module Roast
       def process_api_configuration
         extract_api_token
         extract_api_provider
+        extract_uri_base
       end
 
       def extract_api_token
@@ -47,6 +49,12 @@ module Roast
 
       def extract_api_provider
         @api_provider = Roast::Factories::ApiProviderFactory.from_config(@config_hash)
+      end
+
+      def extract_uri_base
+        if @config_hash["uri_base"]
+          @uri_base = ResourceResolver.process_shell_command(@config_hash["uri_base"])
+        end
       end
 
       def environment_token

--- a/lib/roast/workflow/configuration.rb
+++ b/lib/roast/workflow/configuration.rb
@@ -14,7 +14,7 @@ module Roast
       attr_reader :config_hash, :workflow_path, :name, :steps, :tools, :function_configs, :model, :resource
       attr_accessor :target
 
-      delegate :api_provider, :openrouter?, :openai?, to: :api_configuration
+      delegate :api_provider, :openrouter?, :openai?, :uri_base, to: :api_configuration
 
       # Delegate api_token to effective_token for backward compatibility
       def api_token

--- a/lib/roast/workflow/workflow_initializer.rb
+++ b/lib/roast/workflow/workflow_initializer.rb
@@ -81,11 +81,19 @@ module Roast
         end
       end
 
+      def client_options
+        {
+          access_token: @configuration.api_token,
+          uri_base: @configuration.uri_base&.to_s,
+        }.compact
+      end
+
       def configure_openrouter_client
         $stderr.puts "Configuring OpenRouter client with token from workflow"
         require "open_router"
 
-        client = OpenRouter::Client.new(access_token: @configuration.api_token)
+        client = OpenRouter::Client.new(client_options)
+
         Raix.configure do |config|
           config.openrouter_client = client
         end
@@ -96,7 +104,8 @@ module Roast
         $stderr.puts "Configuring OpenAI client with token from workflow"
         require "openai"
 
-        client = OpenAI::Client.new(access_token: @configuration.api_token)
+        client = OpenAI::Client.new(client_options)
+
         Raix.configure do |config|
           config.openai_client = client
         end

--- a/test/roast/helpers/prompt_loader_test.rb
+++ b/test/roast/helpers/prompt_loader_test.rb
@@ -5,9 +5,14 @@ require "roast/helpers/prompt_loader"
 
 class RoastHelpersPromptLoaderTest < ActiveSupport::TestCase
   def setup
+    @original_openai_key = ENV.delete("OPENAI_API_KEY")
     @workflow_file = fixture_file("workflow/workflow.yml")
     @test_file = fixture_file("test.rb")
     @workflow = build_workflow(@workflow_file, @test_file)
+  end
+
+  def teardown
+    ENV["OPENAI_API_KEY"] = @original_openai_key
   end
 
   def build_workflow(workflow_file, test_file)

--- a/test/roast/value_objects/uri_base_test.rb
+++ b/test/roast/value_objects/uri_base_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "roast/value_objects/uri_base"
+
+module Roast
+  module ValueObjects
+    class UriBaseTest < Minitest::Test
+      def test_initialization_with_valid_uri_base
+        uri_base = UriBase.new("https://api.example.com")
+        assert_equal("https://api.example.com", uri_base.value)
+      end
+
+      def test_initialization_with_nil
+        uri_base = UriBase.new(nil)
+        assert_nil(uri_base.value)
+        assert(uri_base.blank?)
+        refute(uri_base.present?)
+      end
+
+      def test_initialization_with_empty_string_raises_error
+        assert_raises(UriBase::InvalidUriBaseError) do
+          UriBase.new("")
+        end
+      end
+
+      def test_initialization_with_whitespace_only_raises_error
+        assert_raises(UriBase::InvalidUriBaseError) do
+          UriBase.new("   ")
+        end
+      end
+
+      def test_present_and_blank_methods
+        valid_uri_base = UriBase.new("https://api.example.com")
+        assert(valid_uri_base.present?)
+        refute(valid_uri_base.blank?)
+
+        nil_uri_base = UriBase.new(nil)
+        refute(nil_uri_base.present?)
+        assert(nil_uri_base.blank?)
+      end
+
+      def test_to_s_returns_value
+        uri_base = UriBase.new("https://api.example.com")
+        assert_equal("https://api.example.com", uri_base.to_s)
+      end
+
+      def test_equality
+        uri_base1 = UriBase.new("https://api.example.com")
+        uri_base2 = UriBase.new("https://api.example.com")
+        uri_base3 = UriBase.new("https://api.different.com")
+
+        assert_equal(uri_base1, uri_base2)
+        refute_equal(uri_base1, uri_base3)
+        refute_equal(uri_base1, "https://api.example.com")
+        refute_equal(uri_base1, nil)
+      end
+
+      def test_nil_uri_bases_are_equal
+        uri_base1 = UriBase.new(nil)
+        uri_base2 = UriBase.new(nil)
+
+        assert_equal(uri_base1, uri_base2)
+      end
+
+      def test_eql_method
+        uri_base1 = UriBase.new("https://api.example.com")
+        uri_base2 = UriBase.new("https://api.example.com")
+
+        assert(uri_base1.eql?(uri_base2))
+      end
+
+      def test_hash_equality
+        uri_base1 = UriBase.new("https://api.example.com")
+        uri_base2 = UriBase.new("https://api.example.com")
+        uri_base3 = UriBase.new("https://api.different.com")
+
+        assert_equal(uri_base1.hash, uri_base2.hash)
+        refute_equal(uri_base1.hash, uri_base3.hash)
+      end
+
+      def test_can_be_used_as_hash_key
+        hash = {}
+        uri_base1 = UriBase.new("https://api.example.com")
+        uri_base2 = UriBase.new("https://api.example.com")
+
+        hash[uri_base1] = "value"
+        assert_equal("value", hash[uri_base2])
+      end
+
+      def test_frozen_after_initialization
+        uri_base = UriBase.new("https://api.example.com")
+        assert(uri_base.frozen?)
+      end
+
+      def test_coerces_non_string_to_string
+        uri_base = UriBase.new(123)
+        assert_equal("123", uri_base.value)
+      end
+    end
+  end
+end

--- a/test/roast/workflow/configuration_parser_test.rb
+++ b/test/roast/workflow/configuration_parser_test.rb
@@ -7,8 +7,13 @@ require "active_support/notifications"
 
 class RoastWorkflowConfigurationParserTest < ActiveSupport::TestCase
   def setup
+    @original_openai_key = ENV.delete("OPENAI_API_KEY")
     @workflow_path = fixture_file("workflow/workflow.yml")
     @parser = Roast::Workflow::ConfigurationParser.new(@workflow_path)
+  end
+
+  def teardown
+    ENV["OPENAI_API_KEY"] = @original_openai_key
   end
 
   def capture_stderr

--- a/test/roast/workflow/configuration_test.rb
+++ b/test/roast/workflow/configuration_test.rb
@@ -159,16 +159,8 @@ module Roast
         end
 
         def teardown
-          if @original_openai_key.nil?
-            ENV.delete("OPENAI_API_KEY")
-          else
-            ENV["OPENAI_API_KEY"] = @original_openai_key
-          end
-          if @original_openrouter_key.nil?
-            ENV.delete("OPENROUTER_API_KEY")
-          else
-            ENV["OPENROUTER_API_KEY"] = @original_openai_key
-          end
+          ENV["OPENAI_API_KEY"] = @original_openai_key
+          ENV["OPENROUTER_API_KEY"] = @original_openai_key
         end
 
         def test_uses_openai_env_var_when_provider_is_openai

--- a/test/roast/workflow/step_loader_test.rb
+++ b/test/roast/workflow/step_loader_test.rb
@@ -9,11 +9,16 @@ module Roast
       include FixtureHelpers
 
       def setup
+        @original_openai_key = ENV.delete("OPENAI_API_KEY")
         @workflow = BaseWorkflow.new(nil, name: "test_workflow")
         @workflow.output = {}
         @context_path = File.expand_path("../../fixtures/steps", __dir__)
         @config_hash = {}
         @step_loader = StepLoader.new(@workflow, @config_hash, @context_path)
+      end
+
+      def teardown
+        ENV["OPENAI_API_KEY"] = @original_openai_key
       end
 
       def test_loads_prompt_step_when_name_contains_spaces

--- a/test/roast/workflow/targetless_workflow_test.rb
+++ b/test/roast/workflow/targetless_workflow_test.rb
@@ -9,8 +9,13 @@ require "roast/workflow/workflow_executor"
 
 class RoastWorkflowTargetlessWorkflowTest < ActiveSupport::TestCase
   def setup
+    @original_openai_key = ENV.delete("OPENAI_API_KEY")
     @workflow_path = fixture_file_path("targetless_workflow.yml")
     @parser = Roast::Workflow::ConfigurationParser.new(@workflow_path)
+  end
+
+  def teardown
+    ENV["OPENAI_API_KEY"] = @original_openai_key
   end
 
   class MockedExecution < RoastWorkflowTargetlessWorkflowTest


### PR DESCRIPTION
With this you can configure an AI proxy in the workflow.

```yml
uri_base: https://proxy.example.com/v1
```

Feels like maybe it should also be exposed via some command line flag, but also the workflow is a lot more flexible and could use an ENV.

Closes #12. 
