### PR TITLE
Require mocha/minitest once in test files

### DIFF
--- a/test/roast/cli_test.rb
+++ b/test/roast/cli_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "mocha/minitest"
+
 require "roast"
 
 class RoastCLITest < ActiveSupport::TestCase

--- a/test/roast/resources/api_resource_test.rb
+++ b/test/roast/resources/api_resource_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 require "json"
-require "mocha/minitest"
+
 require "net/http"
 
 class ApiResourceTest < ActiveSupport::TestCase

--- a/test/roast/tools/search_file_test.rb
+++ b/test/roast/tools/search_file_test.rb
@@ -5,7 +5,6 @@ require "roast/tools/search_file"
 require "roast/tools/read_file"
 require "tempfile"
 require "fileutils"
-require "mocha/minitest"
 
 class RoastToolsSearchFileTest < ActiveSupport::TestCase
   def setup

--- a/test/roast/workflow/base_step_test.rb
+++ b/test/roast/workflow/base_step_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 require "roast/workflow/base_step"
 require "roast/workflow/base_workflow"
-require "mocha/minitest"
 
 class RoastWorkflowBaseStepTest < ActiveSupport::TestCase
   # Helper to load fixture files

--- a/test/roast/workflow/base_workflow_test.rb
+++ b/test/roast/workflow/base_workflow_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "roast/workflow/base_workflow"
-require "mocha/minitest"
 
 class RoastWorkflowBaseWorkflowTest < ActiveSupport::TestCase
   FILE_PATH = File.join(Dir.pwd, "test/fixtures/files/test.rb")

--- a/test/roast/workflow/configuration_parser_openrouter_test.rb
+++ b/test/roast/workflow/configuration_parser_openrouter_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "mocha/minitest"
 
 module Roast
   module Workflow

--- a/test/roast/workflow/configuration_parser_test.rb
+++ b/test/roast/workflow/configuration_parser_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "mocha/minitest"
+
 require "roast/workflow/configuration_parser"
 
 class RoastWorkflowConfigurationParserTest < ActiveSupport::TestCase

--- a/test/roast/workflow/error_handler_test.rb
+++ b/test/roast/workflow/error_handler_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 require "roast/workflow/error_handler"
 require "roast/workflow/workflow_executor"
-require "mocha/minitest"
 
 class RoastWorkflowErrorHandlerTest < ActiveSupport::TestCase
   def setup

--- a/test/roast/workflow/iteration_config_hash_test.rb
+++ b/test/roast/workflow/iteration_config_hash_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 require "roast/workflow/iteration_executor"
 require "roast/workflow/base_iteration_step"
-require "mocha/minitest"
 
 module Roast
   module Workflow

--- a/test/roast/workflow/iteration_executor_test.rb
+++ b/test/roast/workflow/iteration_executor_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "roast/workflow/iteration_executor"
-require "mocha/minitest"
 
 class RoastWorkflowIterationExecutorTest < ActiveSupport::TestCase
   def setup

--- a/test/roast/workflow/output_handler_test.rb
+++ b/test/roast/workflow/output_handler_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "roast/workflow/output_handler"
-require "mocha/minitest"
 
 class RoastWorkflowOutputHandlerTest < ActiveSupport::TestCase
   def setup

--- a/test/roast/workflow/parallel_executor_test.rb
+++ b/test/roast/workflow/parallel_executor_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "roast/workflow/parallel_executor"
-require "mocha/minitest"
 
 class RoastWorkflowParallelExecutorTest < ActiveSupport::TestCase
   def setup

--- a/test/roast/workflow/replay_handler_test.rb
+++ b/test/roast/workflow/replay_handler_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "roast/workflow/replay_handler"
-require "mocha/minitest"
 
 class RoastWorkflowReplayHandlerTest < ActiveSupport::TestCase
   def setup

--- a/test/roast/workflow/targetless_workflow_test.rb
+++ b/test/roast/workflow/targetless_workflow_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "mocha/minitest"
+
 require "roast/workflow/configuration_parser"
 require "roast/workflow/base_workflow"
 require "roast/resources/none_resource"

--- a/test/roast/workflow/workflow_initializer_test.rb
+++ b/test/roast/workflow/workflow_initializer_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 require "roast/workflow/workflow_initializer"
 require "roast/workflow/configuration"
-require "mocha/minitest"
 
 class RoastWorkflowInitializerTest < ActiveSupport::TestCase
   def setup

--- a/test/roast/workflow/workflow_runner_test.rb
+++ b/test/roast/workflow/workflow_runner_test.rb
@@ -3,7 +3,6 @@
 require "test_helper"
 require "roast/workflow/workflow_runner"
 require "roast/workflow/configuration"
-require "mocha/minitest"
 
 class RoastWorkflowRunnerTest < ActiveSupport::TestCase
   def setup


### PR DESCRIPTION
## Summary
Remove redundant `require "mocha/minitest"` statements from individual test files.

## Context
Currently, `mocha/minitest` is required in two places:
1. Once in `test/test_helper.rb` (line 4)
2. Again in individual test files

Since all test files already require `test_helper.rb`, the individual require statements are redundant.

## Changes
This PR removes `require "mocha/minitest"` from 16 test files:
- `test/roast/cli_test.rb`
- `test/roast/resources/api_resource_test.rb`
- `test/roast/tools/search_file_test.rb`
- `test/roast/workflow/base_step_test.rb`
- `test/roast/workflow/base_workflow_test.rb`
- `test/roast/workflow/configuration_parser_openrouter_test.rb`
- `test/roast/workflow/configuration_parser_test.rb`
- `test/roast/workflow/error_handler_test.rb`
- `test/roast/workflow/iteration_config_hash_test.rb`
- `test/roast/workflow/iteration_executor_test.rb`
- `test/roast/workflow/output_handler_test.rb`
- `test/roast/workflow/parallel_executor_test.rb`
- `test/roast/workflow/replay_handler_test.rb`
- `test/roast/workflow/targetless_workflow_test.rb`
- `test/roast/workflow/workflow_initializer_test.rb`
- `test/roast/workflow/workflow_runner_test.rb`

## Benefits
- **DRY Principle**: Eliminates duplicate require statements
- **Maintainability**: Central location for test dependencies makes it easier to manage
- **Consistency**: Ensures all tests use the same mocha/minitest setup
- **Cleaner Code**: Reduces boilerplate in test files

## Testing
All existing tests should continue to pass as they were already loading mocha/minitest through test_helper.rb.