### PR TITLE
Add retries configuration option to coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,11 +727,16 @@ tools:
         - yarn
   - Roast::Tools::CodingAgent:     # Optional configuration
       coding_agent_command: claude --model opus -p --allowedTools "Bash, Glob, Grep, LS, Read"
+      model: opus                  # Model to use for all CodingAgent invocations
+      retries: 3                   # Number of automatic retries on failure (default: 0)
 ```
 
 Currently supported configurations:
 - `Roast::Tools::Cmd` via `allowed_commands`: restricts which commands can be executed (defaults to: `pwd`, `find`, `ls`, `rake`, `ruby`, `dev`, `mkdir`)
-- `Roast::Tools::CodingAgent` via `coding_agent_command`: customizes the Claude Code CLI command used by the agent
+- `Roast::Tools::CodingAgent` via:
+  - `coding_agent_command`: customizes the Claude Code CLI command used by the agent
+  - `model`: sets the model for all CodingAgent invocations (e.g., `opus`, `sonnet`)
+  - `retries`: number of times to automatically retry if the agent encounters an error (default: 0, no retries)
 
 ##### Cmd Tool Configuration
 
@@ -959,16 +964,25 @@ bash(command: "ps aux | grep ruby | awk '{print $2}'")
 Creates a specialized agent for complex coding tasks or long-running operations.
 
 ```ruby
+# Basic usage
 coding_agent(
-  task: "Refactor the authentication module to use JWT tokens",
-  language: "ruby",
-  files: ["app/models/user.rb", "app/controllers/auth_controller.rb"]
+  prompt: "Refactor the authentication module to use JWT tokens",
+  include_context_summary: true,  # Include workflow context in the agent prompt
+  continue: true                   # Continue from previous agent session
+)
+
+# With automatic retries on failure
+coding_agent(
+  prompt: "Implement complex feature with error handling",
+  retries: 3  # Retry up to 3 times if the agent encounters errors
 )
 ```
 
-- Delegates complex tasks to a specialized coding agent
+- Delegates complex tasks to a specialized coding agent (Claude Code)
 - Useful for tasks that require deep code understanding or multi-step changes
 - Can work across multiple files and languages
+- Supports automatic retries on transient failures (network issues, API errors)
+- Retries can be configured globally (see Tool Configuration) or per invocation
 
 ### MCP (Model Context Protocol) Tools
 

--- a/examples/coding_agent_with_retries.yml
+++ b/examples/coding_agent_with_retries.yml
@@ -1,0 +1,30 @@
+name: CodingAgent with Retries Configuration
+description: |
+  Example workflow demonstrating how to configure the CodingAgent tool
+  with automatic retries on failure. The retries option will automatically
+  retry the coding agent if it encounters an error during execution.
+  Note: this is not the same as running the step
+
+tools:
+  - Roast::Tools::CodingAgent:
+      retries: 2  # Automatically retry up to 2 times on failure
+
+steps:
+  # This step invokes the coding agent directly using the specified number of retries
+  - ^implement_a_feature: |
+      Create a Ruby script that demonstrates robust error handling.
+      The script should:
+      1. Attempt to read a file that might not exist
+      2. Handle any errors gracefully
+      3. Log the results
+
+
+  # This step invokes the general workflow LLM which can in turn invoke the coding agent.
+  # When the general LLM invokes the coding agent, it will execute with the specified number of retries.
+  - add_tests: |
+      Add test for the feature you just implemented.
+      Run the tests and iterate until they all pass.
+      Use the CodingAgent tool to write the tests.
+
+add_tests:
+  retries: 4

--- a/test/roast/tools/coding_agent_options_test.rb
+++ b/test/roast/tools/coding_agent_options_test.rb
@@ -165,6 +165,152 @@ module Roast
         result = CodingAgent.send(:build_command, base_command, continue: false)
         assert_equal "custom-claude-wrapper --some-flag --model opus", result
       end
+
+      test "call uses configured retries as default when not specified" do
+        CodingAgent.configured_options = { "retries" => 2 }
+        ENV["CLAUDE_CODE_COMMAND"] = "claude --output-format stream-json"
+
+        # First two attempts fail
+        mock_stdin1 = mock
+        mock_stdout1 = StringIO.new("")
+        mock_stderr1 = StringIO.new("Network error")
+        mock_wait_thread1 = mock
+        mock_status1 = mock
+        mock_stdin1.expects(:close)
+        mock_status1.expects(:success?).returns(false)
+        mock_wait_thread1.expects(:value).returns(mock_status1)
+
+        mock_stdin2 = mock
+        mock_stdout2 = StringIO.new("")
+        mock_stderr2 = StringIO.new("API timeout")
+        mock_wait_thread2 = mock
+        mock_status2 = mock
+        mock_stdin2.expects(:close)
+        mock_status2.expects(:success?).returns(false)
+        mock_wait_thread2.expects(:value).returns(mock_status2)
+
+        # Third attempt succeeds
+        mock_output3 = [
+          {
+            type: "assistant",
+            message: {
+              content: [{ type: "text", text: "Task completed after retries" }],
+            },
+          }.to_json,
+          { type: "result", subtype: "success", is_error: false, result: "Success on third attempt" }.to_json,
+        ].join("\n")
+        mock_stdin3 = mock
+        mock_stdout3 = StringIO.new(mock_output3)
+        mock_stderr3 = StringIO.new("")
+        mock_wait_thread3 = mock
+        mock_status3 = mock
+        mock_stdin3.expects(:close)
+        mock_status3.expects(:success?).returns(true)
+        mock_wait_thread3.expects(:value).returns(mock_status3)
+
+        # Expect exactly 3 calls (1 initial + 2 retries)
+        Open3.expects(:popen3).times(3).with { |cmd| cmd =~ /cat .* \| claude --output-format stream-json$/ }
+          .yields(mock_stdin1, mock_stdout1, mock_stderr1, mock_wait_thread1)
+          .then.yields(mock_stdin2, mock_stdout2, mock_stderr2, mock_wait_thread2)
+          .then.yields(mock_stdin3, mock_stdout3, mock_stderr3, mock_wait_thread3)
+
+        # Call without specifying retries - should use configured default of 2
+        result = CodingAgent.call("Test prompt")
+        assert_equal "Success on third attempt", result
+      end
+
+      test "call parameter overrides configured retries" do
+        CodingAgent.configured_options = { "retries" => 2 }
+        ENV["CLAUDE_CODE_COMMAND"] = "claude --output-format stream-json"
+
+        # First attempt fails
+        mock_stdin1 = mock
+        mock_stdout1 = StringIO.new("")
+        mock_stderr1 = StringIO.new("Error")
+        mock_wait_thread1 = mock
+        mock_status1 = mock
+        mock_stdin1.expects(:close)
+        mock_status1.expects(:success?).returns(false)
+        mock_wait_thread1.expects(:value).returns(mock_status1)
+
+        # Second attempt succeeds
+        mock_output2 = [
+          {
+            type: "assistant",
+            message: {
+              content: [{ type: "text", text: "Retrying task" }],
+            },
+          }.to_json,
+          { type: "result", subtype: "success", is_error: false, result: "Success after retry" }.to_json,
+        ].join("\n")
+
+        mock_stdin2 = mock
+        mock_stdout2 = StringIO.new(mock_output2)
+        mock_stderr2 = StringIO.new("")
+        mock_wait_thread2 = mock
+        mock_status2 = mock
+        mock_stdin2.expects(:close)
+        mock_status2.expects(:success?).returns(true)
+        mock_wait_thread2.expects(:value).returns(mock_status2)
+
+        Open3.expects(:popen3).twice.with { |cmd| cmd =~ /cat .* \| claude --output-format stream-json$/ }
+          .yields(mock_stdin1, mock_stdout1, mock_stderr1, mock_wait_thread1)
+          .then.yields(mock_stdin2, mock_stdout2, mock_stderr2, mock_wait_thread2)
+
+        # Call with explicit retries=1, should override the configured default of 2
+        result = CodingAgent.call("Test prompt", retries: 1)
+        assert_equal "Success after retry", result
+      end
+
+      test "call fails after exhausting all configured retries" do
+        CodingAgent.configured_options = { "retries" => 2 }
+        ENV["CLAUDE_CODE_COMMAND"] = "claude --output-format stream-json"
+
+        # Create separate mocks for each attempt since stderr.read consumes the stream
+        3.times do |i|
+          mock_stdin = mock
+          mock_stdout = StringIO.new("")
+          mock_stderr = StringIO.new("Persistent error #{i + 1}")
+          mock_wait_thread = mock
+          mock_status = mock
+
+          mock_stdin.expects(:close)
+          mock_status.expects(:success?).returns(false)
+          mock_wait_thread.expects(:value).returns(mock_status)
+
+          Open3.expects(:popen3).with { |cmd| cmd =~ /cat .* \| claude --output-format stream-json$/ }
+            .yields(mock_stdin, mock_stdout, mock_stderr, mock_wait_thread)
+        end
+
+        # Should fail with error message after all retries
+        result = CodingAgent.call("Test prompt")
+        assert_match(/Error running CodingAgent: Persistent error/, result)
+      end
+
+      test "default behavior is no retries when not configured" do
+        # Clear any configured options
+        CodingAgent.configured_options = {}
+        ENV["CLAUDE_CODE_COMMAND"] = "claude --output-format stream-json"
+
+        # Single attempt fails
+        mock_stdin = mock
+        mock_stdout = StringIO.new("")
+        mock_stderr = StringIO.new("Command failed")
+        mock_wait_thread = mock
+        mock_status = mock
+
+        mock_stdin.expects(:close)
+        mock_status.expects(:success?).returns(false)
+        mock_wait_thread.expects(:value).returns(mock_status)
+
+        # Expect only ONE call (no retries)
+        Open3.expects(:popen3).once.with { |cmd| cmd =~ /cat .* \| claude --output-format stream-json$/ }
+          .yields(mock_stdin, mock_stdout, mock_stderr, mock_wait_thread)
+
+        # Should fail immediately without retrying
+        result = CodingAgent.call("Test prompt")
+        assert_match(/Error running CodingAgent: Command failed/, result)
+      end
     end
   end
 end

--- a/test/roast/tools/coding_agent_test.rb
+++ b/test/roast/tools/coding_agent_test.rb
@@ -138,7 +138,7 @@ module Roast
         Open3.expects(:popen3).yields(mock_stdin, mock_stdout, mock_stderr, mock_wait_thread)
 
         result = Roast::Tools::CodingAgent.call("Test prompt")
-        assert_equal "Error running CodingAgent: Command not found: claude", result
+        assert_equal "🤖 Error running CodingAgent: Command not found: claude", result
       end
 
       test "cleans up temporary files even on error" do
@@ -235,7 +235,15 @@ module Roast
         end
 
         result = Roast::Tools::CodingAgent.call("Test prompt")
-        assert_equal(result, "Error running CodingAgent: ERROR TEXT")
+        assert_match(/^🤖 Error running CodingAgent:/, result)
+        assert_match(/"type"/, result)
+        assert_match(/"result"/, result)
+        assert_match(/"subtype"/, result)
+        assert_match(/"success"/, result)
+        assert_match(/"is_error"/, result)
+        assert_match(/true/, result)
+        assert_match(/"result"/, result)
+        assert_match(/ERROR TEXT/, result)
       ensure
         ENV["CLAUDE_CODE_COMMAND"] = original_env
       end


### PR DESCRIPTION
# Add automatic retry support for CodingAgent tool

## Summary

This PR adds configurable automatic retry functionality to the CodingAgent tool, allowing it to recover from transient failures like network issues, API errors, or temporary agent hiccups. The retries can be configured globally for all CodingAgent invocations in a workflow, or specified per-invocation by the LLM.

Note this is distinct from the step-retry functionality implemented in #285. CodingAgent retry will allow quick recovery from minor coding agent failures within the execution of a step without failing the step.

I've been encountering a failure rate with non-interactive Claude invocations something in the neighbourhood of 2-5% of the time, especially for more complex prompts, returning the `"type" => "result", "subtype" => "error_during_execution", ...}` response, even though what claude has done appears to have (mostly) completed successfully. This feature will improve workflow resilient in these cases often with less overhead than retrying the whole step.

## Motivation

The CodingAgent tool delegates complex tasks to Claude Code, which can sometimes fail due to:
- Temporary network connectivity issues
- Transient API errors
- Rate limiting
- Other intermittent failures

Previously, these failures would immediately terminate the workflow, requiring manual intervention and restart. With automatic retries, the CodingAgent can recover from these temporary issues without user intervention, making workflows more robust and reliable.

## Implementation Details

### Configuration Options

1. **Global configuration** in workflow YAML:
```yaml
tools:
  - Roast::Tools::CodingAgent:
      model: opus
      retries: 2  # Use 2 as the default retry count for all invocations
```

2. **Step-specific override**:
```
do_a_task:
  retries: 0
  json: true
```

### Behavior

- **Default**: 0 retries (no change to existing behavior)
- **Retry triggers**: Only `CodingAgentError` exceptions trigger retries
- **Retry logging**: Each retry attempt is logged with attempt number
- **Final failure**: After exhausting retries, the final error is propagated

### Key Changes

1. **`lib/roast/tools/coding_agent.rb`**:
   - Modified `call` method to accept `retries` parameter (defaults to `nil`)
   - Added retry logic with configurable attempts
   - Updated `build_command` to exclude `retries` from CLI options
   - Simplified `handle_result` determination of success or failure

2. **Tests**:
   - Added comprehensive tests for global retry configuration
   - Added tests for per-invocation retry override
   - Fixed existing tests to handle the corrected error response format

3. **Documentation**:
   - Updated README with usage examples and configuration options
   - Added example workflow demonstrating retry configuration

## Testing

- ✅ All existing tests pass
- ✅ New tests added for retry functionality
- ✅ Manual testing with example workflows
- ✅ Linting and style checks pass

## Usage Example

```yaml
name: Complex Refactoring Workflow
tools:
  - Roast::Tools::CodingAgent:
      model: opus
      retries: 2  # Automatically retry up to 2 times on failure

steps:
  - refactor_authentication: |
      Refactor the entire authentication system to use JWT tokens.
      This is a complex task that might require multiple attempts.
```

## Breaking Changes

None. The feature is fully backward compatible:
- Existing workflows continue to work without modification
- Default behaviour (no retries) is preserved
- The `retries` parameter is optional in both configuration and function calls

## Future Considerations

- Could add exponential backoff between retries
- Could make retry behaviour configurable (which errors to retry)
- Could add retry statistics to workflow output

## Checklist

- [x] Implementation complete
- [x] Tests added and passing
- [x] Documentation updated
- [x] Example workflow created
- [x] Backward compatibility maintained
- [x] Code follows project conventions