### PR TITLE
Add activesupport to testing matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,10 @@ jobs:
       matrix:
         os: [ubuntu]
         ruby: ['3.2', '3.3', '3.4']
+        gemfile: ['activesupport7', 'activesupport8']
     runs-on: ${{ matrix.os }}-latest
-    continue-on-error: ${{ matrix.ruby == 'ruby-head' }}
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ bin/ruby-parse
 bin/ruby-rewrite
 bin/thor
 bin/_guard-core
+
+gemfiles/*.lock

--- a/gemfiles/activesupport7.gemfile
+++ b/gemfiles/activesupport7.gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+eval_gemfile "../Gemfile"
+gem "activesupport", "~> 7.0"

--- a/gemfiles/activesupport8.gemfile
+++ b/gemfiles/activesupport8.gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+eval_gemfile "../Gemfile"
+gem "activesupport", "~> 8.0"

--- a/roast.gemspec
+++ b/roast.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("activesupport", "~> 7.0")
+  spec.add_dependency("activesupport", ">= 7.0")
   spec.add_dependency("cli-ui")
   spec.add_dependency("diff-lcs", "~> 1.5")
   spec.add_dependency("faraday-retry")


### PR DESCRIPTION
I made a mistake on #95 where I locked the project to 7.x of active support instead of allowing versions of at least 7 or greater. Luckily @ericproulx noticed and so this PR fixes that and then also adds active support 7 and 8 to the test matrix so that we can't make this mistake again. That's possibly too far - what do you think?

The way I did this is actually inspired by how @ericproulx did it over on Grape here: https://github.com/ruby-grape/grape/pull/2431. I was about to look into setting up Appraisals and then noticed I could just use this `eval_gemfile` method and keep things simple.