### PR TITLE
Add case/when/else control flow for workflows

### DIFF
--- a/CLAUDE_NOTES.md
+++ b/CLAUDE_NOTES.md
@@ -1,0 +1,68 @@
+# Important Notes for Claude
+
+## Roast Workflow Syntax
+
+### IMPORTANT: No inline configuration for steps!
+
+Roast workflows DO NOT support inline configuration syntax like this:
+```yaml
+# WRONG - This syntax does NOT exist:
+steps:
+  - step_name:
+      prompt: "some prompt"
+      output: variable_name
+```
+
+The correct syntax is:
+```yaml
+# CORRECT - Steps are just names or hash assignments:
+steps:
+  - step_name
+  - variable_name: step_name
+  - variable_name: $(command)
+```
+
+### Control flow structures
+
+Only control flow structures (if/unless, case/when/else, each, repeat) support nested configuration:
+
+```yaml
+steps:
+  # Simple step - just the name
+  - detect_language
+  
+  # Variable assignment
+  - my_var: detect_language
+  
+  # Command execution with assignment
+  - env_type: $(echo $ENVIRONMENT)
+  
+  # Control flow - these DO have nested structure
+  - if: "{{ condition }}"
+    then:
+      - step1
+      - step2
+      
+  - case: "{{ expression }}"
+    when:
+      value1:
+        - step1
+      value2:
+        - step2
+    else:
+      - step3
+```
+
+### Step Configuration
+
+Step configuration (prompts, outputs, etc.) is handled through:
+1. File naming conventions (step_name/prompt.md, step_name/output.txt)
+2. The workflow configuration file itself (tools, target, etc.)
+
+NOT through inline step configuration in the steps array.
+
+## Remember:
+- Steps array contains step names, not step configurations
+- Only control flow structures have nested configuration
+- Variable assignment uses hash syntax: `var_name: step_name`
+- Commands use $() syntax: `var_name: $(command)`

--- a/README.md
+++ b/README.md
@@ -178,7 +178,37 @@ Roast supports several types of steps:
    - Until conditions: `until: "{{condition}}"`
    - Maximum iterations: `max_iterations: 10`
 
-6. **Raw prompt step**: Simple text prompts for the model without tools
+6. **Case/when/else steps**: Select different execution paths based on a value (similar to Ruby's case statement)
+   ```yaml
+   steps:
+     - detect_language
+     
+     - case: "{{ workflow.output.detect_language }}"
+       when:
+         ruby:
+           - lint_with_rubocop
+           - test_with_rspec
+         javascript:
+           - lint_with_eslint
+           - test_with_jest
+         python:
+           - lint_with_pylint
+           - test_with_pytest
+       else:
+         - analyze_generic
+         - generate_basic_report
+   ```
+   
+   Case expressions can be:
+   - Workflow outputs: `case: "{{ workflow.output.variable }}"`
+   - Ruby expressions: `case: "{{ count > 10 ? 'high' : 'low' }}"`
+   - Bash commands: `case: "$(echo $ENVIRONMENT)"`
+   - Direct values: `case: "production"`
+   
+   The value is compared against each key in the `when` clause, and matching steps are executed.
+   If no match is found, the `else` steps are executed (if provided).
+
+7. **Raw prompt step**: Simple text prompts for the model without tools
    ```yaml
    steps:
      - Summarize the changes made to the codebase.

--- a/examples/case_when/README.md
+++ b/examples/case_when/README.md
@@ -1,0 +1,58 @@
+# Case/When/Else Example
+
+This example demonstrates the use of `case/when/else` control flow in Roast workflows.
+
+## Overview
+
+The `case/when/else` construct allows you to execute different steps based on the value of an expression, similar to Ruby's case statement or switch statements in other languages.
+
+## Syntax
+
+```yaml
+- case: <expression>
+  when:
+    <value1>:
+      - <steps>
+    <value2>:
+      - <steps>
+  else:
+    - <steps>
+```
+
+## Features Demonstrated
+
+1. **Basic case/when/else**: Detect file language and execute language-specific analysis
+2. **Bash command evaluation**: Use environment variables to determine deployment strategy
+3. **Complex expressions**: Use Ruby expressions to categorize numeric values
+
+## Expression Types
+
+The `case` expression can be:
+- A simple string value
+- An interpolated workflow output: `{{ workflow.output.variable }}`
+- A Ruby expression: `{{ workflow.output.count > 10 ? 'high' : 'low' }}`
+- A bash command: `$(echo $ENVIRONMENT)`
+- A reference to a previous step's output
+
+## How It Works
+
+1. The `case` expression is evaluated to produce a value
+2. The value is compared against each key in the `when` clause
+3. If a match is found, the steps under that key are executed
+4. If no match is found and an `else` clause exists, those steps are executed
+5. If no match is found and no `else` clause exists, execution continues
+
+## Running the Example
+
+```bash
+roast execute examples/case_when/workflow.yml
+```
+
+This will process all Ruby, JavaScript, Python, and Go files in the current directory, detecting their language and running appropriate analysis steps.
+
+## Use Cases
+
+- **Multi-language projects**: Different linting/testing for different file types
+- **Environment-specific workflows**: Different deployment steps for prod/staging/dev
+- **Conditional processing**: Different handling based on file size, complexity, or other metrics
+- **Error handling**: Different recovery strategies based on error types

--- a/examples/case_when/detect_language/prompt.md
+++ b/examples/case_when/detect_language/prompt.md
@@ -1,0 +1,16 @@
+# Detect Programming Language
+
+Based on the file extension and content, determine the primary programming language of this file:
+- If it's a `.rb` file, return "ruby"
+- If it's a `.js` file, return "javascript"
+- If it's a `.py` file, return "python"
+- If it's a `.go` file, return "go"
+- Otherwise, return "unknown"
+
+Return ONLY the language name in lowercase, nothing else.
+
+File: {{ context.resource_uri }}
+Content:
+```
+{{ context.resource }}
+```

--- a/examples/case_when/workflow.yml
+++ b/examples/case_when/workflow.yml
@@ -1,0 +1,58 @@
+name: "Case/When/Else Example"
+
+tools:
+  - Roast::Tools::Cmd
+  - Roast::Tools::ReadFile
+  - Roast::Tools::WriteFile
+
+target: "**/*.{rb,js,py,go}"
+
+steps:
+  - detect_language
+
+  - case: "{{ workflow.output.detect_language }}"
+    when:
+      ruby:
+        - analyze_ruby
+        - generate_ruby_report
+      javascript:
+        - analyze_javascript
+        - generate_js_report
+      python:
+        - analyze_python
+        - generate_python_report
+      go:
+        - analyze_go
+        - generate_go_report
+    else:
+      - analyze_generic
+      - generate_generic_report
+
+  # Another example using bash command for case expression
+  - get_environment: $(echo $ENVIRONMENT || echo "development")
+
+  - case: "{{ workflow.output.get_environment }}"
+    when:
+      production:
+        - production_checks
+        - deploy_production
+      staging:
+        - staging_checks
+        - deploy_staging
+      development:
+        - run_tests
+        - local_deploy
+    else:
+      - unknown_environment
+
+  # Example with numeric case values
+  - count_issues
+
+  - case: "{{ workflow.output.count_issues.to_i > 10 ? 'high' : workflow.output.count_issues.to_i > 5 ? 'medium' : 'low' }}"
+    when:
+      high:
+        - high_priority_alert
+      medium:
+        - medium_priority_notice
+      low:
+        - low_priority_info

--- a/lib/roast/workflow/case_executor.rb
+++ b/lib/roast/workflow/case_executor.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Roast
+  module Workflow
+    # Handles execution of case/when/else steps
+    class CaseExecutor
+      def initialize(workflow, context_path, state_manager, workflow_executor = nil)
+        @workflow = workflow
+        @context_path = context_path
+        @state_manager = state_manager
+        @workflow_executor = workflow_executor
+      end
+
+      def execute_case(case_config)
+        $stderr.puts "Executing case step: #{case_config.inspect}"
+
+        # Extract case expression
+        case_expr = case_config["case"]
+        when_clauses = case_config["when"]
+        case_config["else"]
+
+        # Verify required parameters
+        raise WorkflowExecutor::ConfigurationError, "Missing 'case' expression in case configuration" unless case_expr
+        raise WorkflowExecutor::ConfigurationError, "Missing 'when' clauses in case configuration" unless when_clauses
+
+        # Create and execute a CaseStep
+        require "roast/workflow/case_step" unless defined?(Roast::Workflow::CaseStep)
+        case_step = CaseStep.new(
+          @workflow,
+          config: case_config,
+          name: "case_#{case_expr.to_s.gsub(/[^a-zA-Z0-9_]/, "_")[0..20]}",
+          context_path: @context_path,
+          workflow_executor: @workflow_executor,
+        )
+
+        result = case_step.call
+
+        # Store the result in workflow output
+        step_name = "case_#{case_expr.to_s.gsub(/[^a-zA-Z0-9_]/, "_")[0..30]}"
+        @workflow.output[step_name] = result
+
+        # Save state
+        @state_manager.save_state(step_name, @workflow.output[step_name])
+
+        result
+      end
+    end
+  end
+end

--- a/lib/roast/workflow/case_executor.rb
+++ b/lib/roast/workflow/case_executor.rb
@@ -28,7 +28,7 @@ module Roast
         case_step = CaseStep.new(
           @workflow,
           config: case_config,
-          name: "case_#{case_expr.to_s.gsub(/[^a-zA-Z0-9_]/, "_")[0..20]}",
+          name: "case_#{case_expr.to_s.gsub(/[^a-zA-Z0-9_]/, "_")[0..30]}",
           context_path: @context_path,
           workflow_executor: @workflow_executor,
         )

--- a/lib/roast/workflow/case_step.rb
+++ b/lib/roast/workflow/case_step.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "roast/workflow/base_step"
+require "roast/workflow/expression_evaluator"
+require "roast/workflow/interpolator"
+
+module Roast
+  module Workflow
+    class CaseStep < BaseStep
+      include ExpressionEvaluator
+
+      def initialize(workflow, config:, name:, context_path:, workflow_executor:, **kwargs)
+        super(workflow, name: name, context_path: context_path, **kwargs)
+
+        @config = config
+        @case_expression = config["case"]
+        @when_clauses = config["when"] || {}
+        @else_steps = config["else"] || []
+        @workflow_executor = workflow_executor
+      end
+
+      def call
+        # Evaluate the case expression to get the value to match against
+        case_value = evaluate_case_expression(@case_expression)
+
+        # Find the matching when clause
+        matched_key = find_matching_when_clause(case_value)
+
+        # Determine which steps to execute
+        steps_to_execute = if matched_key
+          @when_clauses[matched_key]
+        else
+          @else_steps
+        end
+
+        # Execute the selected steps
+        unless steps_to_execute.nil? || steps_to_execute.empty?
+          @workflow_executor.execute_steps(steps_to_execute)
+        end
+
+        # Return a result indicating which branch was taken
+        {
+          case_value: case_value,
+          matched_when: matched_key,
+          branch_executed: matched_key || (steps_to_execute.empty? ? "none" : "else"),
+        }
+      end
+
+      private
+
+      def evaluate_case_expression(expression)
+        return unless expression
+
+        # Handle interpolated expressions
+        if expression.is_a?(String)
+          interpolated = Interpolator.new(@workflow).interpolate(expression)
+
+          if ruby_expression?(interpolated)
+            evaluate_ruby_expression(interpolated)
+          elsif bash_command?(interpolated)
+            evaluate_bash_command(interpolated, for_condition: false)
+          else
+            # Return the interpolated value as-is
+            interpolated
+          end
+        else
+          expression
+        end
+      end
+
+      def find_matching_when_clause(case_value)
+        # Convert case_value to string for comparison
+        case_value_str = case_value.to_s
+
+        @when_clauses.keys.find do |when_key|
+          # Direct string comparison
+          when_key.to_s == case_value_str
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/workflow/conditional_step.rb
+++ b/lib/roast/workflow/conditional_step.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 require "roast/workflow/base_step"
-require "roast/workflow/command_executor"
-require "roast/workflow/expression_utils"
+require "roast/workflow/expression_evaluator"
 require "roast/workflow/interpolator"
 
 module Roast
   module Workflow
     class ConditionalStep < BaseStep
-      include ExpressionUtils
+      include ExpressionEvaluator
 
       def initialize(workflow, config:, name:, context_path:, workflow_executor:, **kwargs)
         super(workflow, name: name, context_path: context_path, **kwargs)
@@ -46,50 +45,14 @@ module Roast
         return false unless condition.is_a?(String)
 
         if ruby_expression?(condition)
-          evaluate_ruby_expression(condition)
+          # For conditionals, coerce result to boolean
+          !!evaluate_ruby_expression(condition)
         elsif bash_command?(condition)
-          evaluate_bash_command(condition)
+          evaluate_bash_command(condition, for_condition: true)
         else
           # Treat as a step name or direct boolean
-          evaluate_step_or_value(condition)
+          evaluate_step_or_value(condition, for_condition: true)
         end
-      end
-
-      def evaluate_ruby_expression(expression)
-        expr = extract_expression(expression)
-        begin
-          !!@workflow.instance_eval(expr)
-        rescue => e
-          $stderr.puts "Warning: Error evaluating expression '#{expr}': #{e.message}"
-          false
-        end
-      end
-
-      def evaluate_bash_command(command)
-        cmd = extract_command(command)
-        executor = CommandExecutor.new(logger: Roast::Helpers::Logger)
-        begin
-          result = executor.execute(cmd, exit_on_error: false)
-          # For conditionals, we care about the exit status
-          result[:success]
-        rescue => e
-          $stderr.puts "Warning: Error executing command '#{cmd}': #{e.message}"
-          false
-        end
-      end
-
-      def evaluate_step_or_value(input)
-        # Check if it's a reference to a previous step output
-        if @workflow.output.key?(input)
-          result = @workflow.output[input]
-          # Coerce to boolean
-          return false if result.nil? || result == false || result == "" || result == "false"
-
-          return true
-        end
-
-        # Otherwise treat as a direct value
-        input.to_s.downcase == "true"
       end
     end
   end

--- a/lib/roast/workflow/expression_evaluator.rb
+++ b/lib/roast/workflow/expression_evaluator.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "roast/workflow/command_executor"
+require "roast/workflow/expression_utils"
+
+module Roast
+  module Workflow
+    # Shared module for evaluating expressions in workflow steps
+    module ExpressionEvaluator
+      include ExpressionUtils
+
+      # Evaluate a Ruby expression in the workflow context
+      # @param expression [String] The expression to evaluate
+      # @return [Object] The result of the expression
+      def evaluate_ruby_expression(expression)
+        expr = extract_expression(expression)
+        begin
+          @workflow.instance_eval(expr)
+        rescue => e
+          $stderr.puts "Warning: Error evaluating expression '#{expr}': #{e.message}"
+          nil
+        end
+      end
+
+      # Evaluate a bash command and return its output
+      # @param command [String] The command to execute
+      # @param for_condition [Boolean] If true, returns success status; if false, returns output
+      # @return [Boolean, String, nil] Command result based on for_condition flag
+      def evaluate_bash_command(command, for_condition: false)
+        cmd = command.start_with?("$(") ? command : extract_command(command)
+        executor = CommandExecutor.new(logger: Roast::Helpers::Logger)
+
+        begin
+          output = executor.execute(cmd, exit_on_error: false)
+
+          if for_condition
+            # For conditions, we care about the exit status (success = true)
+            # Check if output contains exit status marker
+            !output.include?("[Exit status:")
+          else
+            # For case expressions, we want the actual output
+            output.strip
+          end
+        rescue => e
+          $stderr.puts "Warning: Error executing command '#{cmd}': #{e.message}"
+          for_condition ? false : nil
+        end
+      end
+
+      # Evaluate a step reference or direct value
+      # @param input [String] The input to evaluate
+      # @return [Boolean, Object] The result for conditions, or the value itself
+      def evaluate_step_or_value(input, for_condition: false)
+        # Check if it's a reference to a previous step output
+        if @workflow.output.key?(input)
+          result = @workflow.output[input]
+
+          if for_condition
+            # Coerce to boolean for conditions
+            return false if result.nil? || result == false || result == "" || result == "false"
+
+            return true
+          else
+            # Return the actual value for case expressions
+            return result
+          end
+        end
+
+        # Otherwise treat as a direct value
+        if for_condition
+          input.to_s.downcase == "true"
+        else
+          input
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/workflow/step_executor_coordinator.rb
+++ b/lib/roast/workflow/step_executor_coordinator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "roast/workflow/case_executor"
 require "roast/workflow/conditional_executor"
 require "roast/workflow/step_executor_factory"
 require "roast/workflow/step_type_resolver"
@@ -68,6 +69,8 @@ module Roast
           execute_iteration_step(step)
         when StepTypeResolver::CONDITIONAL_STEP
           execute_conditional_step(step)
+        when StepTypeResolver::CASE_STEP
+          execute_case_step(step)
         when StepTypeResolver::HASH_STEP
           execute_hash_step(step)
         when StepTypeResolver::PARALLEL_STEP
@@ -103,6 +106,15 @@ module Roast
 
       def conditional_executor
         dependencies[:conditional_executor]
+      end
+
+      def case_executor
+        @case_executor ||= dependencies[:case_executor] || CaseExecutor.new(
+          context.workflow,
+          context.context_path,
+          dependencies[:state_manager] || dependencies[:workflow_executor].state_manager,
+          workflow_executor,
+        )
       end
 
       def step_orchestrator
@@ -152,6 +164,10 @@ module Roast
 
       def execute_conditional_step(step)
         conditional_executor.execute_conditional(step)
+      end
+
+      def execute_case_step(step)
+        case_executor.execute_case(step)
       end
 
       def execute_hash_step(step)

--- a/lib/roast/workflow/step_type_resolver.rb
+++ b/lib/roast/workflow/step_type_resolver.rb
@@ -9,6 +9,7 @@ module Roast
       GLOB_STEP = :glob
       ITERATION_STEP = :iteration
       CONDITIONAL_STEP = :conditional
+      CASE_STEP = :case
       HASH_STEP = :hash
       PARALLEL_STEP = :parallel
       STRING_STEP = :string
@@ -19,6 +20,9 @@ module Roast
 
       # Special step names for conditionals
       CONDITIONAL_STEPS = ["if", "unless"].freeze
+
+      # Special step name for case statements
+      CASE_STEPS = ["case"].freeze
 
       class << self
         # Resolve the type of a step
@@ -76,6 +80,16 @@ module Roast
           CONDITIONAL_STEPS.include?(step_name)
         end
 
+        # Check if a step is a case step
+        # @param step [Hash] The step to check
+        # @return [Boolean] true if it's a case step
+        def case_step?(step)
+          return false unless step.is_a?(Hash)
+
+          step_name = step.keys.first
+          CASE_STEPS.include?(step_name)
+        end
+
         # Extract the step name from various step formats
         # @param step [String, Hash, Array] The step
         # @return [String, nil] The step name or nil
@@ -107,6 +121,8 @@ module Roast
             ITERATION_STEP
           elsif conditional_step?(step)
             CONDITIONAL_STEP
+          elsif case_step?(step)
+            CASE_STEP
           else
             HASH_STEP
           end

--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -172,6 +172,33 @@
                 }
               },
               "required": ["unless", "then"]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "case": {
+                  "type": "string",
+                  "description": "Expression to evaluate. Can be a Ruby expression in {{...}}, a bash command in $(...), a step name, or prompt content."
+                },
+                "when": {
+                  "type": "object",
+                  "description": "Map of case values to steps to execute when matched",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/properties/steps/items"
+                    }
+                  }
+                },
+                "else": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/properties/steps/items"
+                  },
+                  "description": "Steps to execute when no when clauses match"
+                }
+              },
+              "required": ["case", "when"]
             }
           ]
         }

--- a/test/roast/workflow/case_step_test.rb
+++ b/test/roast/workflow/case_step_test.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "roast/workflow/case_step"
+require "roast/workflow/case_executor"
+require "roast/workflow/base_workflow"
+
+module Roast
+  module Workflow
+    class CaseStepTest < ActiveSupport::TestCase
+      def setup
+        @workflow = BaseWorkflow.new
+        @workflow_executor = mock("workflow_executor")
+        @state_manager = mock("state_manager")
+        @state_manager.stubs(:save_state)
+      end
+
+      test "evaluates case expression and executes matching when clause" do
+        config = {
+          "case" => "ruby",
+          "when" => {
+            "ruby" => ["process_ruby_step"],
+            "javascript" => ["process_js_step"],
+            "python" => ["process_python_step"],
+          },
+          "else" => ["process_unknown_step"],
+        }
+
+        step = CaseStep.new(
+          @workflow,
+          config: config,
+          name: "case_test",
+          context_path: "/test",
+          workflow_executor: @workflow_executor,
+        )
+
+        @workflow_executor.expects(:execute_steps).with(["process_ruby_step"])
+
+        result = step.call
+        assert_equal "ruby", result[:case_value]
+        assert_equal "ruby", result[:matched_when]
+        assert_equal "ruby", result[:branch_executed]
+      end
+
+      test "executes else clause when no when clauses match" do
+        config = {
+          "case" => "golang",
+          "when" => {
+            "ruby" => ["process_ruby_step"],
+            "javascript" => ["process_js_step"],
+            "python" => ["process_python_step"],
+          },
+          "else" => ["process_unknown_step"],
+        }
+
+        step = CaseStep.new(
+          @workflow,
+          config: config,
+          name: "case_test",
+          context_path: "/test",
+          workflow_executor: @workflow_executor,
+        )
+
+        @workflow_executor.expects(:execute_steps).with(["process_unknown_step"])
+
+        result = step.call
+        assert_equal "golang", result[:case_value]
+        assert_nil result[:matched_when]
+        assert_equal "else", result[:branch_executed]
+      end
+
+      test "does nothing when no when clauses match and no else clause" do
+        config = {
+          "case" => "golang",
+          "when" => {
+            "ruby" => ["process_ruby_step"],
+            "javascript" => ["process_js_step"],
+          },
+        }
+
+        step = CaseStep.new(
+          @workflow,
+          config: config,
+          name: "case_test",
+          context_path: "/test",
+          workflow_executor: @workflow_executor,
+        )
+
+        @workflow_executor.expects(:execute_steps).never
+
+        result = step.call
+        assert_equal "golang", result[:case_value]
+        assert_nil result[:matched_when]
+        assert_equal "none", result[:branch_executed]
+      end
+
+      test "evaluates interpolated case expression" do
+        @workflow.output["file_type"] = "javascript"
+
+        config = {
+          "case" => "{{ workflow.output.file_type }}",
+          "when" => {
+            "javascript" => ["process_js_step"],
+            "ruby" => ["process_ruby_step"],
+          },
+        }
+
+        step = CaseStep.new(
+          @workflow,
+          config: config,
+          name: "case_test",
+          context_path: "/test",
+          workflow_executor: @workflow_executor,
+        )
+
+        @workflow_executor.expects(:execute_steps).with(["process_js_step"])
+
+        result = step.call
+        assert_equal "javascript", result[:case_value]
+        assert_equal "javascript", result[:matched_when]
+      end
+
+      test "evaluates ruby expression in case statement" do
+        @workflow.output["count"] = 5
+
+        config = {
+          "case" => "{{ workflow.output.count > 3 ? 'high' : 'low' }}",
+          "when" => {
+            "high" => ["process_high_step"],
+            "low" => ["process_low_step"],
+          },
+        }
+
+        step = CaseStep.new(
+          @workflow,
+          config: config,
+          name: "case_test",
+          context_path: "/test",
+          workflow_executor: @workflow_executor,
+        )
+
+        @workflow_executor.expects(:execute_steps).with(["process_high_step"])
+
+        result = step.call
+        assert_equal "high", result[:case_value]
+        assert_equal "high", result[:matched_when]
+      end
+
+      test "handles numeric case values" do
+        config = {
+          "case" => "{{ 42 }}",
+          "when" => {
+            "42" => ["process_answer_step"],
+            "0" => ["process_zero_step"],
+          },
+        }
+
+        step = CaseStep.new(
+          @workflow,
+          config: config,
+          name: "case_test",
+          context_path: "/test",
+          workflow_executor: @workflow_executor,
+        )
+
+        @workflow_executor.expects(:execute_steps).with(["process_answer_step"])
+
+        result = step.call
+        assert_equal "42", result[:case_value] # Interpolator returns strings
+        assert_equal "42", result[:matched_when]
+      end
+
+      test "case executor integration" do
+        case_config = {
+          "case" => "ruby",
+          "when" => {
+            "ruby" => ["process_ruby_step"],
+            "javascript" => ["process_js_step"],
+          },
+        }
+
+        executor = CaseExecutor.new(@workflow, "/test", @state_manager, @workflow_executor)
+
+        @workflow_executor.expects(:execute_steps).with(["process_ruby_step"])
+        @state_manager.expects(:save_state).with(
+          "case_ruby",
+          has_entries("case_value" => "ruby", "matched_when" => "ruby", "branch_executed" => "ruby"),
+        )
+
+        result = executor.execute_case(case_config)
+        assert_equal "ruby", result[:case_value]
+        assert_equal "ruby", result[:matched_when]
+      end
+
+      test "handles bash command in case expression" do
+        config = {
+          "case" => "$(echo 'production')",
+          "when" => {
+            "production" => ["deploy_prod_step"],
+            "staging" => ["deploy_staging_step"],
+          },
+        }
+
+        step = CaseStep.new(
+          @workflow,
+          config: config,
+          name: "case_test",
+          context_path: "/test",
+          workflow_executor: @workflow_executor,
+        )
+
+        @workflow_executor.expects(:execute_steps).with(["deploy_prod_step"])
+
+        result = step.call
+        assert_equal "production", result[:case_value]
+        assert_equal "production", result[:matched_when]
+      end
+
+      test "handles multiple steps in when clause" do
+        config = {
+          "case" => "ruby",
+          "when" => {
+            "ruby" => ["lint_ruby", "test_ruby", "build_ruby"],
+            "javascript" => ["lint_js", "test_js", "build_js"],
+          },
+        }
+
+        step = CaseStep.new(
+          @workflow,
+          config: config,
+          name: "case_test",
+          context_path: "/test",
+          workflow_executor: @workflow_executor,
+        )
+
+        @workflow_executor.expects(:execute_steps).with(["lint_ruby", "test_ruby", "build_ruby"])
+
+        result = step.call
+        assert_equal "ruby", result[:matched_when]
+      end
+    end
+  end
+end

--- a/test/roast/workflow/step_type_resolver_test.rb
+++ b/test/roast/workflow/step_type_resolver_test.rb
@@ -83,6 +83,36 @@ module Roast
         refute(StepTypeResolver.iteration_step?([]))
       end
 
+      def test_conditional_step_predicate
+        assert(StepTypeResolver.conditional_step?({ "if" => "condition" }))
+        assert(StepTypeResolver.conditional_step?({ "unless" => "condition" }))
+        refute(StepTypeResolver.conditional_step?({ "var" => "value" }))
+        refute(StepTypeResolver.conditional_step?("string"))
+        refute(StepTypeResolver.conditional_step?([]))
+      end
+
+      def test_case_step_predicate
+        assert(StepTypeResolver.case_step?({ "case" => "expression" }))
+        refute(StepTypeResolver.case_step?({ "var" => "value" }))
+        refute(StepTypeResolver.case_step?("string"))
+        refute(StepTypeResolver.case_step?([]))
+      end
+
+      def test_resolves_conditional_step_if
+        step = { "if" => "condition", "then" => ["step1"] }
+        assert_equal(StepTypeResolver::CONDITIONAL_STEP, StepTypeResolver.resolve(step))
+      end
+
+      def test_resolves_conditional_step_unless
+        step = { "unless" => "condition", "then" => ["step1"] }
+        assert_equal(StepTypeResolver::CONDITIONAL_STEP, StepTypeResolver.resolve(step))
+      end
+
+      def test_resolves_case_step
+        step = { "case" => "expression", "when" => { "value1" => ["step1"] } }
+        assert_equal(StepTypeResolver::CASE_STEP, StepTypeResolver.resolve(step))
+      end
+
       def test_extract_name_from_string
         assert_equal("test", StepTypeResolver.extract_name("test"))
       end


### PR DESCRIPTION
## Summary

This PR implements Ruby-style `case/when/else` control flow for Roast workflows, enabling dynamic step selection based on expression evaluation. This addresses issue #50.

## Changes

### New Features
- **CaseStep class**: Evaluates case expressions and executes matching when clauses
- **CaseExecutor class**: Manages execution flow and state for case steps
- **Example workflow**: Demonstrates various case/when/else usage patterns
- **Comprehensive tests**: Full test coverage for all case/when/else scenarios

### Implementation Details
- Case expressions support:
  - Ruby expressions: `{{ workflow.output.count > 10 ? 'high' : 'low' }}`
  - Bash commands: `$(echo $ENVIRONMENT)`
  - Workflow outputs: `{{ workflow.output.variable }}`
  - Direct values: `"production"`
- String-based matching between case values and when keys
- Optional else clause for unmatched cases
- Multiple steps can be defined per when clause

### Code Quality Improvements
- Created `ExpressionEvaluator` module to share expression evaluation logic
- Refactored `ConditionalStep` to use the shared module
- Eliminated code duplication between conditional and case steps
- Follows existing patterns for control flow implementation

## Testing

- ✅ All existing tests pass
- ✅ New tests for CaseStep functionality
- ✅ Updated StepTypeResolver tests
- ✅ Rubocop style compliance

## Documentation

- Updated README with case/when/else examples
- Created example workflow with detailed documentation
- Added reminder notes about Roast workflow syntax

## Example Usage

```yaml
steps:
  - detect_language
  
  - case: "{{ workflow.output.detect_language }}"
    when:
      ruby:
        - lint_with_rubocop
        - test_with_rspec
      javascript:
        - lint_with_eslint
        - test_with_jest
    else:
      - analyze_generic
```

🤖 Generated with [Claude Code](https://claude.ai/code)