### PR TITLE
adds 'exit early' feature to InputStep.

### DIFF
--- a/lib/roast/errors.rb
+++ b/lib/roast/errors.rb
@@ -7,5 +7,8 @@ module Roast
 
     # Custom error for when API authentication fails
     class AuthenticationError < StandardError; end
+
+    # Exit the app, for instance via Ctrl-C during an InputStep
+    class ExitEarly < StandardError; end
   end
 end

--- a/lib/roast/workflow/configuration_parser.rb
+++ b/lib/roast/workflow/configuration_parser.rb
@@ -38,6 +38,8 @@ module Roast
         else
           @workflow_runner.run_targetless
         end
+      rescue Roast::Errors::ExitEarly
+        $stderr.puts "Exiting workflow early."
       ensure
         execution_time = Time.now - start_time
 

--- a/lib/roast/workflow/input_step.rb
+++ b/lib/roast/workflow/input_step.rb
@@ -29,6 +29,8 @@ module Roast
         store_in_state(result) if step_name
 
         result
+      rescue Interrupt
+        raise Roast::Errors::ExitEarly
       rescue Timeout::Error
         handle_timeout
       end


### PR DESCRIPTION
Pressing Ctrl-C during an input step will exit the CLI instead of showing a huge stack trace