### PR TITLE
Add support for CodingAgent tool configuration options

### DIFF
--- a/examples/coding_agent_with_model.yml
+++ b/examples/coding_agent_with_model.yml
@@ -1,0 +1,20 @@
+name: CodingAgent with Model Configuration
+description: |
+  Example workflow demonstrating how to configure the CodingAgent tool
+  with specific model options like opus
+
+tools:
+  - Roast::Tools::CodingAgent:
+      model: opus
+      # You can also add other claude options here:
+      # temperature: 0.7
+      # max_tokens: 1000
+
+steps:
+  - analyze_code: |
+      Analyze the Ruby code in lib/roast/tools/coding_agent.rb
+      and explain how the CodingAgent tool works.
+      
+  - implement_feature: |
+      Create a simple Ruby script that demonstrates using command-line
+      options similar to how CodingAgent builds its commands.

--- a/test/roast/workflow/coding_agent_config_test.rb
+++ b/test/roast/workflow/coding_agent_config_test.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Workflow
+    class CodingAgentConfigTest < ActiveSupport::TestCase
+      def setup
+        @temp_dir = Dir.mktmpdir
+        @workflow_path = File.join(@temp_dir, "test_workflow.yml")
+
+        # Reset CodingAgent configuration
+        Tools::CodingAgent.configured_command = nil
+        Tools::CodingAgent.configured_options = {}
+      end
+
+      def teardown
+        FileUtils.rm_rf(@temp_dir)
+        Tools::CodingAgent.configured_command = nil
+        Tools::CodingAgent.configured_options = {}
+      end
+
+      test "CodingAgent tool configuration with model option" do
+        workflow_content = <<~YAML
+          name: Test CodingAgent Config
+          tools:
+            - Roast::Tools::CodingAgent:
+                model: opus
+          steps:
+            - test_step: "Test step"
+        YAML
+
+        File.write(@workflow_path, workflow_content)
+
+        config = Configuration.new(@workflow_path)
+        assert_equal ["Roast::Tools::CodingAgent"], config.tools
+        assert_equal({ "model" => "opus" }, config.tool_config("Roast::Tools::CodingAgent"))
+
+        # Initialize the workflow to trigger post_configuration_setup
+        WorkflowInitializer.new(config).send(:post_configure_tools)
+
+        assert_equal({ "model" => "opus" }, Tools::CodingAgent.configured_options)
+      end
+
+      test "CodingAgent tool configuration with multiple options" do
+        workflow_content = <<~YAML
+          name: Test CodingAgent Config
+          tools:
+            - Roast::Tools::CodingAgent:
+                model: opus
+                temperature: 0.7
+                max_tokens: 1000
+          steps:
+            - test_step: "Test step"
+        YAML
+
+        File.write(@workflow_path, workflow_content)
+
+        config = Configuration.new(@workflow_path)
+        expected_config = {
+          "model" => "opus",
+          "temperature" => 0.7,
+          "max_tokens" => 1000,
+        }
+        assert_equal expected_config, config.tool_config("Roast::Tools::CodingAgent")
+
+        # Initialize the workflow to trigger post_configuration_setup
+        WorkflowInitializer.new(config).send(:post_configure_tools)
+
+        assert_equal expected_config, Tools::CodingAgent.configured_options
+      end
+
+      test "CodingAgent tool configuration with custom command and options" do
+        workflow_content = <<~YAML
+          name: Test CodingAgent Config
+          tools:
+            - Roast::Tools::CodingAgent:
+                coding_agent_command: "custom-claude"
+                model: opus
+          steps:
+            - test_step: "Test step"
+        YAML
+
+        File.write(@workflow_path, workflow_content)
+
+        config = Configuration.new(@workflow_path)
+
+        # Initialize the workflow to trigger post_configuration_setup
+        WorkflowInitializer.new(config).send(:post_configure_tools)
+
+        assert_equal "custom-claude", Tools::CodingAgent.configured_command
+        assert_equal({ "model" => "opus" }, Tools::CodingAgent.configured_options)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds the ability to configure CodingAgent tool options directly in workflow YAML files. This allows users to specify claude command-line options (like `--model opus`) that will be applied to all CodingAgent calls within a workflow.

## Changes

- Modified `CodingAgent` tool to support configuration options
- Added `configured_options` class variable to store tool configuration
- Enhanced `build_command` method to include configured options in the command line
- Added `build_options_string` helper to convert Ruby hash options to CLI flags
- Extended existing tests and added new workflow configuration tests
- Created example workflow demonstrating the feature

## Usage

```yaml
tools:
  - Roast::Tools::CodingAgent:
      model: opus
      # Other options can be added:
      # temperature: 0.7
      # max_tokens: 1000
```

The configured options are automatically converted to command-line flags and added to all claude commands executed by the CodingAgent tool.

## Test plan

- [x] Run existing CodingAgent tests: `bundle exec ruby -Itest test/roast/tools/coding_agent_options_test.rb`
- [x] Run new configuration tests: `bundle exec ruby -Itest test/roast/workflow/coding_agent_config_test.rb`
- [x] Run full test suite: `bundle exec rake`
- [ ] Test with a real workflow using the example configuration

🤖 Generated with [Claude Code](https://claude.ai/code)