### PR TITLE
Allow per-step path to be specified in the workflow configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ steps:
 analyze_coverage:
   model: gpt-4-turbo
   json: true
+
+# Step-specific config that specifies a custom path, not in the current directory
+generate_report:
+  path: ../reporting/generate_report
 ```
 
 Each step can have its own prompt file (e.g., `analyze_coverage/prompt.md`) and configuration. Steps can be run in parallel by nesting them in arrays:


### PR DESCRIPTION
Updating to accept a code path instead of always looking in the same directory. This will allow us to reuse certain steps/methods/code. 

Similar change in `core` https://github.com/shop/world/pull/65063

Examples:
```
model: gpt-4o-mini
tools:
  - Roast::Tools::ReadFile
steps:
  - read_test_file
read_test_file:
  path: ../relative_path/read_test_file    <---- new code/field added
```

```
model: gpt-4o-mini
tools:
  - Roast::Tools::ReadFile
steps:
  - read_test_file
read_test_file:
  path: /absolute_path/read_test_file    <---- new code/field added
```
