### PR TITLE
Fix JSON parsing for CodingAgent steps

### DIFF
--- a/lib/roast/tools/coding_agent.rb
+++ b/lib/roast/tools/coding_agent.rb
@@ -132,7 +132,7 @@ module Roast
           elsif json["subtype"] == "success"
             json["result"]
           else
-            raise CodingAgentError, "CodingAgent did not complete successfully: #{line}"
+            raise CodingAgentError, "CodingAgent did not complete successfully: #{json.inspect}"
           end
         end
       end


### PR DESCRIPTION
# Fix JSON parsing for CodingAgent steps

Closes #303 

## Summary

Fixes CodingAgent step crashes when `json: true` is configured by implementing proper JSON parsing.

## Changes Made

### 1. Fixed undefined variable bug in CodingAgent (`lib/roast/tools/coding_agent.rb`)

- **Line 135**: Fixed undefined `line` variable → `json.inspect` in error message

### 2. Added JSON parsing support to AgentStep (`lib/roast/workflow/agent_step.rb`)

- **Lines 33-59**: Added comprehensive JSON parsing logic that:
    - Checks if `@json` is configured and result is a string
    - Skips parsing for error messages to avoid confusion
    - Strips Markdown code blocks (`````json` and ``````) that Claude commonly wraps JSON in
    - Handles both `````json` and plain ````` ``` fenced blocks
    - Provides clear error messages for JSON parsing failures

## Why This Fix Was Needed

Normal LLM steps automatically get JSON parsing through the Raix gem, but CodingAgent steps bypass this flow by calling
the Claude Code CLI directly. This meant `json: true` configuration was ignored, leading to type mismatches and crashes.

## Testing

Added comprehensive test coverage in `test/roast/workflow/agent_step_test.rb`:
- ✅ JSON parsing when `json: true` is configured
- ✅ Markdown code block stripping (both ````json` and plain `````)
- ✅ Error handling for invalid JSON
- ✅ Error message passthrough without JSON parsing
- ✅ String return when `json: false` (default behavior)

All existing tests pass with no regressions.

Fixes workflow failures when using structured JSON output from CodingAgent steps.