### PR TITLE
Add Roast::Tools::Swarm for Claude Swarm integration

### DIFF
--- a/examples/swarm_example.yml
+++ b/examples/swarm_example.yml
@@ -1,0 +1,23 @@
+name: Swarm Example Workflow
+
+# Example workflow demonstrating Roast's integration with Claude Swarm
+# This workflow uses the Swarm tool to orchestrate multiple Claude Code instances
+
+tools:
+  - Roast::Tools::Swarm:
+      path: ".swarm.yml"  # Optional - will use default locations if not specified
+
+steps:
+  - run_basic_swarm
+  - run_custom_swarm
+
+# Basic swarm execution using tool-level config
+run_basic_swarm:
+  tool: swarm
+  prompt: "Help me refactor this codebase for better performance"
+
+# Override with a different swarm config for specialized tasks
+run_custom_swarm:
+  tool: swarm
+  path: "./specialized-swarm.yml"
+  prompt: "Run the specialized analysis workflow"

--- a/lib/roast/tools/swarm.rb
+++ b/lib/roast/tools/swarm.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "shellwords"
+
+module Roast
+  module Tools
+    module Swarm
+      extend self
+
+      DEFAULT_CONFIG_PATHS = [
+        ".swarm.yml",
+        "swarm.yml",
+        ".swarm/config.yml",
+      ].freeze
+
+      CONFIG_PATH_KEY = "path"
+      private_constant :DEFAULT_CONFIG_PATHS, :CONFIG_PATH_KEY
+
+      class << self
+        def included(base)
+          base.class_eval do
+            function(
+              :swarm,
+              "Execute Claude Swarm to orchestrate multiple Claude Code instances",
+              prompt: {
+                type: "string",
+                description: "The prompt to send to the swarm agents",
+                required: true,
+              },
+              path: {
+                type: "string",
+                description: "Path to the swarm configuration file (optional)",
+                required: false,
+              },
+            ) do |params|
+              Roast::Tools::Swarm.call(params[:prompt], params[:path])
+            end
+          end
+        end
+
+        def post_configuration_setup(base, config = {})
+          @tool_config = config
+        end
+
+        attr_reader :tool_config
+      end
+
+      def call(prompt, step_path = nil)
+        config_path = determine_config_path(step_path)
+
+        if config_path.nil?
+          return "Error: No swarm configuration file found. Please create a .swarm.yml file or specify a path."
+        end
+
+        unless File.exist?(config_path)
+          return "Error: Swarm configuration file not found at: #{config_path}"
+        end
+
+        Roast::Helpers::Logger.info("🐝 Running Claude Swarm with config: #{config_path}\n")
+
+        execute_swarm(prompt, config_path)
+      rescue StandardError => e
+        handle_error(e)
+      end
+
+      private
+
+      def determine_config_path(step_path)
+        # Priority: step-level path > tool-level path > default locations
+
+        # 1. Check step-level path
+        return step_path if step_path
+
+        # 2. Check tool-level path from configuration
+        if tool_config && tool_config[CONFIG_PATH_KEY]
+          return tool_config[CONFIG_PATH_KEY]
+        end
+
+        # 3. Check default locations
+        DEFAULT_CONFIG_PATHS.find { |path| File.exist?(path) }
+      end
+
+      def execute_swarm(prompt, config_path)
+        # Build the swarm command with proper escaping
+        command = build_swarm_command(prompt, config_path)
+
+        result = ""
+
+        # Execute the command directly with the prompt included
+        IO.popen(command, err: [:child, :out]) do |io|
+          result = io.read
+        end
+
+        exit_status = $CHILD_STATUS.exitstatus
+
+        format_output(command, result, exit_status)
+      end
+
+      def build_swarm_command(prompt, config_path)
+        # Build the claude-swarm command with properly escaped arguments
+        [
+          "claude-swarm",
+          "--config",
+          config_path,
+          "--prompt",
+          prompt,
+        ].shelljoin
+      end
+
+      def format_output(command, result, exit_status)
+        "Command: #{command}\n" \
+          "Exit status: #{exit_status}\n" \
+          "Output:\n#{result}"
+      end
+
+      def handle_error(error)
+        error_message = "Error running swarm: #{error.message}"
+        Roast::Helpers::Logger.error("#{error_message}\n")
+        Roast::Helpers::Logger.debug("#{error.backtrace.join("\n")}\n") if ENV["DEBUG"]
+        error_message
+      end
+    end
+  end
+end
+

--- a/test/roast/tools/swarm_test.rb
+++ b/test/roast/tools/swarm_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Tools
+    class SwarmTest < ActiveSupport::TestCase
+      setup do
+        # Reset tool config before each test
+        Roast::Tools::Swarm.instance_variable_set(:@tool_config, nil)
+      end
+
+      test "call returns error when no config file is found" do
+        # Mock that no default config files exist
+        File.stub(:exist?, false) do
+          result = Roast::Tools::Swarm.call("Test prompt")
+          assert_match "Error: No swarm configuration file found", result
+        end
+      end
+
+      test "call returns error when specified config file does not exist" do
+        result = Roast::Tools::Swarm.call("Test prompt", "/nonexistent/path.yml")
+        assert_match "Error: Swarm configuration file not found at:", result
+        assert_match "/nonexistent/path.yml", result
+      end
+
+      test "post_configuration_setup stores tool config" do
+        config = { "path" => "custom-swarm.yml", "other_option" => "value" }
+        Roast::Tools::Swarm.post_configuration_setup(nil, config)
+
+        assert_equal config, Roast::Tools::Swarm.tool_config
+      end
+
+      test "determine_config_path prioritizes step-level path" do
+        # Set tool config
+        Roast::Tools::Swarm.post_configuration_setup(nil, { "path" => "tool-config.yml" })
+
+        # Private method test via send
+        path = Roast::Tools::Swarm.send(:determine_config_path, "step-level.yml")
+        assert_equal "step-level.yml", path
+      end
+
+      test "determine_config_path uses tool config when no step path" do
+        # Set tool config
+        Roast::Tools::Swarm.post_configuration_setup(nil, { "path" => "tool-config.yml" })
+
+        # Private method test via send
+        path = Roast::Tools::Swarm.send(:determine_config_path, nil)
+        assert_equal "tool-config.yml", path
+      end
+
+      test "determine_config_path finds default config files" do
+        # Mock that .swarm.yml exists
+        File.stub(:exist?, ->(path) { path == ".swarm.yml" }) do
+          path = Roast::Tools::Swarm.send(:determine_config_path, nil)
+          assert_equal ".swarm.yml", path
+        end
+      end
+
+      test "build_swarm_command escapes shell arguments properly" do
+        command = Roast::Tools::Swarm.send(:build_swarm_command, 'Test with "quotes" and $vars', "config.yml")
+
+        # Check the command is properly escaped
+        assert_match "claude-swarm", command
+        assert_match "--config config.yml", command
+        assert_match "--prompt", command
+        # Shellwords escaping will handle special characters
+        assert_match "Test", command
+        assert_match "quotes", command
+      end
+
+      test "format_output includes all necessary information" do
+        output = Roast::Tools::Swarm.send(:format_output, "test command", "test output", 0)
+
+        assert_match "Command: test command", output
+        assert_match "Exit status: 0", output
+        assert_match "Output:\ntest output", output
+      end
+
+      test "handle_error formats error messages properly" do
+        error = StandardError.new("Test error")
+
+        # Capture logger output
+        logged_error = nil
+        Roast::Helpers::Logger.stub(:error, ->(msg) { logged_error = msg }) do
+          result = Roast::Tools::Swarm.send(:handle_error, error)
+
+          assert_equal "Error running swarm: Test error", result
+          assert_equal "Error running swarm: Test error\n", logged_error
+        end
+      end
+
+      test "included method registers swarm function" do
+        base_class = Class.new do
+          class << self
+            attr_accessor :registered_functions
+
+            def function(name, description, **params)
+              @registered_functions ||= {}
+              @registered_functions[name] = { description: description, parameters: params }
+            end
+          end
+        end
+
+        Roast::Tools::Swarm.included(base_class)
+
+        assert base_class.registered_functions.key?(:swarm)
+        swarm_func = base_class.registered_functions[:swarm]
+        assert_equal "Execute Claude Swarm to orchestrate multiple Claude Code instances", swarm_func[:description]
+        assert swarm_func[:parameters][:prompt][:required]
+        assert_not swarm_func[:parameters][:path][:required]
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
## Summary

This PR implements issue #182 by adding a new Roast tool that integrates with [Claude Swarm](https://github.com/parruda/claude-swarm), enabling Roast workflows to orchestrate multiple Claude Code instances.

## What's included

- **New tool**: `Roast::Tools::Swarm` in `lib/roast/tools/swarm.rb`
- **Test coverage**: Comprehensive tests in `test/roast/tools/swarm_test.rb`
- **Example workflow**: `examples/swarm_example.yml` demonstrating usage

## Key features

### Configuration flexibility
The tool supports three levels of configuration with clear precedence:
1. **Step-level** - Override config for specific steps
2. **Tool-level** - Default config for all steps using the tool
3. **Convention** - Looks for `.swarm.yml`, `swarm.yml`, or `.swarm/config.yml`

### Usage examples

```yaml
# Basic usage with default config location
tools:
  - Roast::Tools::Swarm

steps:
  - run_swarm

run_swarm:
  tool: swarm
  prompt: "Execute the multi-agent workflow"
```

```yaml
# With custom configuration paths
tools:
  - Roast::Tools::Swarm:
      path: "./default-swarm.yml"

steps:
  - basic_task
  - specialized_task

basic_task:
  tool: swarm
  prompt: "Run with default config"

specialized_task:
  tool: swarm
  path: "./specialized-swarm.yml"
  prompt: "Run with specialized config"
```

## Implementation details

- Follows established Roast tool patterns (similar to `Roast::Tools::Cmd`)
- Uses Ruby's `Shellwords` for safe shell argument escaping
- Integrates with Claude Swarm via the `claude-swarm` CLI command
- Provides clear error messages when configuration files are missing
- All tests pass and code follows project linting standards

## Testing

```bash
# Run the specific test file
bundle exec ruby -Itest test/roast/tools/swarm_test.rb

# Run full test suite
bundle exec rake
```

Fixes #182

🤖 Generated with [Claude Code](https://claude.ai/code)