### PR TITLE
Correctly prefix path when searching for files

### DIFF
--- a/lib/roast/tools/search_file.rb
+++ b/lib/roast/tools/search_file.rb
@@ -29,9 +29,9 @@ module Roast
         Roast::Helpers::Logger.info("🔍 Searching for: '#{glob_pattern}' in '#{File.expand_path(path)}'\n")
         search_for(glob_pattern, path).then do |results|
           return "No results found for #{glob_pattern} in #{path}" if results.empty?
-          return read_contents(results.first) if results.size == 1
+          return read_contents(File.join(path, results.first)) if results.size == 1
 
-          results.join("\n") # purposely give the AI list of actual paths so that it can read without searching first
+          results.map { |result| File.join(path, result) }.join("\n") # purposely give the AI list of actual paths so that it can read without searching first
         end
       rescue StandardError => e
         "Error searching for '#{glob_pattern}' in '#{path}': #{e.message}".tap do |error_message|

--- a/test/roast/tools/search_file_test.rb
+++ b/test/roast/tools/search_file_test.rb
@@ -81,14 +81,14 @@ class RoastToolsSearchFileTest < ActiveSupport::TestCase
 
   test ".call returns file content for single match" do
     Roast::Tools::SearchFile.stubs(:search_for).with("test_file1.txt", ".").returns(["test_file1.txt"])
-    Roast::Tools::SearchFile.stubs(:read_contents).with("test_file1.txt").returns("file content")
+    Roast::Tools::SearchFile.stubs(:read_contents).with("./test_file1.txt").returns("file content")
 
     result = Roast::Tools::SearchFile.call("test_file1.txt")
     assert_equal "file content", result
   end
 
   test ".call with path parameter passes path to search_for" do
-    Roast::Tools::SearchFile.expects(:search_for).with("test_file", "nested/dir").returns(["nested/dir/test_file.txt"])
+    Roast::Tools::SearchFile.expects(:search_for).with("test_file", "nested/dir").returns(["test_file.txt"])
     Roast::Tools::SearchFile.stubs(:read_contents).with("nested/dir/test_file.txt").returns("file content")
 
     result = Roast::Tools::SearchFile.call("test_file", "nested/dir")
@@ -99,7 +99,7 @@ class RoastToolsSearchFileTest < ActiveSupport::TestCase
     Roast::Tools::SearchFile.stubs(:search_for).with("file", ".").returns(["file1.txt", "file2.txt"])
 
     result = Roast::Tools::SearchFile.call("file")
-    assert_equal "file1.txt\nfile2.txt", result
+    assert_equal "./file1.txt\n./file2.txt", result
   end
 
   test ".call returns no results message when empty" do


### PR DESCRIPTION
The search_file tool will search for a file using Dir.glob and include a base path if there is one. It will then base the result into read_contents. However, Dir.glob with a base will return results relative to that base, so the read contents will fail.

Many times the LLM will see the resulting error and then use the full path with a base of ., which will work correctly. This should just skip that roundtrip.