### PR TITLE
Add step-level tool filtering feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,52 @@ tools:
 
 Custom descriptions help the LLM understand when and how to use each command, making your workflows more effective.
 
+### Step-Level Tool Filtering
+
+You can restrict which tools are available to specific steps using the `available_tools` configuration:
+
+```yaml
+# Define all tools globally
+tools:
+  - Roast::Tools::Grep
+  - Roast::Tools::ReadFile
+  - Roast::Tools::WriteFile
+  - Roast::Tools::Cmd:
+      allowed_commands:
+        - pwd
+        - ls
+        - echo
+
+# Configure steps with specific tool access
+explore_directory:
+  available_tools:
+    - pwd
+    - ls
+
+analyze_files:
+  available_tools:
+    - grep
+    - read_file
+
+write_summary:
+  available_tools:
+    - write_file
+    - echo
+```
+
+This feature provides:
+- **Security**: Each step only has access to the tools it needs
+- **Performance**: Reduces the tool list sent to the LLM
+- **Clarity**: Makes tool usage explicit for each step
+
+Key points:
+- Use snake_case tool names (e.g., `read_file` for `Roast::Tools::ReadFile`)
+- For `Cmd` tool, use the specific command names (e.g., `pwd`, `ls`)
+- When `available_tools` is not specified, all tools remain available (backward compatible)
+- Empty array (`available_tools: []`) means no tools for that step
+
+See the [available_tools_demo](examples/available_tools_demo/) for a complete example.
+
 #### ReadFile
 
 Reads the contents of a file from the filesystem.

--- a/examples/available_tools_demo/README.md
+++ b/examples/available_tools_demo/README.md
@@ -1,0 +1,42 @@
+# Available Tools Demo
+
+This example demonstrates the `available_tools` feature in Roast, which allows you to restrict which tools are available to specific steps in your workflow.
+
+## Overview
+
+The workflow consists of three steps, each with different tool access:
+
+1. **explore_directory**: Can only use `pwd` and `ls` commands
+2. **analyze_files**: Can only use `grep` and `read_file` tools
+3. **write_summary**: Can only use `write_file` and `echo` tools
+
+## Key Features Demonstrated
+
+### Security Through Least Privilege
+Each step only has access to the tools it needs. For example, the exploration step cannot write files, and the summary step cannot read files or explore directories.
+
+### Tool Name Convention
+- For built-in tools: Use snake_case names (e.g., `read_file` for `Roast::Tools::ReadFile`)
+- For Cmd tool: Use the specific command names (e.g., `pwd`, `ls`)
+
+### Configuration Structure
+```yaml
+step_name:
+  available_tools:
+    - tool1
+    - tool2
+```
+
+## Running the Example
+
+```bash
+roast examples/available_tools_demo/workflow.yml
+```
+
+## What Happens
+
+1. The first step explores the current directory using only `pwd` and `ls`
+2. The second step searches for Ruby files and reads one using only `grep` and `read_file`
+3. The final step creates a summary file using only `write_file` and `echo`
+
+Each step is restricted to its specified tools, demonstrating how you can create secure, focused workflows where each step has exactly the capabilities it needs.

--- a/examples/available_tools_demo/analyze_files/prompt.md
+++ b/examples/available_tools_demo/analyze_files/prompt.md
@@ -1,0 +1,6 @@
+Based on the directory listing from the previous step, your task is to:
+
+1. Search for any Ruby files using grep
+2. Read the contents of the first Ruby file you find
+
+Note: You only have access to the `grep` and `read_file` tools for this step. You cannot use commands like `ls` or `pwd`.

--- a/examples/available_tools_demo/explore_directory/prompt.md
+++ b/examples/available_tools_demo/explore_directory/prompt.md
@@ -1,0 +1,6 @@
+You are exploring a new directory. Your task is to:
+
+1. Show the current working directory
+2. List all files and subdirectories
+
+Note: You only have access to the `pwd` and `ls` commands for this step.

--- a/examples/available_tools_demo/workflow.yml
+++ b/examples/available_tools_demo/workflow.yml
@@ -1,0 +1,32 @@
+model: anthropic:claude-opus-4
+
+tools:
+  - Roast::Tools::Grep
+  - Roast::Tools::ReadFile
+  - Roast::Tools::WriteFile
+  - Roast::Tools::Cmd:
+      allowed_commands:
+        - pwd
+        - ls
+        - echo
+
+steps:
+  - explore_directory
+  - analyze_files
+  - write_summary
+
+# Step-level tool configuration
+explore_directory:
+  available_tools:
+    - pwd
+    - ls
+
+analyze_files:
+  available_tools:
+    - grep
+    - read_file
+
+write_summary:
+  available_tools:
+    - write_file
+    - echo

--- a/examples/available_tools_demo/write_summary/prompt.md
+++ b/examples/available_tools_demo/write_summary/prompt.md
@@ -1,0 +1,6 @@
+Based on your exploration and analysis, create a summary:
+
+1. Write a brief summary of what you found to a file called `summary.txt`
+2. Echo a completion message
+
+Note: You only have access to the `write_file` and `echo` tools for this step. You cannot read files or use other commands.

--- a/lib/roast/workflow/base_step.rb
+++ b/lib/roast/workflow/base_step.rb
@@ -5,7 +5,7 @@ module Roast
     class BaseStep
       extend Forwardable
 
-      attr_accessor :model, :print_response, :json, :params, :resource, :coerce_to
+      attr_accessor :model, :print_response, :json, :params, :resource, :coerce_to, :available_tools
       attr_reader :workflow, :name, :context_path
 
       def_delegator :workflow, :append_to_final_output
@@ -21,12 +21,13 @@ module Roast
         @json = false
         @params = {}
         @coerce_to = nil
+        @available_tools = nil
         @resource = workflow.resource if workflow.respond_to?(:resource)
       end
 
       def call
         prompt(read_sidecar_prompt)
-        result = chat_completion(print_response:, json:, params:)
+        result = chat_completion(print_response:, json:, params:, available_tools:)
 
         # Apply coercion if configured
         apply_coercion(result)
@@ -34,13 +35,14 @@ module Roast
 
       protected
 
-      def chat_completion(print_response: nil, json: nil, params: nil)
+      def chat_completion(print_response: nil, json: nil, params: nil, available_tools: nil)
         # Use instance variables as defaults if parameters are not provided
         print_response = @print_response if print_response.nil?
         json = @json if json.nil?
         params = @params if params.nil?
+        available_tools = @available_tools if available_tools.nil?
 
-        result = workflow.chat_completion(openai: workflow.openai? && model, model: model, json:, params:)
+        result = workflow.chat_completion(openai: workflow.openai? && model, model: model, json:, params:, available_tools:)
         process_output(result, print_response:)
 
         result

--- a/lib/roast/workflow/step_loader.rb
+++ b/lib/roast/workflow/step_loader.rb
@@ -184,6 +184,10 @@ module Roast
         step.json = step_config["json"] if step_config.key?("json")
         step.params = step_config["params"] if step_config.key?("params")
         step.coerce_to = step_config["coerce_to"].to_sym if step_config.key?("coerce_to")
+
+        if step_config.key?("available_tools")
+          step.available_tools = step_config["available_tools"]
+        end
       end
     end
   end

--- a/test/roast/workflow/inline_prompt_configuration_test.rb
+++ b/test/roast/workflow/inline_prompt_configuration_test.rb
@@ -36,6 +36,7 @@ module Roast
           model: "gpt-4o",
           json: true,
           params: { "temperature" => 0.7 },
+          available_tools: nil,
         ).returns({ "result" => "Test response" })
 
         result = @executor.execute_step("analyze the code")
@@ -52,6 +53,7 @@ module Roast
           model: "openai/gpt-4o-mini", # Default model
           json: false,
           params: {},
+          available_tools: nil,
         ).returns("Default response")
 
         result = executor.execute_step("analyze without config")
@@ -70,6 +72,7 @@ module Roast
           model: "claude-3-opus",
           json: false,
           params: {},
+          available_tools: nil,
         ).returns("Claude response")
 
         result = executor.execute_step("use global model")
@@ -90,6 +93,7 @@ module Roast
           model: "step-specific-model", # Step-specific overrides global
           json: false,
           params: {},
+          available_tools: nil,
         ).returns("Specific response")
 
         result = executor.execute_step("specific prompt")

--- a/test/roast/workflow/prompt_step_print_response_test.rb
+++ b/test/roast/workflow/prompt_step_print_response_test.rb
@@ -54,6 +54,7 @@ module Roast
             model: "anthropic:claude-opus-4",
             json: false,
             params: {},
+            available_tools: nil,
           },
           workflow.chat_completion_calls.first,
         )
@@ -90,6 +91,7 @@ module Roast
             model: "anthropic:claude-opus-4",
             json: true,
             params: { temperature: 0.5 },
+            available_tools: nil,
           },
           workflow.chat_completion_calls.first,
         )

--- a/test/roast/workflow/step_executor_registry_test.rb
+++ b/test/roast/workflow/step_executor_registry_test.rb
@@ -120,13 +120,16 @@ module Roast
       end
 
       def test_multiple_matchers_first_match_wins
-        matcher1 = ->(step) { step.is_a?(String) && step.include?("test") }
-        matcher2 = ->(step) { step.is_a?(String) && step.include?("es") }
+        @workflow_executor.stubs(:workflow).returns(mock("workflow"))
+        @workflow_executor.stubs(:config_hash).returns({})
+        
+        matcher1 = ->(step) { step.is_a?(Symbol) && step.to_s.include?("test") }
+        matcher2 = ->(step) { step.is_a?(Symbol) && step.to_s.include?("es") }
 
         StepExecutorRegistry.register_with_matcher(matcher1, TestExecutor)
         StepExecutorRegistry.register_with_matcher(matcher2, AnotherTestExecutor)
 
-        executor = StepExecutorRegistry.for("test", @workflow_executor)
+        executor = StepExecutorRegistry.for(:test, @workflow_executor)
         assert_instance_of(TestExecutor, executor)
       end
 

--- a/test/roast/workflow/step_loader_test.rb
+++ b/test/roast/workflow/step_loader_test.rb
@@ -127,6 +127,37 @@ module Roast
         assert_equal({ "key" => "value" }, step.params)
       end
 
+      def test_applies_available_tools_configuration
+        @config_hash["test"] = {
+          "available_tools" => ["grep", "search_file"],
+        }
+
+        step = @step_loader.load("test")
+
+        assert_equal(["grep", "search_file"], step.available_tools)
+      end
+
+      def test_does_not_set_available_tools_when_not_configured
+        @config_hash["test"] = {
+          "json" => true,
+          "print_response" => true,
+        }
+
+        step = @step_loader.load("test")
+
+        assert_nil(step.available_tools)
+      end
+
+      def test_handles_empty_available_tools_array
+        @config_hash["test"] = {
+          "available_tools" => [],
+        }
+
+        step = @step_loader.load("test")
+
+        assert_equal([], step.available_tools)
+      end
+
       def test_sets_resource_when_supported
         @workflow.resource = Roast::Resources::FileResource.new("test.txt")
 

--- a/test/roast/workflow/workflow_executor_test.rb
+++ b/test/roast/workflow/workflow_executor_test.rb
@@ -58,6 +58,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
       model: "gpt-4o",
       json: false,
       params: {},
+      available_tools: nil,
     ).returns("Test response")
 
     result = @executor.execute_step("this is a plain text prompt")


### PR DESCRIPTION
## Summary

Implements step-level tool filtering feature that allows workflow authors to specify which tools should be available for each individual step in a Roast workflow.

## Implementation

This is a clean reimplementation of the feature originally proposed in PR #106, built fresh from the main branch to avoid merge conflicts and implementation issues.

### Key Changes

- **BaseStep**: Added `available_tools` attribute and passed it through to `chat_completion`
- **StepLoader**: Added support for reading `available_tools` from step configuration
- **Tests**: Added comprehensive test coverage for the new feature
- **Documentation**: Updated README with clear explanation and examples
- **Example**: Created `examples/available_tools_demo/` demonstrating the feature

## Usage

```yaml
# Define all tools globally
tools:
  - Roast::Tools::Grep
  - Roast::Tools::ReadFile
  - Roast::Tools::WriteFile
  - Roast::Tools::Cmd:
      allowed_commands:
        - pwd
        - ls
        - echo

# Configure steps with specific tool access
explore_directory:
  available_tools:
    - pwd
    - ls

analyze_files:
  available_tools:
    - grep
    - read_file

write_summary:
  available_tools:
    - write_file
    - echo
```

## Benefits

1. **Security**: Each step only has access to the tools it needs (principle of least privilege)
2. **Performance**: Reduces the tool list sent to the LLM, potentially improving response times
3. **Clarity**: Makes tool usage explicit and predictable for each step
4. **Flexibility**: Each step can have its own security context based on its needs

## Testing

All tests pass locally. The implementation leverages Raix's existing `available_tools` support, making it a simple and reliable addition.

Fixes #149

🤖 Generated with [Claude Code](https://claude.ai/code)