### PR TITLE
Increase bash tool execution timeout to 1 hour

### DIFF
--- a/lib/roast/helpers/timeout_handler.rb
+++ b/lib/roast/helpers/timeout_handler.rb
@@ -17,7 +17,7 @@ module Roast
     #   output, status = TimeoutHandler.call("pwd", timeout: 10, working_directory: "/tmp")
     class TimeoutHandler
       DEFAULT_TIMEOUT = 30
-      MAX_TIMEOUT = 300
+      MAX_TIMEOUT = 3600
 
       class << self
         # Execute a command with timeout using Open3 with proper process cleanup


### PR DESCRIPTION
## Summary
- Increased MAX_TIMEOUT constant in TimeoutHandler from 300 seconds (5 minutes) to 3600 seconds (1 hour)
- This allows bash and cmd steps to run longer-running commands without timing out

## Test plan
- [x] Updated the timeout constant value
- [ ] All existing tests should continue to pass (unable to run full test suite due to environment issues)
- [ ] The change only affects the maximum allowed timeout, not the default timeout behavior

🤖 Generated with [Claude Code](https://claude.ai/code)