### PR TITLE
Fix warning: method redefined; discarding old chat_completion

### DIFF
--- a/lib/roast/workflow/base_step.rb
+++ b/lib/roast/workflow/base_step.rb
@@ -13,7 +13,6 @@ module Roast
       attr_reader :workflow, :name, :context_path
 
       def_delegator :workflow, :append_to_final_output
-      def_delegator :workflow, :chat_completion
       def_delegator :workflow, :transcript
 
       # TODO: is this really the model we want to default to, and is this the right place to set it?


### PR DESCRIPTION
This comes up when running tests:

    ~/workspace/roast/lib/roast/workflow/base_step.rb:43: warning: method redefined; discarding old chat_completion
    ~/.local/share/mise/installs/ruby/3.4.2/lib/ruby/3.4.0/forwardable.rb:231: warning: previous definition of chat_completion was here

It's being overriden anyways, so it's safe to remove the initial definition via def_delegator.