### PR TITLE
Support shared.yml file for reusable YAML anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,43 @@ Roast supports several types of steps:
    ```
    This creates a simple prompt-response interaction without tool calls or looping. It's detected by the presence of spaces in the step name and is useful for summarization or simple questions at the end of a workflow.
 
+#### Shared Configuration
+
+Roast supports sharing common configuration and steps across multiple workflows using a `shared.yml` file.
+
+1. Place a `shared.yml` file one level above your workflow directory
+2. Define YAML anchors for common configurations like tools, models or steps
+3. Reference these anchors in your workflow files using YAML alias syntax
+
+**Example structure:**
+```
+my_project/
+├── shared.yml          # Common configuration anchors
+└── workflows/
+    ├── analyze_code.yml
+    ├── generate_docs.yml
+    └── test_suite.yml
+```
+
+**Example `shared.yml`:**
+```yaml
+# Define common tools
+standard_tools: &standard_tools
+  - Roast::Tools::Grep
+  - Roast::Tools::ReadFile
+  - Roast::Tools::WriteFile
+  - Roast::Tools::SearchFile
+```
+
+**Using in workflows:**
+```yaml
+name: Code Analysis Workflow
+tools: *standard_tools         # Reference shared tools
+
+steps:
+  ...
+```
+
 #### Data Flow Between Steps
 
 Roast handles data flow between steps in three primary ways:

--- a/examples/shared_config/README.md
+++ b/examples/shared_config/README.md
@@ -1,0 +1,52 @@
+# Shared Configuration Example
+
+This example demonstrates how to use `shared.yml` to define common configuration anchors that can be referenced across multiple workflow files.
+
+## Structure
+
+```
+├── shared.yml                      # Common configuration anchors
+└── example_with_shared_config/
+    └── workflow.yml               # Workflow using shared anchors
+```
+
+## How it works
+
+1. When loading a workflow file, Roast checks if `shared.yml` exists one level above the workflow directory
+2. If found, it loads `shared.yml` first, then the workflow file
+3. This allows YAML anchors defined in `shared.yml` to be referenced in workflow files
+
+## Example Usage
+
+In `shared.yml`:
+```yaml
+standard_tools: &standard_tools
+  - Roast::Tools::Grep
+  - Roast::Tools::ReadFile
+  - Roast::Tools::WriteFile
+  - Roast::Tools::SearchFile
+
+mirage: &mirage '$(echo "Oh my god. Its a mirage")'
+```
+
+In your workflow:
+```yaml
+name: Example with shared config
+tools: *standard_tools  # Reference the standard tools from shared.yml
+
+steps:
+  - *mirage  # Reference a shared step definition
+  - sabotage: '$(echo "Im tellin yall, its sabotage")'
+```
+
+## Running the Example
+
+```bash
+# Run the workflow that uses shared configuration
+roast execute examples/shared_config/example_with_shared_config/workflow.yml
+```
+
+The workflow will:
+1. Load the shared configuration from `shared.yml`
+2. Apply the referenced tools and steps
+3. Execute the workflow with the merged configuration

--- a/examples/shared_config/example_with_shared_config/workflow.yml
+++ b/examples/shared_config/example_with_shared_config/workflow.yml
@@ -1,0 +1,6 @@
+name: Example with shared config
+tools: *standard_tools
+
+steps:
+  - *mirage
+  - sabotage: '$(echo "Im tellin yall, its sabotage")'

--- a/examples/shared_config/shared.yml
+++ b/examples/shared_config/shared.yml
@@ -1,0 +1,7 @@
+standard_tools: &standard_tools
+  - Roast::Tools::Grep
+  - Roast::Tools::ReadFile
+  - Roast::Tools::WriteFile
+  - Roast::Tools::SearchFile
+
+mirage: &mirage '$(echo "Oh my god. Its a mirage")'

--- a/lib/roast/workflow/configuration_loader.rb
+++ b/lib/roast/workflow/configuration_loader.rb
@@ -12,7 +12,21 @@ module Roast
         # @return [Hash] The parsed configuration hash
         def load(workflow_path)
           validate_path!(workflow_path)
-          config_hash = YAML.load_file(workflow_path)
+
+          # Load shared.yml if it exists one level above
+          parent_dir = File.dirname(workflow_path)
+          shared_path = File.join(parent_dir, "..", "shared.yml")
+
+          yaml_content = ""
+
+          if File.exist?(shared_path)
+            yaml_content += File.read(shared_path)
+            yaml_content += "\n"
+          end
+
+          yaml_content += File.read(workflow_path)
+          config_hash = YAML.load(yaml_content, aliases: true)
+
           validate_config!(config_hash)
           config_hash
         end

--- a/test/roast/workflow/configuration_loader_test.rb
+++ b/test/roast/workflow/configuration_loader_test.rb
@@ -123,6 +123,76 @@ module Roast
         assert_equal("options.rb", target)
       end
 
+      def test_load_with_shared_yml
+        shared_yaml = <<~YAML
+          standard_tools: &tools
+            - "Roast::Tools::Grep"
+            - "Roast::Tools::ReadFile"
+        YAML
+
+        workflow_yaml = <<~YAML
+          name: "test-workflow"
+          api_token: "test-token"
+          model: "gpt-4"
+          tools: *tools
+          steps: ["step1", "step2"]
+        YAML
+
+        with_temp_workflow_and_shared_yaml(workflow_yaml, shared_yaml) do |workflow_path|
+          config = ConfigurationLoader.load(workflow_path)
+
+          assert_equal("test-workflow", config["name"])
+          assert_equal("test-token", config["api_token"])
+          assert_equal("gpt-4", config["model"])
+          assert_equal(["Roast::Tools::Grep", "Roast::Tools::ReadFile"], config["tools"])
+          assert_equal(["step1", "step2"], config["steps"])
+        end
+      end
+
+      def test_load_without_shared_yml
+        # Ensure it still works when shared.yml doesn't exist
+        workflow_config = {
+          "name" => "test-workflow",
+          "api_token" => "direct-token",
+          "steps" => ["step1", "step2"],
+        }
+
+        with_temp_dir do |dir|
+          subdir = File.join(dir, "workflows")
+          FileUtils.mkdir_p(subdir)
+          workflow_path = File.join(subdir, "workflow.yml")
+          File.write(workflow_path, YAML.dump(workflow_config))
+
+          config = ConfigurationLoader.load(workflow_path)
+
+          assert_equal("test-workflow", config["name"])
+          assert_equal("direct-token", config["api_token"])
+          assert_equal(["step1", "step2"], config["steps"])
+        end
+      end
+
+      def test_yaml_aliases_with_array_references
+        shared_yaml = <<~YAML
+          standard_tools: &tools
+            - Roast::Tools::Grep
+            - Roast::Tools::ReadFile
+            - Roast::Tools::SearchFile
+        YAML
+
+        workflow_yaml = <<~YAML
+          name: test-workflow
+          tools: *tools
+          steps:
+            - step1
+        YAML
+
+        with_temp_workflow_and_shared_yaml(workflow_yaml, shared_yaml) do |workflow_path|
+          config = ConfigurationLoader.load(workflow_path)
+
+          assert_equal(["Roast::Tools::Grep", "Roast::Tools::ReadFile", "Roast::Tools::SearchFile"], config["tools"])
+        end
+      end
+
       private
 
       def with_temp_yaml_file(content)
@@ -139,6 +209,32 @@ module Roast
         path = File.join(dir, filename)
         File.write(path, content)
         yield path
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+
+      def with_temp_dir
+        dir = Dir.mktmpdir
+        yield dir
+      ensure
+        FileUtils.rm_rf(dir)
+      end
+
+      def with_temp_workflow_and_shared_yaml(workflow_yaml, shared_yaml)
+        dir = Dir.mktmpdir
+
+        # Create shared.yml in parent directory
+        File.write(File.join(dir, "shared.yml"), shared_yaml)
+
+        # Create workflow subdirectory
+        workflow_dir = File.join(dir, "workflows")
+        FileUtils.mkdir_p(workflow_dir)
+
+        # Create workflow.yml in subdirectory
+        workflow_path = File.join(workflow_dir, "workflow.yml")
+        File.write(workflow_path, workflow_yaml)
+
+        yield workflow_path
       ensure
         FileUtils.rm_rf(dir)
       end


### PR DESCRIPTION
 ## Summary

  - Add support for `shared.yml` file to define reusable YAML anchors across
  workflows
  - Enables DRY configuration by allowing common settings to be defined once
  and referenced in multiple workflow files

  ## Changes

  ### Implementation
  - Modified `ConfigurationLoader#load` to check for `shared.yml` one level
  above the workflow directory
  - When found, loads `shared.yml` content first, then appends workflow
  content, enabling anchor references
  - Uses `YAML.load` with `aliases: true` to properly handle YAML anchors

  ### Documentation & Examples
  - Added comprehensive example in `examples/shared_config/` demonstrating the
   feature
  - Updated main README with documentation about shared configuration support
  - Includes practical examples of defining common tool lists and reusable
  steps

  ### Testing
  - Added extensive test coverage for the new functionality including:
    - Loading workflows with shared configuration
    - Handling missing shared.yml files gracefully
    - Verifying anchor resolution works correctly

  ## Use Case

  This feature is particularly useful for:
  - Defining standard tool sets used across multiple workflows
  - Creating reusable step definitions
  - Maintaining consistent configuration across a workflow suite
  - Reducing duplication in workflow definitions

  ## Example

  ```yaml
  # shared.yml
  standard_tools: &standard_tools
    - Roast::Tools::Grep
    - Roast::Tools::ReadFile

  # workflow.yml
  tools: *standard_tools  # Reference shared configuration