### PR TITLE
Default print_response to true for the last step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-06-05
+
+### Added
+- Default `print_response: true` for the last step in a workflow (#100)
+  - The last step now automatically prints its response unless explicitly configured otherwise
+  - Helps newcomers who would otherwise see no output from their workflows
+  - Works with all step types: string steps, hash steps with variable assignment, and conditional steps
+  - Parallel steps and iteration steps are intelligently handled (no automatic output since there's no single "last" step)
+
+### Fixed
+- PromptStep now properly passes `print_response`, `json`, and `params` parameters to chat_completion
+
 ## [0.3.0] - 2025-06-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -270,6 +270,31 @@ Roast supports several types of steps:
    ```
    This creates a simple prompt-response interaction without tool calls or looping. It's detected by the presence of spaces in the step name and is useful for summarization or simple questions at the end of a workflow.
 
+#### Step Configuration
+
+Steps can be configured with various options to control their behavior:
+
+```yaml
+steps:
+  - analyze_code           # Simple step reference
+  - generate_report:       # Step with configuration
+      model: gpt-4o        # Override the global model for this step
+      print_response: true # Explicitly control output printing
+      json: true           # Request JSON-formatted response
+      params:              # Additional parameters for the API call
+        temperature: 0.8
+```
+
+**Configuration options:**
+- `model`: Override the workflow's default model for this specific step
+- `print_response`: Control whether the step's response is included in the final output (default: `false`, except for the last step which defaults to `true` as of v0.3.1)
+- `json`: Request a JSON-formatted response from the model
+- `params`: Additional parameters passed to the model API (temperature, max_tokens, etc.)
+- `path`: Custom directory path for the step's prompt files
+- `coerce_to`: Type coercion for the step result (`:boolean`, `:llm_boolean`, `:iterable`)
+
+**Automatic Last Step Output**: As of version 0.3.1, the last step in a workflow automatically has `print_response: true` unless explicitly configured otherwise. This ensures that newcomers to Roast see output from their workflows by default.
+
 #### Shared Configuration
 
 Roast supports sharing common configuration and steps across multiple workflows using a `shared.yml` file.

--- a/lib/roast/version.rb
+++ b/lib/roast/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Roast
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/lib/roast/workflow/configuration.rb
+++ b/lib/roast/workflow/configuration.rb
@@ -45,6 +45,8 @@ module Roast
         # Process target and resource
         @target = ConfigurationLoader.extract_target(@config_hash, options)
         process_resource
+
+        mark_last_step_for_output
       end
 
       def context_path
@@ -100,6 +102,60 @@ module Roast
           @resource = ResourceResolver.resolve(@target, context_path)
           # Update target with processed value for backward compatibility
           @target = @resource.value if has_target?
+        end
+      end
+
+      def mark_last_step_for_output
+        return if @steps.empty?
+
+        last_step = find_last_executable_step(@steps.last)
+        return unless last_step
+
+        # Get the step name/key
+        step_key = extract_step_key(last_step)
+        return unless step_key
+
+        # Ensure config exists for this step
+        @config_hash[step_key] ||= {}
+
+        # Only set print_response if not already explicitly configured
+        @config_hash[step_key]["print_response"] = true unless @config_hash[step_key].key?("print_response")
+      end
+
+      def find_last_executable_step(step)
+        case step
+        when String
+          step
+        when Hash
+          # Check if it's a special step type (if, unless, each, repeat, case)
+          if step.key?("if") || step.key?("unless")
+            # For conditional steps, try to find the last step in the "then" branch
+            then_steps = step["then"] || step["steps"]
+            find_last_executable_step(then_steps.last) if then_steps&.any?
+          elsif step.key?("each") || step.key?("repeat")
+            # For iteration steps, we can't reliably determine the last step
+            nil
+          elsif step.key?("case")
+            # For case steps, we can't reliably determine the last step
+            nil
+          elsif step.size == 1
+            # Regular hash step with variable assignment
+            step
+          end
+        when Array
+          # For parallel steps, we can't determine a single "last" step
+          nil
+        else
+          step
+        end
+      end
+
+      def extract_step_key(step)
+        case step
+        when String
+          step
+        when Hash
+          step.keys.first
         end
       end
     end

--- a/lib/roast/workflow/prompt_step.rb
+++ b/lib/roast/workflow/prompt_step.rb
@@ -9,7 +9,7 @@ module Roast
 
       def call
         prompt(name)
-        result = chat_completion
+        result = chat_completion(print_response:, json:, params:)
 
         # Apply coercion if configured
         apply_coercion(result)

--- a/test/roast/workflow/last_step_print_response_test.rb
+++ b/test/roast/workflow/last_step_print_response_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "roast/workflow/configuration"
+require "roast/workflow/workflow_executor"
+require "roast/workflow/base_workflow"
+require "tmpdir"
+
+class RoastWorkflowLastStepPrintResponseTest < ActiveSupport::TestCase
+  def setup
+    @tmpdir = Dir.mktmpdir
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  test "last step has print_response set to true by default" do
+    workflow_content = <<~YAML
+      name: test_workflow
+      steps:
+        - step1
+        - step2
+        - step3
+    YAML
+
+    workflow_path = File.join(@tmpdir, "workflow.yml")
+    File.write(workflow_path, workflow_content)
+
+    config = Roast::Workflow::Configuration.new(workflow_path)
+
+    # First two steps should not have print_response set
+    assert_nil config.config_hash["step1"]
+    assert_nil config.config_hash["step2"]
+
+    # Last step should have print_response = true
+    assert_equal true, config.config_hash["step3"]["print_response"]
+  end
+
+  test "last step respects explicit print_response configuration" do
+    workflow_content = <<~YAML
+      name: test_workflow
+      steps:
+        - step1
+        - step2
+        - step3
+      step3:
+        print_response: false
+    YAML
+
+    workflow_path = File.join(@tmpdir, "workflow.yml")
+    File.write(workflow_path, workflow_content)
+
+    config = Roast::Workflow::Configuration.new(workflow_path)
+
+    # Last step should keep its explicit configuration
+    assert_equal false, config.config_hash["step3"]["print_response"]
+  end
+
+  test "last step with hash format has print_response set to true" do
+    workflow_content = <<~YAML
+      name: test_workflow
+      steps:
+        - step1
+        - result: calculate_total
+    YAML
+
+    workflow_path = File.join(@tmpdir, "workflow.yml")
+    File.write(workflow_path, workflow_content)
+
+    config = Roast::Workflow::Configuration.new(workflow_path)
+
+    # Last step (with variable assignment) should have print_response = true
+    assert_equal true, config.config_hash["result"]["print_response"]
+  end
+
+  test "parallel steps do not have print_response set" do
+    workflow_content = <<~YAML
+      name: test_workflow
+      steps:
+        - step1
+        - [parallel1, parallel2]
+    YAML
+
+    workflow_path = File.join(@tmpdir, "workflow.yml")
+    File.write(workflow_path, workflow_content)
+
+    config = Roast::Workflow::Configuration.new(workflow_path)
+
+    # Parallel steps should not have print_response set
+    assert_nil config.config_hash["parallel1"]
+    assert_nil config.config_hash["parallel2"]
+  end
+
+  test "conditional last step has inner last step with print_response" do
+    workflow_content = <<~YAML
+      name: test_workflow
+      steps:
+        - step1
+        - if: some_condition
+          then:
+            - inner_step1
+            - inner_step2
+    YAML
+
+    workflow_path = File.join(@tmpdir, "workflow.yml")
+    File.write(workflow_path, workflow_content)
+
+    config = Roast::Workflow::Configuration.new(workflow_path)
+
+    # The last step inside the conditional should have print_response = true
+    assert_equal true, config.config_hash["inner_step2"]["print_response"]
+  end
+
+  test "empty workflow does not error" do
+    workflow_content = <<~YAML
+      name: test_workflow
+      steps: []
+    YAML
+
+    workflow_path = File.join(@tmpdir, "workflow.yml")
+    File.write(workflow_path, workflow_content)
+
+    # Should not raise an error
+    assert_nothing_raised do
+      Roast::Workflow::Configuration.new(workflow_path)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR addresses #100 by automatically setting `print_response=true` for the last step in a workflow if not explicitly configured. This helps newcomers to Roast who would otherwise see no output from their workflows.

## Problem

Currently, newcomers to Roast often get stuck because `print_response` defaults to false. When they run a workflow, even if it functions correctly, they sometimes don't get any output, making it appear as if nothing happened.

## Solution

The last step in a workflow now automatically has `print_response` set to `true` unless explicitly configured otherwise. This is implemented at the configuration level, making it transparent and non-intrusive.

## Implementation Details

1. **Configuration Enhancement**: Added `mark_last_step_for_output` method to the `Configuration` class that:
   - Identifies the last executable step in the workflow
   - Sets `print_response=true` in the config hash if not already explicitly set
   - Handles various step types (string, hash, conditional, parallel, etc.)

2. **PromptStep Fix**: Updated `PromptStep#call` to pass instance variables (`print_response`, `json`, `params`) to the `chat_completion` method, ensuring the configuration is properly applied.

3. **Comprehensive Tests**: Added tests covering:
   - Default behavior for last step
   - Respecting explicit configuration
   - Various step formats (string, hash with variable assignment)
   - Edge cases (parallel steps, conditional steps, empty workflows)

## Example

Before this change:
```yaml
name: example_workflow
steps:
  - analyze_data
  - process_results
  - generate_summary  # No output unless print_response: true is added
```

After this change:
```yaml
name: example_workflow
steps:
  - analyze_data
  - process_results
  - generate_summary  # Automatically prints response\!
```

## Test Results

All tests pass:
```
688 runs, 1723 assertions, 0 failures, 0 errors, 3 skips
```

Fixes #100

🤖 Generated with [Claude Code](https://claude.ai/code)