### PR TITLE
Fix JSON parsing in BaseStep when json option is true

### DIFF
--- a/lib/roast/workflow/base_step.rb
+++ b/lib/roast/workflow/base_step.rb
@@ -45,19 +45,10 @@ module Roast
         json = @json if json.nil?
         params = @params if params.nil?
 
-        workflow.chat_completion(openai: workflow.openai? && model, model: model, json:, params:).tap do |result|
-          process_output(result, print_response:)
+        result = workflow.chat_completion(openai: workflow.openai? && model, model: model, json:, params:)
+        process_output(result, print_response:)
 
-          begin
-            if json
-              return nil if result.strip.empty? # Explicitly handle empty string
-
-              return JSON.parse(result)
-            end
-          rescue JSON::ParserError
-            # If JSON parsing fails, leave it as a string
-          end
-        end
+        result
       end
 
       def prompt(text)

--- a/test/roast/workflow/base_step_json_test.rb
+++ b/test/roast/workflow/base_step_json_test.rb
@@ -10,12 +10,12 @@ module Roast
         @workflow.output = {}
       end
 
-      test "JSON array response returns first element when json is true" do
+      test "JSON array response returns parsed array when json is true" do
         step = BaseStep.new(@workflow, name: "test_step")
         step.json = true
 
-        # Raix 1.0 returns JSON as string
-        json_response = '[{"id": 1, "name": "Item 1"}, {"id": 2, "name": "Item 2"}]'
+        # When json: true, chat_completion returns parsed JSON
+        json_response = [{ "id" => 1, "name" => "Item 1" }, { "id" => 2, "name" => "Item 2" }]
 
         # Stub workflow methods
         @workflow.stub(:openai?, false) do
@@ -57,8 +57,8 @@ module Roast
         step = BaseStep.new(@workflow, name: "test_step")
         step.json = true
 
-        # Raix 1.0 returns JSON as string
-        json_response = '[null, {"id": 2, "name": "Item 2"}, {"id": 3, "name": "Item 3"}]'
+        # When json: true, chat_completion returns parsed JSON
+        json_response = [nil, { "id" => 2, "name" => "Item 2" }, { "id" => 3, "name" => "Item 3" }]
 
         @workflow.stub(:openai?, false) do
           @workflow.stub(:chat_completion, json_response) do
@@ -78,8 +78,8 @@ module Roast
         step = BaseStep.new(@workflow, name: "test_step")
         step.json = true
 
-        # Raix 1.0 returns JSON as string
-        json_response = '[[{"id": 1, "name": "Nested Item 1"}, {"id": 2, "name": "Nested Item 2"}], {"id": 3, "name": "Item 3"}]'
+        # When json: true, chat_completion returns parsed JSON
+        json_response = [[{ "id" => 1, "name" => "Nested Item 1" }, { "id" => 2, "name" => "Nested Item 2" }], { "id" => 3, "name" => "Item 3" }]
 
         @workflow.stub(:openai?, false) do
           @workflow.stub(:chat_completion, json_response) do
@@ -100,8 +100,8 @@ module Roast
         step = BaseStep.new(@workflow, name: "test_step")
         step.json = true
 
-        # Raix 1.0 returns JSON as string
-        json_response = '{"status": "success", "data": {"count": 42}, "items": ["a", "b", "c"]}'
+        # When json: true, chat_completion returns parsed JSON
+        json_response = { "status" => "success", "data" => { "count" => 42 }, "items" => ["a", "b", "c"] }
 
         @workflow.stub(:openai?, false) do
           @workflow.stub(:chat_completion, json_response) do

--- a/test/roast/workflow/inline_prompt_configuration_test.rb
+++ b/test/roast/workflow/inline_prompt_configuration_test.rb
@@ -37,7 +37,7 @@ module Roast
           model: "gpt-4o",
           json: true,
           params: { "temperature" => 0.7 },
-        ).returns('{"result": "Test response"}')
+        ).returns({ "result" => "Test response" })
 
         result = @executor.execute_step("analyze the code")
         assert_equal({ "result" => "Test response" }, result)

--- a/test/roast/workflow/prompt_step_print_response_test.rb
+++ b/test/roast/workflow/prompt_step_print_response_test.rb
@@ -20,8 +20,8 @@ module Roast
 
         def chat_completion(**kwargs)
           @chat_completion_calls << kwargs
-          # Raix 1.0 always returns a string
-          response = kwargs[:json] ? '{"result": "json response"}' : "Test response"
+          # When json: true, return parsed JSON; otherwise return string
+          response = kwargs[:json] ? { "result" => "json response" } : "Test response"
           # Simulate adding assistant response to transcript
           @transcript << { assistant: response }
           response


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/Shopify/roast/pull/142 (5302b0b) where JSON responses were being double-parsed, causing errors for steps that use the `json: true` option. The fix removes unnecessary JSON parsing in `BaseStep#chat_completion` since [Raix 1.0 already returns parsed JSON objects when the json option is enabled](https://github.com/OlympiaAI/raix/blob/7d290d6109689eae16cda74795bba20471806596/lib/raix/chat_completion.rb#L242).

### Background

In the Raix 1.0 upgrade , the `BaseStep#chat_completion` method was modified to parse JSON responses. However, this approach incorrectly assumed that `chat_completion` always returns a string. When examining the Raix gem source code (v1.0.0), we can see that the `chat_completion` method already handles JSON parsing when `json: true` is passed. This means that when `json: true` is specified, Raix returns a parsed Ruby Hash/Array, not a JSON string. Attempting to parse it again with `JSON.parse` results in errors.

### Changes Made

1. **Fixed BaseStep#chat_completion** - Removed the redundant JSON parsing logic
2. **Updated test expectations** - Modified all tests to expect parsed JSON objects (Hash/Array) instead of JSON strings when `json: true`:
   - `test/roast/workflow/base_step_json_test.rb` - Updated all JSON response stubs to return parsed objects
   - `test/roast/workflow/prompt_step_print_response_test.rb` - Modified mock workflow to return parsed JSON
   - `test/roast/workflow/inline_prompt_configuration_test.rb` - Updated test expectation for JSON responses

### Impact

This fix ensures that workflows using JSON steps work correctly with Raix 1.0. Without this fix, any step configuration with `json: true` would fail with parsing errors.