### PR TITLE
Downgrade activesupport dependency to 7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     roast-ai (0.2.1)
-      activesupport (~> 8.0)
+      activesupport (~> 7.0)
       cli-ui
       diff-lcs (~> 1.5)
       faraday-retry
@@ -13,7 +13,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.0.2)
+    activesupport (7.2.2.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -25,7 +25,6 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)

--- a/roast.gemspec
+++ b/roast.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("activesupport", "~> 8.0")
+  spec.add_dependency("activesupport", "~> 7.0")
   spec.add_dependency("cli-ui")
   spec.add_dependency("diff-lcs", "~> 1.5")
   spec.add_dependency("faraday-retry")


### PR DESCRIPTION
We hit a snag with our projects that use cocoapods where that project has a requirement that activesupport be less than version 8, seen here:

https://rubygems.org/gems/cocoapods-core

So this PR just downgrades activesupport to play nice.