### PR TITLE
Add agent step type with ^ prefix syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## About the codebase
 - This is a Ruby gem called Roast. Its purpose is to run AI workflows defined in a YAML file.
+- Note that this project now uses Zeitwerk, which means you don't have to manually require project files anymore
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,14 @@ Roast supports several types of steps:
    ```
    This creates a simple prompt-response interaction without tool calls or looping. It's detected by the presence of spaces in the step name and is useful for summarization or simple questions at the end of a workflow.
 
+8. **Agent step**: Direct pass-through to coding agents (e.g., Claude Code)
+   ```yaml
+   steps:
+     - ^fix_linting_errors    # Sends prompt directly to CodingAgent
+     - regular_analysis       # Normal step through LLM
+   ```
+   Agent steps are prefixed with `^` and send the prompt content directly to the CodingAgent tool without LLM translation. This is useful when you want to give precise instructions to a coding agent without the intermediate interpretation layer. The prompt file (`fix_linting_errors/prompt.md`) is passed directly to the agent.
+
 #### Step Configuration
 
 Steps can be configured with various options to control their behavior:

--- a/examples/agent_workflow/README.md
+++ b/examples/agent_workflow/README.md
@@ -1,0 +1,37 @@
+# Agent Workflow Example
+
+This example demonstrates the use of agent steps in Roast workflows.
+
+## What are Agent Steps?
+
+Agent steps are a special type of step that sends prompts directly to the CodingAgent tool (e.g., Claude Code) without going through the normal LLM translation layer. This is useful when you want to give precise instructions to a coding agent.
+
+## How to Use
+
+Agent steps are denoted by prefixing the step name with `^`:
+
+```yaml
+steps:
+  - regular_step      # Normal step - goes through LLM
+  - ^agent_step       # Agent step - direct to CodingAgent
+```
+
+## Workflow Structure
+
+This example workflow has three steps:
+
+1. **analyze_code** - A regular step that analyzes code for issues
+2. **^fix_issues** - An agent step that fixes the identified issues directly
+3. **verify_fixes** - A regular step that verifies the fixes
+
+## Running the Workflow
+
+```bash
+roast execute examples/agent_workflow/workflow.yml your_code.rb
+```
+
+## Benefits of Agent Steps
+
+- **Direct control**: Your prompt goes directly to the coding agent without interpretation
+- **Precision**: Useful for complex coding tasks where exact instructions matter
+- **Efficiency**: Skips the LLM translation layer when not needed

--- a/examples/agent_workflow/analyze_code/prompt.md
+++ b/examples/agent_workflow/analyze_code/prompt.md
@@ -1,0 +1,7 @@
+Please analyze the provided code file and identify any issues related to:
+- Code style violations
+- Potential bugs
+- Performance concerns
+- Security vulnerabilities
+
+Provide a summary of the issues found.

--- a/examples/agent_workflow/fix_issues/prompt.md
+++ b/examples/agent_workflow/fix_issues/prompt.md
@@ -1,0 +1,8 @@
+Based on the analysis, please fix all the identified issues in the code:
+
+1. Fix any style violations
+2. Address potential bugs
+3. Optimize performance issues
+4. Patch security vulnerabilities
+
+Make sure to preserve the original functionality while improving the code quality.

--- a/examples/agent_workflow/verify_fixes/prompt.md
+++ b/examples/agent_workflow/verify_fixes/prompt.md
@@ -1,0 +1,7 @@
+Please verify that all the fixes have been applied correctly:
+
+1. Check that the code still functions as intended
+2. Confirm all identified issues have been addressed
+3. Ensure no new issues were introduced
+
+Provide a brief summary of the verification results.

--- a/examples/agent_workflow/workflow.yml
+++ b/examples/agent_workflow/workflow.yml
@@ -1,0 +1,14 @@
+description: Example workflow demonstrating agent steps
+
+# Agent steps send prompts directly to CodingAgent (e.g., Claude Code)
+# without the intermediate LLM translation layer
+
+steps:
+  # Regular step - goes through LLM first
+  - analyze_code
+  
+  # Agent step - direct to CodingAgent
+  - ^fix_issues
+  
+  # Another regular step
+  - verify_fixes

--- a/lib/roast/workflow/agent_step.rb
+++ b/lib/roast/workflow/agent_step.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Roast
+  module Workflow
+    class AgentStep < BaseStep
+      def initialize(workflow, **kwargs)
+        super(workflow, **kwargs)
+      end
+
+      def call
+        # Load the prompt content
+        prompt_content = read_sidecar_prompt
+
+        # Call CodingAgent directly with the prompt content
+        result = Roast::Tools::CodingAgent.call(prompt_content)
+
+        # Process output if print_response is enabled
+        process_output(result, print_response:)
+
+        # Apply coercion if configured
+        apply_coercion(result)
+      end
+    end
+  end
+end

--- a/lib/roast/workflow/step_executor_coordinator.rb
+++ b/lib/roast/workflow/step_executor_coordinator.rb
@@ -58,6 +58,8 @@ module Roast
         when StepTypeResolver::COMMAND_STEP
           # Command steps should also go through interpolation
           execute_string_step(step, options)
+        when StepTypeResolver::AGENT_STEP
+          execute_agent_step(step, options)
         when StepTypeResolver::GLOB_STEP
           execute_glob_step(step)
         when StepTypeResolver::ITERATION_STEP
@@ -164,6 +166,15 @@ module Roast
             raise
           end
         end
+      end
+
+      def execute_agent_step(step, options = {})
+        # Extract the step name without the ^ prefix
+        step_name = StepTypeResolver.extract_name(step)
+
+        # Load and execute the agent step
+        exit_on_error = options.fetch(:exit_on_error, context.exit_on_error?(step))
+        step_orchestrator.execute_step(step_name, exit_on_error:, step_key: options[:step_key], agent: true)
       end
 
       def execute_glob_step(step)

--- a/lib/roast/workflow/step_orchestrator.rb
+++ b/lib/roast/workflow/step_orchestrator.rb
@@ -22,7 +22,7 @@ module Roast
         @workflow_executor = workflow_executor
       end
 
-      def execute_step(name, exit_on_error: true, step_key: nil)
+      def execute_step(name, exit_on_error: true, step_key: nil, agent: false)
         resource_type = @workflow.respond_to?(:resource) ? @workflow.resource&.type : nil
 
         @error_handler.with_error_handling(name, resource_type: resource_type) do
@@ -30,7 +30,7 @@ module Roast
 
           # Use step_key for loading if provided, otherwise use name
           load_key = step_key || name
-          step_object = @step_loader.load(name, step_key: load_key)
+          step_object = @step_loader.load(name, step_key: load_key, agent: agent)
           step_result = step_object.call
 
           # Store result in workflow output

--- a/lib/roast/workflow/step_type_resolver.rb
+++ b/lib/roast/workflow/step_type_resolver.rb
@@ -14,6 +14,7 @@ module Roast
       PARALLEL_STEP = :parallel
       STRING_STEP = :string
       STANDARD_STEP = :standard
+      AGENT_STEP = :agent
 
       # Special step names for iterations
       ITERATION_STEPS = ["repeat", "each"].freeze
@@ -47,6 +48,13 @@ module Roast
         # @return [Boolean] true if it's a command step
         def command_step?(step)
           step.is_a?(String) && step.start_with?("$(")
+        end
+
+        # Check if a step is an agent step
+        # @param step [String] The step to check
+        # @return [Boolean] true if it's an agent step
+        def agent_step?(step)
+          step.is_a?(String) && step.start_with?("^")
         end
 
         # Check if a step is a glob pattern
@@ -96,7 +104,8 @@ module Roast
         def extract_name(step)
           case step
           when String
-            step
+            # Strip ^ prefix for agent steps
+            agent_step?(step) ? step[1..] : step
           when Hash
             step.keys.first
           when Array
@@ -109,6 +118,8 @@ module Roast
         def resolve_string_step(step, context)
           if command_step?(step)
             COMMAND_STEP
+          elsif agent_step?(step)
+            AGENT_STEP
           elsif glob_step?(step, context)
             GLOB_STEP
           else

--- a/test/fixtures/files/agent_step_workflow.yml
+++ b/test/fixtures/files/agent_step_workflow.yml
@@ -1,0 +1,5 @@
+description: Test workflow for agent steps
+
+steps:
+  - regular_prompt    # Normal prompt through LLM
+  - ^agent_prompt     # Direct to CodingAgent

--- a/test/fixtures/files/agent_step_workflow/agent_prompt/prompt.md
+++ b/test/fixtures/files/agent_step_workflow/agent_prompt/prompt.md
@@ -1,0 +1,1 @@
+Create a file called hello.rb that prints "Hello from CodingAgent!"

--- a/test/fixtures/files/agent_step_workflow/regular_prompt/prompt.md
+++ b/test/fixtures/files/agent_step_workflow/regular_prompt/prompt.md
@@ -1,0 +1,1 @@
+Please write a simple "Hello, World!" Ruby script.

--- a/test/roast/workflow/agent_step_test.rb
+++ b/test/roast/workflow/agent_step_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
+  def setup
+    # Mock the CodingAgent call
+    Roast::Tools::CodingAgent.stubs(:call).returns("Agent response")
+
+    # Mock chat completion for regular prompt
+    @mock_openai_client = mock
+    @mock_openai_client.stubs(:chat).returns({
+      "choices" => [{ "message" => { "content" => "Regular LLM response" } }],
+    })
+    OpenAI::Client.stubs(:new).returns(@mock_openai_client)
+
+    # Store original env
+    @original_openai_key = ENV["OPENAI_API_KEY"]
+    ENV["OPENAI_API_KEY"] = "test-key"
+  end
+
+  def teardown
+    Roast::Tools::CodingAgent.unstub(:call)
+    OpenAI::Client.unstub(:new)
+    ENV["OPENAI_API_KEY"] = @original_openai_key
+  end
+
+  test "agent step type is recognized correctly" do
+    assert Roast::Workflow::StepTypeResolver.agent_step?("^my_prompt")
+    refute Roast::Workflow::StepTypeResolver.agent_step?("my_prompt")
+    refute Roast::Workflow::StepTypeResolver.agent_step?("$(command)")
+  end
+
+  test "extract_name strips ^ prefix for agent steps" do
+    assert_equal "my_prompt", Roast::Workflow::StepTypeResolver.extract_name("^my_prompt")
+    assert_equal "regular_prompt", Roast::Workflow::StepTypeResolver.extract_name("regular_prompt")
+  end
+
+  test "resolve returns AGENT_STEP for ^ prefixed steps" do
+    step_type = Roast::Workflow::StepTypeResolver.resolve("^my_prompt")
+    assert_equal Roast::Workflow::StepTypeResolver::AGENT_STEP, step_type
+  end
+
+  test "agent step loads AgentStep class when agent flag is true" do
+    # Create a mock workflow
+    workflow = mock
+    workflow.stubs(:resource).returns(nil)
+    workflow.stubs(:output).returns({})
+    workflow.stubs(:transcript).returns([])
+
+    # Create a temporary directory structure for the test
+    Dir.mktmpdir do |tmpdir|
+      # Create prompt directories
+      agent_prompt_dir = File.join(tmpdir, "agent_prompt")
+      regular_prompt_dir = File.join(tmpdir, "regular_prompt")
+      Dir.mkdir(agent_prompt_dir)
+      Dir.mkdir(regular_prompt_dir)
+
+      # Create prompt files
+      File.write(File.join(agent_prompt_dir, "prompt.md"), "Agent prompt content")
+      File.write(File.join(regular_prompt_dir, "prompt.md"), "Regular prompt content")
+
+      # Create step loader
+      step_loader = Roast::Workflow::StepLoader.new(workflow, {}, tmpdir)
+
+      # Load regular prompt step (with directory, it loads BaseStep)
+      regular_step = step_loader.load("regular_prompt", agent: false)
+      assert_instance_of Roast::Workflow::BaseStep, regular_step
+
+      # Load agent step (with directory and agent flag, it loads AgentStep)
+      agent_step = step_loader.load("agent_prompt", agent: true)
+      assert_instance_of Roast::Workflow::AgentStep, agent_step
+    end
+  end
+
+  test "agent step calls CodingAgent directly without LLM translation" do
+    # Create a mock workflow
+    workflow = mock
+    workflow.stubs(:resource).returns(nil)
+    workflow.stubs(:output).returns({})
+    workflow.stubs(:transcript).returns([])
+    workflow.stubs(:append_to_final_output)
+    workflow.stubs(:file).returns(nil)
+
+    # Create agent step
+    agent_step = Roast::Workflow::AgentStep.new(workflow, name: "test_agent")
+
+    # Mock the prompt loader to return our test prompt
+    Roast::Helpers::PromptLoader.stubs(:load_prompt).returns("Test agent prompt")
+
+    # Execute the step
+    result = agent_step.call
+
+    # Verify the result
+    assert_equal "Agent response", result
+
+    # Verify CodingAgent was called - we stubbed it in setup
+    # Since we're using mocha stubs, we can't use received method
+    # The test passes if the call doesn't raise an error
+  end
+
+  test "step executor coordinator handles agent steps" do
+    # Create mock dependencies
+    workflow = mock
+    workflow.stubs(:output).returns({})
+    config_mock = mock
+    config_mock.stubs(:workflow_path).returns("/test/workflow.yml")
+    workflow.stubs(:config).returns(config_mock)
+
+    state_manager = mock
+    state_manager.stubs(:save_state)
+
+    error_handler = mock
+    error_handler.stubs(:with_error_handling).yields
+
+    step_orchestrator = mock
+    step_orchestrator.expects(:execute_step).with("my_prompt", exit_on_error: true, step_key: nil, agent: true).returns("agent result")
+
+    context = Roast::Workflow::WorkflowContext.new(
+      workflow:,
+      config_hash: {},
+      context_path: "/test",
+    )
+
+    dependencies = {
+      workflow_executor: mock,
+      state_manager:,
+      error_handler:,
+      step_orchestrator:,
+    }
+
+    coordinator = Roast::Workflow::StepExecutorCoordinator.new(context:, dependencies:)
+
+    # Execute an agent step
+    result = coordinator.execute("^my_prompt")
+    assert_equal "agent result", result
+  end
+end

--- a/test/roast/workflow/step_orchestrator_test.rb
+++ b/test/roast/workflow/step_orchestrator_test.rb
@@ -31,7 +31,7 @@ module Roast
         @workflow.expects(:output).returns({})
 
         step_object = mock("step_object")
-        @step_loader.expects(:load).with(step_name, step_key: step_name).returns(step_object)
+        @step_loader.expects(:load).with(step_name, step_key: step_name, agent: false).returns(step_object)
         step_object.expects(:call).returns(step_result)
 
         @state_manager.expects(:save_state).with(step_name, step_result)
@@ -50,7 +50,7 @@ module Roast
         @workflow.expects(:output).returns({})
 
         step_object = mock("step_object")
-        @step_loader.expects(:load).with(step_name, step_key: step_name).returns(step_object)
+        @step_loader.expects(:load).with(step_name, step_key: step_name, agent: false).returns(step_object)
         step_object.expects(:call).returns(step_result)
 
         @state_manager.expects(:save_state).with(step_name, step_result)
@@ -70,7 +70,7 @@ module Roast
         @workflow.expects(:output).returns(output_hash)
 
         step_object = mock("step_object")
-        @step_loader.expects(:load).with(step_name, step_key: step_name).returns(step_object)
+        @step_loader.expects(:load).with(step_name, step_key: step_name, agent: false).returns(step_object)
         step_object.expects(:call).returns(step_result)
 
         @state_manager.expects(:save_state).with(step_name, step_result)
@@ -87,7 +87,7 @@ module Roast
         @workflow.expects(:output).returns({})
 
         step_object = mock("step_object")
-        @step_loader.expects(:load).with(step_name, step_key: step_name).returns(step_object)
+        @step_loader.expects(:load).with(step_name, step_key: step_name, agent: false).returns(step_object)
         step_object.expects(:call).returns("result")
 
         @state_manager.expects(:save_state)
@@ -103,7 +103,7 @@ module Roast
         @workflow.expects(:output).returns({})
 
         step_object = mock("step_object")
-        @step_loader.expects(:load).with(step_name, step_key: step_name).returns(step_object)
+        @step_loader.expects(:load).with(step_name, step_key: step_name, agent: false).returns(step_object)
         step_object.expects(:call).returns("result")
 
         @state_manager.expects(:save_state)
@@ -130,7 +130,7 @@ module Roast
         @workflow.expects(:output).returns({})
 
         step_object = mock("step_object")
-        @step_loader.expects(:load).with(step_name, step_key: step_key).returns(step_object)
+        @step_loader.expects(:load).with(step_name, step_key: step_key, agent: false).returns(step_object)
         step_object.expects(:call).returns(step_result)
 
         @state_manager.expects(:save_state).with(step_name, step_result)

--- a/test/roast/workflow/workflow_executor_test.rb
+++ b/test/roast/workflow/workflow_executor_test.rb
@@ -16,7 +16,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
   test "executes string steps" do
     step_obj = mock("step")
     step_obj.expects(:call).returns("result")
-    @executor.step_loader.expects(:load).with("step1", step_key: "step1").returns(step_obj)
+    @executor.step_loader.expects(:load).with("step1", step_key: "step1", agent: false).returns(step_obj)
     @executor.execute_steps(["step1"])
   end
 
@@ -24,7 +24,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
     @workflow.stubs(pause_step_name: "step1")
     step_obj = mock("step")
     step_obj.expects(:call).returns("result")
-    @executor.step_loader.expects(:load).with("step1", step_key: "step1").returns(step_obj)
+    @executor.step_loader.expects(:load).with("step1", step_key: "step1", agent: false).returns(step_obj)
     mock_binding = mock("mock_binding")
     Kernel.stubs(:binding).returns(mock_binding)
     mock_binding.expects(:irb)
@@ -35,7 +35,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
     @workflow.expects(:instance_eval).with("file").returns("test.rb")
     step_obj = mock("step")
     step_obj.expects(:call).returns("result")
-    @executor.step_loader.expects(:load).with("step test.rb", step_key: "step test.rb").returns(step_obj)
+    @executor.step_loader.expects(:load).with("step test.rb", step_key: "step test.rb", agent: false).returns(step_obj)
     @executor.execute_steps(["step {{file}}"])
   end
 
@@ -68,7 +68,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
   test "executes hash steps" do
     step_obj = mock("step")
     step_obj.expects(:call).returns("result")
-    @executor.step_loader.expects(:load).with("command1", step_key: "var1").returns(step_obj)
+    @executor.step_loader.expects(:load).with("command1", step_key: "var1", agent: false).returns(step_obj)
     @executor.execute_steps([{ "var1" => "command1" }])
     assert_equal "result", @output["var1"]
   end
@@ -77,7 +77,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
     @workflow.expects(:instance_eval).with("var_name").returns("test_var")
     step_obj = mock("step")
     step_obj.expects(:call).returns("result")
-    @executor.step_loader.expects(:load).with("command1", step_key: "test_var").returns(step_obj)
+    @executor.step_loader.expects(:load).with("command1", step_key: "test_var", agent: false).returns(step_obj)
     @executor.execute_steps([{ "{{var_name}}" => "command1" }])
     assert_equal "result", @output["test_var"]
   end
@@ -86,7 +86,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
     @workflow.expects(:instance_eval).with("cmd").returns("test_command")
     step_obj = mock("step")
     step_obj.expects(:call).returns("result")
-    @executor.step_loader.expects(:load).with("test_command", step_key: "var1").returns(step_obj)
+    @executor.step_loader.expects(:load).with("test_command", step_key: "var1", agent: false).returns(step_obj)
     @executor.execute_steps([{ "var1" => "{{cmd}}" }])
     assert_equal "result", @output["var1"]
   end
@@ -96,7 +96,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
     @workflow.expects(:instance_eval).with("cmd").returns("test_command")
     step_obj = mock("step")
     step_obj.expects(:call).returns("result")
-    @executor.step_loader.expects(:load).with("test_command", step_key: "test_var").returns(step_obj)
+    @executor.step_loader.expects(:load).with("test_command", step_key: "test_var", agent: false).returns(step_obj)
     @executor.execute_steps([{ "{{var_name}}" => "{{cmd}}" }])
     assert_equal "result", @output["test_var"]
   end
@@ -134,7 +134,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
 
     step_obj = mock("step")
     step_obj.expects(:call).returns("result")
-    @executor.step_loader.expects(:load).with(anything, anything).returns(step_obj)
+    @executor.step_loader.expects(:load).with(anything, anything, anything).returns(step_obj)
 
     @executor.execute_step("test_step")
 
@@ -160,7 +160,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
       events << { name: name, payload: payload }
     end
 
-    @executor.step_loader.expects(:load).with(anything, anything).raises(StandardError.new("test error"))
+    @executor.step_loader.expects(:load).with(anything, anything, anything).raises(StandardError.new("test error"))
 
     assert_raises(Roast::Workflow::WorkflowExecutor::StepExecutionError) do
       @executor.execute_step("failing_step")


### PR DESCRIPTION
## Summary
- Implements #141 - Adds a new step type that sends prompts directly to CodingAgent without LLM translation
- Uses `^` prefix syntax that doesn't require quotes in YAML (much cleaner than `@`\!)
- Allows users to give precise instructions to coding agents when the intermediate interpretation layer would modify the intent

## Implementation Details

### New Step Type
Added a new `AgentStep` class that inherits from `BaseStep` but calls `CodingAgent` directly instead of using `chat_completion`. This bypasses the LLM translation layer entirely.

### Syntax
```yaml
steps:
  - analyze_code    # Normal step through LLM
  - ^fix_issues     # Direct to CodingAgent (no quotes needed\!)
```

### Key Changes
- **New Files:**
  - `lib/roast/workflow/agent_step.rb` - The AgentStep class
  - `test/roast/workflow/agent_step_test.rb` - Comprehensive tests
  - `examples/agent_workflow/` - Example workflow demonstrating usage

- **Modified Files:**
  - `StepTypeResolver` - Added `AGENT_STEP` type and detection for `^` prefix
  - `StepExecutorCoordinator` - Added `execute_agent_step` method
  - `StepLoader` - Added `agent` parameter to load appropriate step class
  - `StepOrchestrator` - Pass through agent flag
  - Updated existing tests to handle new method signatures

## Testing
- Added comprehensive unit tests covering all new functionality
- All existing tests updated and passing
- Manually tested with example workflows

## Documentation
- Updated README.md with new step type documentation
- Created example workflow with explanatory README
- Clear explanation of when and why to use agent steps

## Benefits
1. **Direct control** - Prompts go straight to the coding agent without interpretation
2. **Precision** - No more instructions being dropped or modified by the LLM layer
3. **Clean syntax** - The `^` prefix doesn't require quotes in YAML

Fixes #141

🤖 Generated with [Claude Code](https://claude.ai/code)