### PR TITLE
Switch from arm64-darwin-23 to arm64-darwin in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
-  arm64-darwin-23
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
I don't know at what point it was added, but bundler supports arm64-darwin without a version. This avoids needing to update explicitly or have to ignore new versions showing up after an upgrade of macOS.