### PR TITLE
Fix model inheritance for nested steps in iteration steps

### DIFF
--- a/lib/roast/workflow/base_iteration_step.rb
+++ b/lib/roast/workflow/base_iteration_step.rb
@@ -12,11 +12,12 @@ module Roast
 
       DEFAULT_MAX_ITERATIONS = 100
 
-      attr_reader :steps
+      attr_reader :steps, :config_hash
 
-      def initialize(workflow, steps:, **kwargs)
+      def initialize(workflow, steps:, config_hash: {}, **kwargs)
         super(workflow, **kwargs)
         @steps = steps
+        @config_hash = config_hash
         # Don't initialize cmd_tool here - we'll do it lazily when needed
       end
 
@@ -65,7 +66,7 @@ module Roast
 
       # Execute nested steps
       def execute_nested_steps(steps, context, executor = nil)
-        executor ||= WorkflowExecutor.new(context, {}, context_path)
+        executor ||= WorkflowExecutor.new(context, config_hash, context_path)
         results = []
 
         steps.each do |step|
@@ -139,7 +140,7 @@ module Roast
       # Execute a step by name and return its result
       def execute_step_by_name(step_name, context)
         # Reuse existing step execution logic
-        executor = WorkflowExecutor.new(context, {}, context_path)
+        executor = WorkflowExecutor.new(context, config_hash, context_path)
         executor.execute_step(step_name)
       end
 

--- a/lib/roast/workflow/base_step.rb
+++ b/lib/roast/workflow/base_step.rb
@@ -16,6 +16,7 @@ module Roast
       def_delegator :workflow, :chat_completion
       def_delegator :workflow, :transcript
 
+      # TODO: is this really the model we want to default to, and is this the right place to set it?
       def initialize(workflow, model: "anthropic:claude-opus-4", name: nil, context_path: nil, auto_loop: true)
         @workflow = workflow
         @model = model

--- a/lib/roast/workflow/iteration_executor.rb
+++ b/lib/roast/workflow/iteration_executor.rb
@@ -4,10 +4,11 @@ module Roast
   module Workflow
     # Handles execution of iteration steps (repeat and each)
     class IterationExecutor
-      def initialize(workflow, context_path, state_manager)
+      def initialize(workflow, context_path, state_manager, config_hash = {})
         @workflow = workflow
         @context_path = context_path
         @state_manager = state_manager
+        @config_hash = config_hash
       end
 
       def execute_repeat(repeat_config)
@@ -31,6 +32,7 @@ module Roast
           max_iterations: max_iterations,
           name: "repeat_#{@workflow.output.size}",
           context_path: @context_path,
+          config_hash: @config_hash,
         )
 
         # Apply configuration if provided
@@ -70,6 +72,7 @@ module Roast
           steps: steps,
           name: "each_#{variable_name}",
           context_path: @context_path,
+          config_hash: @config_hash,
         )
 
         # Apply configuration if provided

--- a/lib/roast/workflow/workflow_executor.rb
+++ b/lib/roast/workflow/workflow_executor.rb
@@ -85,7 +85,7 @@ module Roast
         @command_executor = command_executor || CommandExecutor.new(logger: @error_handler)
         @interpolator = interpolator || Interpolator.new(workflow, logger: @error_handler)
         @state_manager = state_manager || StateManager.new(workflow, logger: @error_handler)
-        @iteration_executor = iteration_executor || IterationExecutor.new(workflow, context_path, @state_manager)
+        @iteration_executor = iteration_executor || IterationExecutor.new(workflow, context_path, @state_manager, config_hash)
         @conditional_executor = conditional_executor || ConditionalExecutor.new(workflow, context_path, @state_manager, self)
         @step_orchestrator = step_orchestrator || StepOrchestrator.new(workflow, @step_loader, @state_manager, @error_handler, self)
 

--- a/test/roast/workflow/iteration_config_hash_test.rb
+++ b/test/roast/workflow/iteration_config_hash_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "roast/workflow/iteration_executor"
+require "roast/workflow/base_iteration_step"
+require "mocha/minitest"
+
+module Roast
+  module Workflow
+    class IterationConfigHashTest < ActiveSupport::TestCase
+      def setup
+        @workflow = mock("workflow")
+        @workflow.stubs(:output).returns({})
+        @state_manager = mock("state_manager")
+        @state_manager.stubs(:save_state)
+
+        @config_hash = {
+          "model" => "gpt-4o",
+          "nested_step" => {
+            "model" => "gpt-3.5-turbo",
+          },
+        }
+      end
+
+      test "IterationExecutor passes config_hash to RepeatStep" do
+        executor = IterationExecutor.new(@workflow, "/test/path", @state_manager, @config_hash)
+
+        repeat_config = {
+          "until" => "true",
+          "steps" => ["nested_step"],
+          "model" => "claude-3-opus-20240229",
+        }
+
+        # Mock RepeatStep to verify it receives config_hash
+        repeat_step_mock = mock("repeat_step")
+        repeat_step_mock.stubs(:model=)
+        repeat_step_mock.expects(:call).returns("result")
+
+        RepeatStep.expects(:new).with do |workflow, params|
+          workflow == @workflow &&
+            params[:config_hash] == @config_hash &&
+            params[:steps] == ["nested_step"]
+        end.returns(repeat_step_mock)
+
+        executor.execute_repeat(repeat_config)
+      end
+
+      test "IterationExecutor passes config_hash to EachStep" do
+        executor = IterationExecutor.new(@workflow, "/test/path", @state_manager, @config_hash)
+
+        each_config = {
+          "each" => "[1, 2]",
+          "as" => "item",
+          "steps" => ["process_item"],
+          "model" => "claude-3-haiku-20240307",
+        }
+
+        # Mock EachStep to verify it receives config_hash
+        each_step_mock = mock("each_step")
+        each_step_mock.stubs(:model=)
+        each_step_mock.expects(:call).returns("result")
+
+        EachStep.expects(:new).with do |workflow, params|
+          workflow == @workflow &&
+            params[:config_hash] == @config_hash &&
+            params[:steps] == ["process_item"]
+        end.returns(each_step_mock)
+
+        executor.execute_each(each_config)
+      end
+
+      test "BaseIterationStep creates WorkflowExecutor with config_hash" do
+        # Create a test subclass to access protected methods
+        test_step = Class.new(BaseIterationStep) do
+          def test_execute_nested_steps(steps, context)
+            execute_nested_steps(steps, context)
+          end
+
+          def test_execute_step_by_name(step_name, context)
+            execute_step_by_name(step_name, context)
+          end
+        end.new(
+          @workflow,
+          steps: ["step1"],
+          config_hash: @config_hash,
+          context_path: "/test/path",
+          name: "test_iteration",
+        )
+
+        # Mock WorkflowExecutor to verify it receives config_hash
+        executor_mock = mock("executor")
+        executor_mock.stubs(:execute_step).returns("result")
+        executor_mock.stubs(:execute_steps).returns(["result"])
+
+        WorkflowExecutor.expects(:new).with(@workflow, @config_hash, "/test/path").returns(executor_mock)
+
+        test_step.test_execute_nested_steps(["step1"], @workflow)
+      end
+
+      test "BaseIterationStep execute_step_by_name creates WorkflowExecutor with config_hash" do
+        test_step = Class.new(BaseIterationStep) do
+          def test_execute_step_by_name(step_name, context)
+            execute_step_by_name(step_name, context)
+          end
+        end.new(
+          @workflow,
+          steps: ["step1"],
+          config_hash: @config_hash,
+          context_path: "/test/path",
+          name: "test_iteration",
+        )
+
+        # Mock WorkflowExecutor to verify it receives config_hash
+        WorkflowExecutor.expects(:new).with(@workflow, @config_hash, "/test/path").returns(
+          mock("executor", execute_step: "result"),
+        )
+
+        test_step.test_execute_step_by_name("test_step", @workflow)
+      end
+    end
+  end
+end

--- a/test/roast/workflow/iteration_executor_test.rb
+++ b/test/roast/workflow/iteration_executor_test.rb
@@ -10,7 +10,7 @@ class RoastWorkflowIterationExecutorTest < ActiveSupport::TestCase
     @workflow.stubs(:output).returns({})
     @context_path = "/test/path"
     @state_manager = mock("state_manager")
-    @executor = Roast::Workflow::IterationExecutor.new(@workflow, @context_path, @state_manager)
+    @executor = Roast::Workflow::IterationExecutor.new(@workflow, @context_path, @state_manager, {})
   end
 
   def test_execute_repeat_with_valid_config
@@ -30,6 +30,7 @@ class RoastWorkflowIterationExecutorTest < ActiveSupport::TestCase
       max_iterations: 10,
       name: "repeat_0",
       context_path: @context_path,
+      config_hash: {},
     ).returns(repeat_step)
 
     @state_manager.expects(:save_state).with("repeat_counter___5", ["result1", "result2"])
@@ -77,6 +78,7 @@ class RoastWorkflowIterationExecutorTest < ActiveSupport::TestCase
       steps: ["process_item"],
       name: "each_item",
       context_path: @context_path,
+      config_hash: {},
     ).returns(each_step)
 
     @state_manager.expects(:save_state).with("each_item", [{ item: 1, result: "processed1" }, { item: 2, result: "processed2" }])

--- a/test/roast/workflow/iteration_step_configuration_test.rb
+++ b/test/roast/workflow/iteration_step_configuration_test.rb
@@ -15,7 +15,7 @@ module Roast
         @context_path = "/tmp/test"
         @state_manager = mock("state_manager")
         @state_manager.stubs(:save_state)
-        @executor = IterationExecutor.new(@workflow, @context_path, @state_manager)
+        @executor = IterationExecutor.new(@workflow, @context_path, @state_manager, {})
       end
 
       test "repeat step accepts configuration for model" do
@@ -46,6 +46,7 @@ module Roast
           max_iterations: 100,
           name: "repeat_0",
           context_path: @context_path,
+          config_hash: {},
         ).returns(mock_step)
 
         @executor.execute_repeat(repeat_config)
@@ -75,6 +76,7 @@ module Roast
           steps: ["process item"],
           name: "each_item",
           context_path: @context_path,
+          config_hash: {},
         ).returns(mock_step)
 
         @executor.execute_each(each_config)


### PR DESCRIPTION
## Summary

This PR fixes an issue where nested steps within iteration steps (repeat/each) were not respecting model configuration from the workflow or step level. They would always fall back to the default model.

## Problem

When `BaseIterationStep` executed nested steps, it created a new `WorkflowExecutor` with an empty config_hash:
```ruby
executor ||= WorkflowExecutor.new(context, {}, context_path)
```

This meant the `StepLoader` couldn't access model configuration, causing it to fall back to the default model.

## Solution

1. Updated `IterationExecutor` to accept and pass along the config_hash
2. Modified `BaseIterationStep` to store and use the config_hash when creating WorkflowExecutors
3. Updated `WorkflowExecutor` to pass config_hash to IterationExecutor

## Testing

Added comprehensive unit tests in `iteration_config_hash_test.rb` to verify that:
- IterationExecutor passes config_hash to RepeatStep and EachStep
- BaseIterationStep creates WorkflowExecutor with the proper config_hash
- All existing tests continue to pass

## Example

With this fix, the following workflow will now work correctly:
```yaml
name: example_workflow
model: gpt-4o  # Workflow-level model

steps:
  - repeat:
      model: claude-3-opus  # Iteration-level model
      until: "done"
      steps:
        - analyze: "This step will now use claude-3-opus instead of the default"
```

Fixes the issue reported by @obie where nested steps always used the default model.