### PR TITLE
Fix config loading for AgentStep

### DIFF
--- a/lib/roast/workflow/agent_step.rb
+++ b/lib/roast/workflow/agent_step.rb
@@ -3,6 +3,15 @@
 module Roast
   module Workflow
     class AgentStep < BaseStep
+      attr_accessor :include_context_summary, :continue
+
+      def initialize(workflow, **kwargs)
+        super
+        # Set default values for agent-specific options
+        @include_context_summary = false
+        @continue = false
+      end
+
       def call
         # For inline prompts (detected by plain text step names), use the name as the prompt
         # For file-based steps, load from the prompt file
@@ -12,11 +21,10 @@ module Roast
           read_sidecar_prompt
         end
 
-        # Extract agent-specific configuration from workflow config
-        step_config = workflow.config[name.to_s] || {}
+        # Use agent-specific configuration that was applied by StepLoader
         agent_options = {
-          include_context_summary: step_config.fetch("include_context_summary", false),
-          continue: step_config.fetch("continue", false),
+          include_context_summary: @include_context_summary,
+          continue: @continue,
         }
 
         # Call CodingAgent directly with the prompt content and options

--- a/lib/roast/workflow/step_loader.rb
+++ b/lib/roast/workflow/step_loader.rb
@@ -203,6 +203,18 @@ module Roast
         if step_config.key?("available_tools")
           step.available_tools = step_config["available_tools"]
         end
+
+        # Apply any other configuration attributes that the step supports
+        step_config.each do |key, value|
+          # Skip keys we've already handled above
+          next if ["print_response", "json", "params", "coerce_to", "available_tools"].include?(key)
+
+          # Apply configuration if the step has a setter for this attribute
+          setter_method = "#{key}="
+          if step.respond_to?(setter_method)
+            step.public_send(setter_method, value)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Fix AgentStep bug with nil workflow.config

Fixes #298 

### Summary

Fixes a bug in `lib/roast/workflow/agent_step.rb` where `workflow.config[name.to_s]` throws `NoMethodError: undefined method '[]' for nil` because `workflow.config` returns `nil`. This bug completely prevents AgentStep (^ prefixed steps) from working in production.

### Root Cause

AgentStep was using an inconsistent configuration access pattern that bypassed Roast's standard step configuration system:

- **AgentStep**: Tried to access config via `workflow.config[name.to_s]` 
- **All other step types**: Use `config_hash` via StepLoader's standard configuration pattern
- **BaseWorkflow**: Has `workflow_configuration` attribute, not `config` method

The bug occurred because `BaseWorkflow.config` returns `nil`, but AgentStep assumed it would return a hash.

### Solution

Refactored AgentStep to use the standard configuration pattern like all other step types.

#### Key Changes

1. **AgentStep refactored** (`lib/roast/workflow/agent_step.rb`)
   - Removed `workflow.config[name.to_s]` access that was causing the nil error
   - Added `attr_accessor :include_context_summary, :continue` for configuration attributes
   - Added constructor that stes default values: `@include_context_summary = false`, `@continue = false`
   - Modified `call` method to use instance variables (`@include_context_summary`, `@continue`) instead of `workflow.config`

2. **StepLoader made generic** (`lib/roast/workflow/step_loader.rb`)
   - Added generic configuration application using `step.respond_to?(setter_method)` pattern
   - Iterates through all config keys and applies them to steps that have corresponding setter methods
   - Works for any step type with custom attributes, eliminating need for agent-specific code

3. **Full integration test added** (`test/roast/workflow/agent_step_test.rb`)
   - Added comprehensive integration test that starts from workflow YAML
   - Tests complete execution flow: YAML parsing → Configuration → WorkflowExecutor → AgentStep
   - Verifies configuration properly flows from YAML to AgentStep instance variables
   - Tests both agent steps with different configurations to ensure generic pattern works
   - This test fails before the aforementioned fixes are applied, and passes afterwards. 

### Breaking Changes

None. This is a bug fix that maintains full backward compatibility for workflow YAML syntax and AgentStep behavior.
