### PR TITLE
Allow configuring commands for the Cmd tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ steps:
 
 ## Try it
 
-If you don’t have one already, get an OpenAI key from [here](https://platform.openai.com/settings/organization/api-keys). You will need an account with a credit card, make sure that a basic completion works.
+If you don't have one already, get an OpenAI key from [here](https://platform.openai.com/settings/organization/api-keys). You will need an account with a credit card, make sure that a basic completion works.
 
 ```bash
 export OPENAI_API_KEY=sk-proj-....
@@ -169,7 +169,7 @@ Roast supports several types of steps:
    steps:
      - lint_check: $(rubocop {{file}})
      - fix_issues
-   
+
    # Step configuration
    lint_check:
      exit_on_error: false  # Continue workflow even if command fails
@@ -186,13 +186,13 @@ Roast supports several types of steps:
            - notify_team
          else:
            - run_development_setup
-     
+
      - verify_dependencies:
          unless: "$(bundle check)"
          then:
            - bundle_install: "$(bundle install)"
    ```
-   
+
    Conditions can be:
    - Ruby expressions: `if: "{{output['count'] > 5}}"`
    - Bash commands: `if: "$(test -f config.yml && echo true)"` (exit code 0 = true)
@@ -209,7 +209,7 @@ Roast supports several types of steps:
          steps:
            - analyze_file
            - Generate a report for {{current_file}}
-     
+
      # Repeat until a condition is met
      - improve_code:
          repeat:
@@ -219,12 +219,12 @@ Roast supports several types of steps:
              - run_tests
              - fix_issues
    ```
-   
+
    Each loops support:
    - Collections from Ruby expressions: `each: "{{[1, 2, 3]}}"`
    - Command output: `each: "$(ls *.rb)"`
    - Step references: `each: "file_list"`
-   
+
    Repeat loops support:
    - Until conditions: `until: "{{condition}}"`
    - Maximum iterations: `max_iterations: 10`
@@ -233,7 +233,7 @@ Roast supports several types of steps:
    ```yaml
    steps:
      - detect_language
-     
+
      - case: "{{ workflow.output.detect_language }}"
        when:
          ruby:
@@ -249,13 +249,13 @@ Roast supports several types of steps:
          - analyze_generic
          - generate_basic_report
    ```
-   
+
    Case expressions can be:
    - Workflow outputs: `case: "{{ workflow.output.variable }}"`
    - Ruby expressions: `case: "{{ count > 10 ? 'high' : 'low' }}"`
    - Bash commands: `case: "$(echo $ENVIRONMENT)"`
    - Direct values: `case: "production"`
-   
+
    The value is compared against each key in the `when` clause, and matching steps are executed.
    If no match is found, the `else` steps are executed (if provided).
 
@@ -541,6 +541,22 @@ Roast provides extensive instrumentation capabilities using ActiveSupport::Notif
 ### Built-in Tools
 
 Roast provides several built-in tools that you can use in your workflows:
+
+#### Tool Configuration
+
+Tools can be configured using a hash format in your workflow YAML:
+
+```yaml
+tools:
+  - Roast::Tools::ReadFile        # No configuration needed
+  - Roast::Tools::Cmd:             # With configuration
+      allowed_commands:
+        - git
+        - npm
+        - yarn
+```
+
+Currently, only `Roast::Tools::Cmd` supports configuration via `allowed_commands`, which restricts which commands can be executed (defaults to: `pwd`, `find`, `ls`, `rake`, `ruby`, `dev`, `mkdir`).
 
 #### ReadFile
 

--- a/examples/tool_config_example/README.md
+++ b/examples/tool_config_example/README.md
@@ -1,0 +1,88 @@
+# Tool Configuration Example
+
+This example demonstrates how to configure tools with specific settings in Roast workflows.
+
+## Overview
+
+Starting with this update, Roast supports configuring tools with specific settings directly in the workflow YAML file. This is particularly useful for tools like `Roast::Tools::Cmd` where you might want to restrict which commands can be executed.
+
+## Configuration Syntax
+
+Tools can be configured in two ways:
+
+### 1. Simple String Format (No Configuration)
+```yaml
+tools:
+  - Roast::Tools::ReadFile
+  - Roast::Tools::WriteFile
+  - Roast::Tools::Grep
+```
+
+### 2. Hash Format (With Configuration)
+```yaml
+tools:
+  - Roast::Tools::Cmd:
+      allowed_commands:
+        - ls
+        - pwd
+        - echo
+```
+
+### 3. Mixed Format
+You can mix both formats in the same workflow:
+
+```yaml
+tools:
+  - Roast::Tools::ReadFile
+  - Roast::Tools::Cmd:
+      allowed_commands:
+        - ls
+        - pwd
+        - ruby
+        - sed
+  - Roast::Tools::WriteFile
+  - Roast::Tools::SearchFile
+```
+
+## Example: Configuring Allowed Commands
+
+The `Roast::Tools::Cmd` tool now supports an `allowed_commands` configuration that restricts which commands can be executed:
+
+```yaml
+tools:
+  - Roast::Tools::Cmd:
+      allowed_commands:
+        - ls
+        - pwd
+        - echo
+        - cat
+        - ruby
+        - rake
+```
+
+With this configuration:
+- ✅ `ls -la` will work
+- ✅ `echo "Hello World"` will work
+- ❌ `rm file.txt` will be rejected (not in allowed list)
+- ❌ `git status` will be rejected (not in allowed list)
+
+## Default Behavior
+
+If no configuration is provided for `Roast::Tools::Cmd`, it uses the default allowed commands:
+- pwd
+- find
+- ls
+- rake
+- ruby
+- dev
+- mkdir
+
+## Running the Example
+
+To run this example workflow:
+
+```bash
+bin/roast execute examples/tool_config_example/workflow.yml
+```
+
+The workflow will validate the tool configuration by executing various commands and demonstrating which ones are allowed and which are rejected based on the configuration.

--- a/examples/tool_config_example/example_step/prompt.md
+++ b/examples/tool_config_example/example_step/prompt.md
@@ -1,0 +1,42 @@
+# Tool Configuration Validation
+
+Execute the following commands using the cmd tool:
+
+1. `ls -la`
+2. `pwd`
+3. `echo "Hello from configured commands!"`
+4. `git status`
+
+RESPONSE FORMAT
+You must respond in JSON format within <json> XML tags.
+
+<json>
+{
+  "commands": [
+    {
+      "command": "ls -la",
+      "exit_status": 0,
+      "output": "total 208\ndrwxr-xr-x@ 31 user  staff...",
+      "success": true
+    },
+    {
+      "command": "pwd",
+      "exit_status": 0,
+      "output": "/Users/user/project",
+      "success": true
+    },
+    {
+      "command": "echo \"Hello from configured commands!\"",
+      "exit_status": 0,
+      "output": "Hello from configured commands!",
+      "success": true
+    },
+    {
+      "command": "git status",
+      "exit_status": null,
+      "output": "Error: Command not allowed. Only commands starting with ls, pwd, echo, cat are permitted.",
+      "success": false
+    }
+  ]
+}
+</json>

--- a/examples/tool_config_example/workflow.yml
+++ b/examples/tool_config_example/workflow.yml
@@ -1,0 +1,15 @@
+name: Tool Configuration Example
+model: default
+tools:
+  - Roast::Tools::ReadFile
+  - Roast::Tools::Cmd:
+      allowed_commands:
+        - ls
+        - pwd
+        - echo
+        - cat
+  - Roast::Tools::WriteFile
+
+steps:
+  - example_step
+

--- a/lib/roast/workflow/configuration.rb
+++ b/lib/roast/workflow/configuration.rb
@@ -11,7 +11,7 @@ module Roast
     # Encapsulates workflow configuration data and provides structured access
     # to the configuration settings
     class Configuration
-      attr_reader :config_hash, :workflow_path, :name, :steps, :pre_processing, :post_processing, :tools, :function_configs, :model, :resource
+      attr_reader :config_hash, :workflow_path, :name, :steps, :pre_processing, :post_processing, :tools, :tool_configs, :function_configs, :model, :resource
       attr_accessor :target
 
       delegate :api_provider, :openrouter?, :openai?, :uri_base, to: :api_configuration
@@ -32,7 +32,7 @@ module Roast
         @steps = ConfigurationLoader.extract_steps(@config_hash)
         @pre_processing = ConfigurationLoader.extract_pre_processing(@config_hash)
         @post_processing = ConfigurationLoader.extract_post_processing(@config_hash)
-        @tools = ConfigurationLoader.extract_tools(@config_hash)
+        @tools, @tool_configs = ConfigurationLoader.extract_tools(@config_hash)
         @function_configs = ConfigurationLoader.extract_functions(@config_hash)
         @model = ConfigurationLoader.extract_model(@config_hash)
 
@@ -80,6 +80,13 @@ module Roast
       # @return [Hash] The configuration for the function or empty hash if not found
       def function_config(function_name)
         @function_configs[function_name.to_s] || {}
+      end
+
+      # Get configuration for a specific tool
+      # @param tool_name [String] The name of the tool (e.g., 'Roast::Tools::Cmd')
+      # @return [Hash] The configuration for the tool or empty hash if not found
+      def tool_config(tool_name)
+        @tool_configs[tool_name.to_s] || {}
       end
 
       private

--- a/lib/roast/workflow/configuration_loader.rb
+++ b/lib/roast/workflow/configuration_loader.rb
@@ -46,11 +46,27 @@ module Roast
           config_hash["post_processing"] || []
         end
 
-        # Extract tools from the configuration
+        # Extract tools and tool configurations from the configuration
         # @param config_hash [Hash] The configuration hash
-        # @return [Array] The tools array or empty array
+        # @return [Array, Hash] The tools array or empty array
         def extract_tools(config_hash)
-          config_hash["tools"] || []
+          tools_config = config_hash["tools"] || []
+          tools = []
+          tool_configs = {}
+
+          tools_config.each do |tool_entry|
+            case tool_entry
+            when String
+              tools << tool_entry
+            when Hash
+              tool_entry.each do |tool_name, config|
+                tools << tool_name
+                tool_configs[tool_name] = config || {}
+              end
+            end
+          end
+
+          [tools, tool_configs]
         end
 
         # Extract function configurations

--- a/test/roast/tools/cmd_test.rb
+++ b/test/roast/tools/cmd_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Tools
+    class CmdTest < ActiveSupport::TestCase
+      test "executes default allowed commands" do
+        result = Roast::Tools::Cmd.call("pwd")
+        assert_match(/Command: pwd/, result)
+        assert_match(/Exit status: 0/, result)
+        assert_match(/Output:/, result)
+      end
+
+      test "rejects disallowed commands with default configuration" do
+        result = Roast::Tools::Cmd.call("echo 'test'")
+        assert_equal "Error: Command not allowed. Only commands starting with pwd, find, ls, rake, ruby, dev, mkdir are permitted.", result
+      end
+
+      test "allows custom commands when configured" do
+        config = { "allowed_commands" => ["echo"] }
+        result = Roast::Tools::Cmd.call("echo 'hello world'", config)
+        assert_match(/Command: echo 'hello world'/, result)
+        assert_match(/Exit status: 0/, result)
+        assert_match(/hello world/, result)
+      end
+
+      test "custom configuration overrides defaults completely" do
+        config = { "allowed_commands" => ["echo"] }
+        result = Roast::Tools::Cmd.call("pwd", config)
+        assert_equal "Error: Command not allowed. Only commands starting with echo are permitted.", result
+      end
+
+      test "validates commands using exact prefix matching" do
+        config = { "allowed_commands" => ["git"] }
+
+        # git should work
+        result = Roast::Tools::Cmd.call("git status", config)
+        assert_match(/Command: git status/, result)
+        refute_match(/Error: Command not allowed/, result)
+
+        # gitk should not work (doesn't match exactly)
+        result = Roast::Tools::Cmd.call("gitk", config)
+        assert_equal "Error: Command not allowed. Only commands starting with git are permitted.", result
+      end
+
+      test "handles empty configuration gracefully" do
+        result = Roast::Tools::Cmd.call("ls", {})
+        assert_match(/Command: ls/, result)
+        assert_match(/Exit status: 0/, result)
+      end
+
+      test "handles nil configuration gracefully" do
+        result = Roast::Tools::Cmd.call("pwd")
+        assert_match(/Command: pwd/, result)
+        assert_match(/Exit status: 0/, result)
+      end
+
+      test "handles command execution errors" do
+        config = { "allowed_commands" => ["false"] }
+        result = Roast::Tools::Cmd.call("false", config)
+        assert_match(/Command: false/, result)
+        assert_match(/Exit status: 1/, result)
+      end
+
+      test "handles non-existent commands" do
+        config = { "allowed_commands" => ["nonexistent_command_xyz"] }
+        result = Roast::Tools::Cmd.call("nonexistent_command_xyz", config)
+        assert_match(/Error running command:/, result)
+      end
+
+      test "formats output correctly" do
+        config = { "allowed_commands" => ["echo"] }
+        result = Roast::Tools::Cmd.call("echo 'test'", config)
+
+        lines = result.split("\n")
+        assert_match(/^Command: echo 'test'$/, lines[0])
+        assert_match(/^Exit status: \d+$/, lines[1])
+        assert_equal "Output:", lines[2]
+        assert_match(/test/, lines[3])
+      end
+
+      test "includes all expected default commands" do
+        expected_commands = ["pwd", "find", "ls", "rake", "ruby", "dev", "mkdir"]
+        expected_commands.each do |cmd|
+          # Test that each default command is allowed by trying to execute it with a safe argument
+          test_command = case cmd
+          when "find"
+            "find . -maxdepth 0" # Safe find command that won't recurse
+          when "ruby"
+            "ruby -v" # Just show version
+          when "rake"
+            "rake --version" # Just show version
+          when "dev"
+            "dev version" # Assuming dev has a version command
+          else
+            cmd # pwd, ls, mkdir work without arguments
+          end
+
+          result = Roast::Tools::Cmd.call(test_command)
+          refute_match(/Error: Command not allowed/, result, "Expected '#{cmd}' to be allowed in default configuration, but it was rejected")
+        end
+      end
+    end
+  end
+end

--- a/test/roast/workflow/configuration_loader_test.rb
+++ b/test/roast/workflow/configuration_loader_test.rb
@@ -78,13 +78,60 @@ module Roast
       end
 
       def test_extract_tools
-        tools = ConfigurationLoader.extract_tools(@valid_config)
+        tools, tool_configs = ConfigurationLoader.extract_tools(@valid_config)
         assert_equal(["Roast::Tools::Grep"], tools)
+        assert_equal({}, tool_configs)
       end
 
       def test_extract_tools_returns_empty_array_when_missing
-        tools = ConfigurationLoader.extract_tools({})
+        tools, tool_configs = ConfigurationLoader.extract_tools({})
         assert_equal([], tools)
+        assert_equal({}, tool_configs)
+      end
+
+      def test_extract_tools_with_mixed_formats
+        config = {
+          "tools" => [
+            "Roast::Tools::Grep",
+            { "Roast::Tools::Cmd" => { "allowed_commands" => ["ls", "pwd"] } },
+            "Roast::Tools::ReadFile",
+          ],
+        }
+        tools, tool_configs = ConfigurationLoader.extract_tools(config)
+
+        assert_equal(["Roast::Tools::Grep", "Roast::Tools::Cmd", "Roast::Tools::ReadFile"], tools)
+        assert_equal({ "Roast::Tools::Cmd" => { "allowed_commands" => ["ls", "pwd"] } }, tool_configs)
+      end
+
+      def test_extract_tools_with_only_hash_format
+        config = {
+          "tools" => [
+            { "Roast::Tools::Cmd" => { "allowed_commands" => ["git"] } },
+            { "Roast::Tools::Grep" => nil },
+          ],
+        }
+        tools, tool_configs = ConfigurationLoader.extract_tools(config)
+
+        assert_equal(["Roast::Tools::Cmd", "Roast::Tools::Grep"], tools)
+        assert_equal(
+          {
+            "Roast::Tools::Cmd" => { "allowed_commands" => ["git"] },
+            "Roast::Tools::Grep" => {},
+          },
+          tool_configs,
+        )
+      end
+
+      def test_extract_tools_with_nil_config_in_hash
+        config = {
+          "tools" => [
+            { "Roast::Tools::Cmd" => nil },
+          ],
+        }
+        tools, tool_configs = ConfigurationLoader.extract_tools(config)
+
+        assert_equal(["Roast::Tools::Cmd"], tools)
+        assert_equal({ "Roast::Tools::Cmd" => {} }, tool_configs)
       end
 
       def test_extract_functions

--- a/test/roast/workflow/configuration_test.rb
+++ b/test/roast/workflow/configuration_test.rb
@@ -5,6 +5,7 @@ require "roast/workflow/configuration"
 require "yaml"
 require "open3"
 require "fileutils"
+require "tempfile"
 
 module Roast
   module Workflow
@@ -123,6 +124,150 @@ module Roast
         def test_returns_empty_hash_for_non_existing_function
           configuration = Roast::Workflow::Configuration.new(@workflow_path, @options)
           assert_equal({}, configuration.function_config("nonexistent"))
+        end
+      end
+
+      class ToolConfigTest < ActiveSupport::TestCase
+        FIXTURES = File.expand_path("../../../test/fixtures/files", __dir__)
+
+        def fixture_file(filename)
+          File.join(FIXTURES, filename)
+        end
+
+        def setup
+          @options = {}
+          FileUtils.mkdir_p(FIXTURES) unless Dir.exist?(FIXTURES)
+        end
+
+        def teardown
+          # Clean up any temporary files created during tests
+          Dir.glob(File.join(FIXTURES, "*.yml")).each do |file|
+            File.delete(file) if File.basename(file).start_with?("mixed_tools_config") ||
+              File.basename(file).start_with?("string_tools_only") ||
+              File.basename(file).start_with?("hash_tools_only") ||
+              File.basename(file).start_with?("empty_tools")
+          end
+        end
+
+        def test_parses_mixed_tool_formats_with_string_and_hash_configurations
+          temp_file = Tempfile.new(["mixed_tools_config", ".yml"], FIXTURES)
+          config_hash = {
+            "name" => "Mixed Tools Test",
+            "tools" => [
+              "Roast::Tools::Grep",
+              { "Roast::Tools::Cmd" => { "allowed_commands" => ["sed", "gh", "ruby"] } },
+              "Roast::Tools::ReadFile",
+              "Roast::Tools::SearchFile",
+            ],
+            "steps" => ["step1"],
+          }
+          temp_file.write(config_hash.to_yaml)
+          temp_file.close
+
+          begin
+            config = Configuration.new(temp_file.path)
+
+            # Check that all tools are parsed correctly
+            assert_equal(
+              [
+                "Roast::Tools::Grep",
+                "Roast::Tools::Cmd",
+                "Roast::Tools::ReadFile",
+                "Roast::Tools::SearchFile",
+              ],
+              config.tools,
+            )
+
+            # Check that tool configurations are stored correctly
+            assert_equal({}, config.tool_config("Roast::Tools::Grep"))
+            assert_equal({ "allowed_commands" => ["sed", "gh", "ruby"] }, config.tool_config("Roast::Tools::Cmd"))
+            assert_equal({}, config.tool_config("Roast::Tools::ReadFile"))
+            assert_equal({}, config.tool_config("Roast::Tools::SearchFile"))
+
+            # Check that non-existent tool returns empty hash
+            assert_equal({}, config.tool_config("NonExistent::Tool"))
+          ensure
+            temp_file.unlink
+          end
+        end
+
+        def test_handles_tools_with_only_string_format_backward_compatibility
+          temp_file = Tempfile.new(["string_tools_only", ".yml"], FIXTURES)
+          config_hash = {
+            "name" => "String Tools Test",
+            "tools" => [
+              "Roast::Tools::Grep",
+              "Roast::Tools::ReadFile",
+            ],
+            "steps" => ["step1"],
+          }
+          temp_file.write(config_hash.to_yaml)
+          temp_file.close
+
+          begin
+            config = Configuration.new(temp_file.path)
+
+            # Check that tools are parsed correctly
+            assert_equal(2, config.tools.length)
+            assert_includes(config.tools, "Roast::Tools::Grep")
+            assert_includes(config.tools, "Roast::Tools::ReadFile")
+
+            # Check that no tool configurations are stored (all should be empty hashes)
+            assert_equal({}, config.tool_config("Roast::Tools::Grep"))
+            assert_equal({}, config.tool_config("Roast::Tools::ReadFile"))
+          ensure
+            temp_file.unlink
+          end
+        end
+
+        def test_handles_tools_with_only_hash_format
+          temp_file = Tempfile.new(["hash_tools_only", ".yml"], FIXTURES)
+          config_hash = {
+            "name" => "Hash Tools Test",
+            "tools" => [
+              { "Roast::Tools::Cmd" => { "allowed_commands" => ["git", "npm"] } },
+              { "Roast::Tools::Grep" => nil }, # Shows hash format works even without config
+            ],
+            "steps" => ["step1"],
+          }
+          temp_file.write(config_hash.to_yaml)
+          temp_file.close
+
+          begin
+            config = Configuration.new(temp_file.path)
+
+            # Check that tools are parsed correctly
+            assert_equal(2, config.tools.length)
+            assert_includes(config.tools, "Roast::Tools::Cmd")
+            assert_includes(config.tools, "Roast::Tools::Grep")
+
+            # Check that tool configurations are stored correctly
+            assert_equal({ "allowed_commands" => ["git", "npm"] }, config.tool_config("Roast::Tools::Cmd"))
+            assert_equal({}, config.tool_config("Roast::Tools::Grep")) # Empty since Grep doesn't support config
+          ensure
+            temp_file.unlink
+          end
+        end
+
+        def test_handles_empty_tools_configuration
+          temp_file = Tempfile.new(["empty_tools", ".yml"], FIXTURES)
+          config_hash = {
+            "name" => "Empty Tools Test",
+            "steps" => ["step1"],
+          }
+          temp_file.write(config_hash.to_yaml)
+          temp_file.close
+
+          begin
+            config = Configuration.new(temp_file.path)
+
+            # Check that empty tools are handled correctly
+            assert_empty(config.tools)
+            assert_empty(config.tool_configs)
+            assert_equal({}, config.tool_config("Any::Tool"))
+          ensure
+            temp_file.unlink
+          end
         end
       end
 


### PR DESCRIPTION
## Add Tool Configuration Support

Enables configuring tools with specific settings in Roast workflow YAML files.

### Key Changes
- Tools can now be configured using hash format: `Roast::Tools::Cmd: { allowed_commands: ["git", "npm"] }`
- `Roast::Tools::Cmd` now supports `allowed_commands` to restrict executable commands
- Mixed string/hash format supported in same workflow
- Default allowed commands: `pwd`, `find`, `ls`, `rake`, `ruby`, `dev`, `mkdir`

### Example
```yaml
tools:
  - Roast::Tools::ReadFile
  - Roast::Tools::Cmd:
      allowed_commands:
        - git
        - npm
        - yarn
```

### Added
- Tool configuration parsing in workflow loader
- Command validation in Cmd tool
- Complete example in `examples/tool_config_example/`
- Comprehensive test coverage