### PR TITLE
Fix require path for `minitest_coverage_runner` helper

### DIFF
--- a/examples/grading/rb_test_runner
+++ b/examples/grading/rb_test_runner
@@ -4,7 +4,7 @@
 require "rubygems"
 require "bundler/setup"
 
-require_relative "../../lib/roast/helpers/minitest_coverage_runner"
+require "roast/helpers/minitest_coverage_runner"
 
 # Suppress fancy minitest reporting
 ENV["RM_INFO"] = "true"


### PR DESCRIPTION
I ran `roast init` in my repo and chose the `grading` example. Then I ran:

`bundle exec roast execute grading/workflow.yml test/models/user_test.rb`

It failed because it couldn't find `minitest_coverage_runner`.