### PR TITLE
Consolidate ActiveSupport requires in lib/roast.rb

### DIFF
--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 require "active_support"
+require "active_support/cache"
+require "active_support/notifications"
+require "active_support/core_ext/hash/indifferent_access"
+require "active_support/core_ext/string"
+require "active_support/core_ext/string/inflections"
+require "active_support/core_ext/module/delegation"
+require "active_support/isolated_execution_state"
 require "fileutils"
 require "cli/ui"
 require "raix"

--- a/lib/roast/helpers/function_caching_interceptor.rb
+++ b/lib/roast/helpers/function_caching_interceptor.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support"
-require "active_support/isolated_execution_state"
-require "active_support/cache"
-require "active_support/notifications"
 require "roast/helpers/logger"
 
 module Roast

--- a/lib/roast/helpers/prompt_loader.rb
+++ b/lib/roast/helpers/prompt_loader.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/string"
 require "erb"
 
 module Roast

--- a/lib/roast/tools.rb
+++ b/lib/roast/tools.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/cache"
 require "English"
 require "fileutils"
 

--- a/lib/roast/workflow/base_workflow.rb
+++ b/lib/roast/workflow/base_workflow.rb
@@ -2,10 +2,7 @@
 
 require "raix/chat_completion"
 require "raix/function_dispatch"
-require "active_support"
-require "active_support/isolated_execution_state"
-require "active_support/notifications"
-require "active_support/core_ext/hash/indifferent_access"
+
 require "roast/workflow/output_manager"
 require "roast/workflow/context_path_resolver"
 

--- a/lib/roast/workflow/configuration.rb
+++ b/lib/roast/workflow/configuration.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/delegation"
 require "roast/workflow/api_configuration"
 require "roast/workflow/configuration_loader"
 require "roast/workflow/resource_resolver"

--- a/lib/roast/workflow/configuration_parser.rb
+++ b/lib/roast/workflow/configuration_parser.rb
@@ -3,9 +3,6 @@
 require "roast/workflow/configuration"
 require "roast/workflow/workflow_initializer"
 require "roast/workflow/workflow_runner"
-require "active_support"
-require "active_support/isolated_execution_state"
-require "active_support/notifications"
 
 module Roast
   module Workflow

--- a/lib/roast/workflow/error_handler.rb
+++ b/lib/roast/workflow/error_handler.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/notifications"
 require "roast/helpers/logger"
 require "roast/workflow/command_executor"
 

--- a/lib/roast/workflow/output_manager.rb
+++ b/lib/roast/workflow/output_manager.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/hash/indifferent_access"
 require "roast/workflow/dot_access_hash"
 
 module Roast

--- a/lib/roast/workflow/workflow_execution_context.rb
+++ b/lib/roast/workflow/workflow_execution_context.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/string/inflections"
-
 module Roast
   module Workflow
     # Manages execution context across pre-processing, target workflows, and post-processing phases

--- a/lib/roast/workflow/workflow_executor.rb
+++ b/lib/roast/workflow/workflow_executor.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require "English"
-require "active_support"
-require "active_support/isolated_execution_state"
-require "active_support/notifications"
+
 require "roast/workflow/command_executor"
 require "roast/workflow/conditional_executor"
 require "roast/workflow/error_handler"

--- a/lib/roast/workflow/workflow_runner.rb
+++ b/lib/roast/workflow/workflow_runner.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/notifications"
 require "erb"
 require "roast/workflow/replay_handler"
 require "roast/workflow/workflow_executor"

--- a/test/roast/workflow/configuration_parser_test.rb
+++ b/test/roast/workflow/configuration_parser_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 require "mocha/minitest"
 require "roast/workflow/configuration_parser"
-require "active_support/notifications"
 
 class RoastWorkflowConfigurationParserTest < ActiveSupport::TestCase
   def setup

--- a/test/roast/workflow/error_handler_test.rb
+++ b/test/roast/workflow/error_handler_test.rb
@@ -4,7 +4,6 @@ require "test_helper"
 require "roast/workflow/error_handler"
 require "roast/workflow/workflow_executor"
 require "mocha/minitest"
-require "active_support/notifications"
 
 class RoastWorkflowErrorHandlerTest < ActiveSupport::TestCase
   def setup


### PR DESCRIPTION
- Move all ActiveSupport requires to lib/roast.rb for better organization

- Add specific requires for commonly used ActiveSupport modules:

  - active_support/cache

  - active_support/notifications

  - active_support/core_ext/hash/indifferent_access

  - active_support/core_ext/string

  - active_support/core_ext/string/inflections

  - active_support/core_ext/module/delegation

  - active_support/isolated_execution_state

- Remove redundant ActiveSupport requires from individual files

- All tests passing (622 tests, 0 failures)