### PR TITLE
Add --dangerously-skip-permissions flag to CodingAgent by default

### DIFF
--- a/lib/roast/tools/coding_agent.rb
+++ b/lib/roast/tools/coding_agent.rb
@@ -147,7 +147,7 @@ module Roast
       end
 
       def claude_code_command
-        CodingAgent.configured_command || ENV["CLAUDE_CODE_COMMAND"] || "claude -p --verbose --output-format stream-json"
+        CodingAgent.configured_command || ENV["CLAUDE_CODE_COMMAND"] || "claude -p --verbose --output-format stream-json --dangerously-skip-permissions"
       end
 
       def build_command(base_command, continue:)

--- a/test/roast/tools/coding_agent_test.rb
+++ b/test/roast/tools/coding_agent_test.rb
@@ -40,7 +40,7 @@ module Roast
         mock_status.expects(:success?).returns(true)
         mock_wait_thread.expects(:value).returns(mock_status)
 
-        Open3.expects(:popen3).with { |cmd| cmd =~ /cat .* \| claude -p --verbose --output-format stream-json$/ }.yields(mock_stdin, mock_stdout, mock_stderr, mock_wait_thread)
+        Open3.expects(:popen3).with { |cmd| cmd =~ /cat .* \| claude -p --verbose --output-format stream-json --dangerously-skip-permissions$/ }.yields(mock_stdin, mock_stdout, mock_stderr, mock_wait_thread)
 
         result = Roast::Tools::CodingAgent.call("Test prompt")
         assert_equal("AI response", result)


### PR DESCRIPTION
## Summary

- Added `--dangerously-skip-permissions` flag to the default CodingAgent command
- This prevents permission prompts from interrupting automated workflows when CodingAgent runs Claude Code CLI

## Test plan

- [x] Updated existing test to expect the new flag in the default command
- [x] All CodingAgent tests pass
- [x] Full test suite passes with `bundle exec rake`

🤖 Generated with [Claude Code](https://claude.ai/code)