### PR TITLE
Downgrade cli-ui to fix roast init

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 gem "cgi"
-gem "cli-ui"
+gem "cli-ui", "2.3.0"
 gem "dotenv"
 gem "guard"
 gem "guard-minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     roast-ai (0.3.1)
       activesupport (>= 7.0)
-      cli-ui
+      cli-ui (= 2.3.0)
       diff-lcs (~> 1.5)
       faraday-retry
       json-schema
@@ -35,7 +35,7 @@ GEM
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     cgi (0.5.0)
-    cli-ui (2.3.1)
+    cli-ui (2.3.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -175,7 +175,7 @@ PLATFORMS
 
 DEPENDENCIES
   cgi
-  cli-ui
+  cli-ui (= 2.3.0)
   dotenv
   guard
   guard-minitest

--- a/roast.gemspec
+++ b/roast.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency("activesupport", ">= 7.0")
-  spec.add_dependency("cli-ui")
+  spec.add_dependency("cli-ui", "2.3.0")
   spec.add_dependency("diff-lcs", "~> 1.5")
   spec.add_dependency("faraday-retry")
   spec.add_dependency("json-schema")


### PR DESCRIPTION
Currently, `roast init` gives us a picker prompt where the first option isn't selectable given a recently introduced bug in CLI-UI. 

We can downgrade [until the fix is merged](https://github.com/Shopify/cli-ui/pull/593)
