### PR TITLE
Remove workaround for test order

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,9 +7,6 @@ require "vcr"
 
 require "active_support/test_case"
 
-# not sure why this workaround is needed
-def ActiveSupport.test_order = :random
-
 # Add the lib directory to the load path
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 


### PR DESCRIPTION
I was seeing this warning during tests:

    activesupport-8.0.2/lib/active_support.rb:100: warning: previous definition of test_order was here

I checked the git blame, and don't see any background on why this is needed. I'm not sure if it's a bug in ActiveSupport or a bug in our test suite.

This tries to remove it to see if it's still a problem. Some cursory running of the tests does seem to be random (ie different seeds) at least.