### PR TITLE
[Bug] Require active_support extensions as first dependency when loading roast

### DIFF
--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support"
 require "fileutils"
 require "cli/ui"
 require "raix"


### PR DESCRIPTION
Solves https://github.com/Shopify/roast/issues/112

Requires `active_support` extensions as the first step while loading `roast` dependencies to solve issues with required `ActiveSupport` modules that could not have been loaded on application that do not load the whole `ActiveSupport`