### PR TITLE
Update README.md to use the exported env var in the test curl command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ steps:
 
 ## Try it
 
-If you don’t have one already, get an OpenAI key from [here](https://platform.openai.com/settings/organization/api-keys). You will need an account with a credit card, make sure that a basic completion works.
+If you don’t have one already, get an OpenAI key from [here](https://platform.openai.com/settings/organization/api-keys). You will need an account with a credit card and credits applied to the associated project.  Make sure that a basic completion works:
 
 ```bash
 export OPENAI_API_KEY=sk-proj-....
 
 curl -H "Content-Type: application/json" \
-    -H "Authorization: Bearer $API_TOKEN" \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
     -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"What is 1+1?"}]}' \
     https://api.openai.com/v1/chat/completions
 ```


### PR DESCRIPTION
A small PR to update the readme for a misnamed var in the curl command.  I think after https://github.com/Shopify/roast/pull/111 we will probably also want to update the example usage of the first call to roast.