### PR TITLE
Automatically find project workflows by name on execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ roast execute workflow.yml target_file.rb
 
 # Or for a targetless workflow (API calls, data generation, etc.)
 roast execute workflow.yml
+
+# Roast will automatically search in `project_root/roast/workflow_name` if the path is incomplete.
+roast execute my_cool_workflow # Equivalent to `roast execute roast/my_cool_workflow/workflow.yml
 ```
 
 ### Understanding Workflows

--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -28,7 +28,13 @@ module Roast
       raise Thor::Error, "Workflow configuration file is required" if paths.empty?
 
       workflow_path, *files = paths
-      expanded_workflow_path = File.expand_path(workflow_path)
+
+      expanded_workflow_path = if workflow_path.include?("workflow.yml")
+        File.expand_path(workflow_path)
+      else
+        File.expand_path("roast/#{workflow_path}/workflow.yml")
+      end
+
       raise Thor::Error, "Expected a Roast workflow configuration file, got directory: #{expanded_workflow_path}" if File.directory?(expanded_workflow_path)
 
       Roast::Workflow::ConfigurationParser.new(expanded_workflow_path, files, options.transform_keys(&:to_sym)).begin!

--- a/test/roast/cli_test.rb
+++ b/test/roast/cli_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "mocha/minitest"
+require "roast"
+
+class RoastCLITest < ActiveSupport::TestCase
+  def test_execute_with_workflow_yml_path
+    workflow_path = "path/to/workflow.yml"
+    expanded_path = File.expand_path(workflow_path)
+
+    # Mock the ConfigurationParser to prevent actual execution
+    mock_parser = mock("ConfigurationParser")
+    mock_parser.expects(:begin!).once
+    Roast::Workflow::ConfigurationParser.expects(:new).with(expanded_path, [], {}).returns(mock_parser)
+
+    # Make sure File.directory? returns false to avoid the directory error
+    File.expects(:directory?).with(expanded_path).returns(false)
+
+    # Execute the CLI command
+    cli = Roast::CLI.new
+    cli.execute(workflow_path)
+  end
+
+  def test_execute_with_conventional_path
+    workflow_name = "my_workflow"
+    conventional_path = "roast/#{workflow_name}/workflow.yml"
+    expanded_path = File.expand_path(conventional_path)
+
+    # Mock the ConfigurationParser to prevent actual execution
+    mock_parser = mock("ConfigurationParser")
+    mock_parser.expects(:begin!).once
+    Roast::Workflow::ConfigurationParser.expects(:new).with(expanded_path, [], {}).returns(mock_parser)
+
+    # Make sure File.directory? returns false to avoid the directory error
+    File.expects(:directory?).with(expanded_path).returns(false)
+
+    # Execute the CLI command
+    cli = Roast::CLI.new
+    cli.execute(workflow_name)
+  end
+
+  def test_execute_with_directory_path_raises_error
+    workflow_path = "path/to/directory"
+    expanded_path = File.expand_path("roast/#{workflow_path}/workflow.yml")
+
+    # Make the directory check return true to trigger the error
+    File.expects(:directory?).with(expanded_path).returns(true)
+
+    # Execute the CLI command and expect an error
+    cli = Roast::CLI.new
+    assert_raises(Thor::Error) do
+      cli.execute(workflow_path)
+    end
+  end
+
+  def test_execute_with_files_passes_files_to_parser
+    workflow_path = "path/to/workflow.yml"
+    expanded_path = File.expand_path(workflow_path)
+    files = ["file1.rb", "file2.rb"]
+
+    # Mock the ConfigurationParser to prevent actual execution
+    mock_parser = mock("ConfigurationParser")
+    mock_parser.expects(:begin!).once
+    Roast::Workflow::ConfigurationParser.expects(:new).with(expanded_path, files, {}).returns(mock_parser)
+
+    # Make sure File.directory? returns false to avoid the directory error
+    File.expects(:directory?).with(expanded_path).returns(false)
+
+    # Execute the CLI command
+    cli = Roast::CLI.new
+    cli.execute(workflow_path, *files)
+  end
+
+  def test_execute_with_options_passes_options_to_parser
+    workflow_path = "path/to/workflow.yml"
+    expanded_path = File.expand_path(workflow_path)
+    options = { "verbose" => true, "concise" => false }
+
+    # Mock the ConfigurationParser to prevent actual execution
+    mock_parser = mock("ConfigurationParser")
+    mock_parser.expects(:begin!).once
+    Roast::Workflow::ConfigurationParser.expects(:new).with(expanded_path, [], options.transform_keys(&:to_sym)).returns(mock_parser)
+
+    # Make sure File.directory? returns false to avoid the directory error
+    File.expects(:directory?).with(expanded_path).returns(false)
+
+    # Create CLI with options
+    cli = Roast::CLI.new([], options)
+    cli.execute(workflow_path)
+  end
+end


### PR DESCRIPTION
Add auto-discovery feature for workflow paths that makes it easier to run workflows by name. If a path doesn't contain "workflow.yml", Roast will automatically look in `roast/{workflow_name}/workflow.yml`. 

This simplifies command-line usage, allowing for shorter commands like `roast execute my_workflow` instead of `roast execute roast/my_workflow/workflow.yml`.