### PR TITLE
Add metadata store for tracking internal execution details

### DIFF
--- a/lib/roast/helpers/metadata_access.rb
+++ b/lib/roast/helpers/metadata_access.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Roast
+  module Helpers
+    module MetadataAccess
+      def step_metadata(step_name = nil)
+        step_name ||= current_step_name
+        return {} unless step_name
+
+        metadata = workflow_metadata || {}
+        metadata[step_name] || {}
+      end
+
+      def set_current_step_metadata(key, value)
+        step_name = current_step_name
+        metadata = workflow_metadata
+
+        return unless step_name && metadata
+
+        metadata[step_name] ||= {}
+        metadata[step_name][key] = value
+      end
+
+      private
+
+      def workflow_metadata
+        metadata = Thread.current[:workflow_metadata]
+        Roast::Helpers::Logger.warn("MetadataAccess#workflow_metadata is not present") if metadata.nil?
+        metadata
+      end
+
+      def current_step_name
+        step_name = Thread.current[:current_step_name]
+        Roast::Helpers::Logger.warn("MetadataAccess#current_step_name is not present") if step_name.nil?
+        step_name
+      end
+    end
+  end
+end

--- a/lib/roast/workflow/base_workflow.rb
+++ b/lib/roast/workflow/base_workflow.rb
@@ -24,6 +24,7 @@ module Roast
 
       delegate :api_provider, :openai?, to: :workflow_configuration, allow_nil: true
       delegate :output, :output=, :append_to_final_output, :final_output, to: :output_manager
+      delegate :metadata, :metadata=, to: :metadata_manager
       delegate_missing_to :output
 
       def initialize(file = nil, name: nil, context_path: nil, resource: nil, session_name: nil, workflow_configuration: nil, pre_processing_data: nil)
@@ -38,6 +39,7 @@ module Roast
 
         # Initialize managers
         @output_manager = OutputManager.new
+        @metadata_manager = MetadataManager.new
         @context_manager = ContextManager.new
         @context_management_config = {}
 
@@ -125,8 +127,8 @@ module Roast
         self
       end
 
-      # Expose output manager for state management
-      attr_reader :output_manager
+      # Expose output and metadata managers for state management
+      attr_reader :output_manager, :metadata_manager
 
       private
 

--- a/lib/roast/workflow/metadata_manager.rb
+++ b/lib/roast/workflow/metadata_manager.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Roast
+  module Workflow
+    # Manages workflow metadata, providing a structure parallel to output
+    # but specifically for internal metadata that shouldn't be user-facing
+    class MetadataManager
+      def initialize
+        @metadata = ActiveSupport::HashWithIndifferentAccess.new
+        @metadata_wrapper = nil
+      end
+
+      # Get metadata wrapped in DotAccessHash for dot notation access
+      def metadata
+        @metadata_wrapper ||= DotAccessHash.new(@metadata)
+      end
+
+      # Set metadata, ensuring it's always a HashWithIndifferentAccess
+      def metadata=(value)
+        @metadata = if value.is_a?(ActiveSupport::HashWithIndifferentAccess)
+          value
+        else
+          ActiveSupport::HashWithIndifferentAccess.new(value)
+        end
+        # Reset the wrapper when metadata changes
+        @metadata_wrapper = nil
+      end
+
+      # Get the raw metadata hash (for internal use)
+      def raw_metadata
+        @metadata
+      end
+
+      # Get a snapshot of the current state for persistence
+      def to_h
+        @metadata.to_h
+      end
+
+      # Restore state from a hash
+      def from_h(data)
+        return unless data
+
+        self.metadata = data
+      end
+    end
+  end
+end

--- a/lib/roast/workflow/replay_handler.rb
+++ b/lib/roast/workflow/replay_handler.rb
@@ -77,6 +77,7 @@ module Roast
         return unless state_data && @workflow
 
         restore_output(state_data)
+        restore_metadata(state_data)
         restore_transcript(state_data)
         restore_final_output(state_data)
       end
@@ -86,6 +87,13 @@ module Roast
         return unless @workflow.respond_to?(:output=)
 
         @workflow.output = state_data[:output]
+      end
+
+      def restore_metadata(state_data)
+        return unless state_data.key?(:metadata)
+        return unless @workflow.respond_to?(:metadata=)
+
+        @workflow.metadata = state_data[:metadata]
       end
 
       def restore_transcript(state_data)

--- a/lib/roast/workflow/state_manager.rb
+++ b/lib/roast/workflow/state_manager.rb
@@ -42,6 +42,7 @@ module Roast
           order: determine_step_order(step_name),
           transcript: extract_transcript,
           output: extract_output,
+          metadata: extract_metadata,
           final_output: extract_final_output,
           execution_order: extract_execution_order,
         }
@@ -66,6 +67,13 @@ module Roast
         return {} unless workflow.respond_to?(:output)
 
         workflow.output.clone
+      end
+
+      # Extract metadata if available
+      def extract_metadata
+        return {} unless workflow.respond_to?(:metadata)
+
+        workflow.metadata.clone
       end
 
       # Extract final output data if available

--- a/lib/roast/workflow/step_executor_coordinator.rb
+++ b/lib/roast/workflow/step_executor_coordinator.rb
@@ -54,6 +54,10 @@ module Roast
       # @return [Object] The result of the step execution
       def execute(step, options = {})
         step_type = StepTypeResolver.resolve(step, @context)
+        step_name = StepTypeResolver.extract_name(step)
+
+        Thread.current[:current_step_name] = step_name if step_name
+        Thread.current[:workflow_metadata] = @context.workflow.metadata
 
         case step_type
         when StepTypeResolver::COMMAND_STEP

--- a/test/roast/helpers/metadata_access_test.rb
+++ b/test/roast/helpers/metadata_access_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MetadataAccessTest < ActiveSupport::TestCase
+  class TestClass
+    include Roast::Helpers::MetadataAccess
+  end
+
+  def setup
+    @test_object = TestClass.new
+    @metadata = {}
+    Thread.current[:workflow_metadata] = @metadata
+    Thread.current[:current_step_name] = "test_step"
+    Roast::Helpers::Logger.reset
+  end
+
+  def teardown
+    Thread.current[:workflow_metadata] = nil
+    Thread.current[:current_step_name] = nil
+  end
+
+  test "step_metadata returns metadata for current step" do
+    @metadata["test_step"] = { "key" => "value" }
+
+    result = @test_object.step_metadata
+    assert_equal({ "key" => "value" }, result)
+  end
+
+  test "step_metadata returns metadata for specified step" do
+    @metadata["other_step"] = { "other_key" => "other_value" }
+
+    result = @test_object.step_metadata("other_step")
+    assert_equal({ "other_key" => "other_value" }, result)
+  end
+
+  test "step_metadata returns empty hash when step has no metadata" do
+    result = @test_object.step_metadata("nonexistent_step")
+    assert_equal({}, result)
+  end
+
+  test "step_metadata returns empty hash when no step name" do
+    Thread.current[:current_step_name] = nil
+
+    out, _ = capture_io do
+      assert_equal({}, @test_object.step_metadata)
+    end
+
+    assert_match(/WARN: MetadataAccess#current_step_name is not present/, out)
+  end
+
+  test "step_metadata returns empty hash and logs warning when workflow_metadata is nil" do
+    Thread.current[:workflow_metadata] = nil
+
+    out, _ = capture_io do
+      assert_equal({}, @test_object.step_metadata)
+    end
+
+    assert_match(/WARN: MetadataAccess#workflow_metadata is not present/, out)
+  end
+
+  test "set_current_step_metadata sets metadata for current step" do
+    @test_object.set_current_step_metadata("duration_ms", 150)
+
+    assert_equal({ "duration_ms" => 150 }, @metadata["test_step"])
+  end
+
+  test "set_current_step_metadata creates step metadata if not exists" do
+    assert_nil @metadata["test_step"]
+
+    @test_object.set_current_step_metadata("new_key", "new_value")
+
+    assert_equal({ "new_key" => "new_value" }, @metadata["test_step"])
+  end
+
+  test "set_current_step_metadata adds to existing metadata" do
+    @metadata["test_step"] = { "existing" => "data" }
+
+    @test_object.set_current_step_metadata("new_key", "new_value")
+
+    assert_equal(
+      {
+        "existing" => "data",
+        "new_key" => "new_value",
+      },
+      @metadata["test_step"],
+    )
+  end
+
+  test "set_current_step_metadata returns early when no step name" do
+    Thread.current[:current_step_name] = nil
+
+    out, _ = capture_io do
+      @test_object.set_current_step_metadata("key", "value")
+    end
+
+    # Should not modify metadata
+    assert_equal({}, @metadata)
+    assert_match(/WARN: MetadataAccess#current_step_name is not present/, out)
+  end
+
+  test "set_current_step_metadata returns early when no workflow metadata" do
+    Thread.current[:workflow_metadata] = nil
+
+    out, _ = capture_io do
+      @test_object.set_current_step_metadata("key", "value")
+    end
+
+    # Should not raise error
+    assert_nil Thread.current[:workflow_metadata]
+    assert_match(/WARN: MetadataAccess#workflow_metadata is not present/, out)
+  end
+
+  test "workflow_metadata is private" do
+    assert_raises(NoMethodError) { @test_object.workflow_metadata }
+  end
+
+  test "current_step_name is private" do
+    assert_raises(NoMethodError) { @test_object.current_step_name }
+  end
+
+  test "metadata access works with symbols and strings" do
+    # HashWithIndifferentAccess behavior
+    metadata = ActiveSupport::HashWithIndifferentAccess.new
+    Thread.current[:workflow_metadata] = metadata
+
+    @test_object.set_current_step_metadata(:symbol_key, "value1")
+    @test_object.set_current_step_metadata("string_key", "value2")
+
+    result = @test_object.step_metadata
+    assert_equal "value1", result[:symbol_key]
+    assert_equal "value1", result["symbol_key"]
+    assert_equal "value2", result[:string_key]
+    assert_equal "value2", result["string_key"]
+  end
+end

--- a/test/roast/workflow/agent_step_test.rb
+++ b/test/roast/workflow/agent_step_test.rb
@@ -101,6 +101,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     # Create mock dependencies
     workflow = mock
     workflow.stubs(:output).returns({})
+    workflow.stubs(:metadata).returns({})
     config_mock = mock
     config_mock.stubs(:workflow_path).returns("/test/workflow.yml")
     workflow.stubs(:config).returns(config_mock)
@@ -140,6 +141,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     # Create mock dependencies
     workflow = mock
     workflow.stubs(:output).returns({})
+    workflow.stubs(:metadata).returns({})
     config_mock = mock
     config_mock.stubs(:workflow_path).returns("/test/workflow.yml")
     workflow.stubs(:config).returns(config_mock)

--- a/test/roast/workflow/base_workflow_test.rb
+++ b/test/roast/workflow/base_workflow_test.rb
@@ -56,4 +56,96 @@ class RoastWorkflowBaseWorkflowTest < ActiveSupport::TestCase
   test "handles other errors properly without conversion" do
     skip "Skipping due to complex Raix configuration requirements"
   end
+
+  test "workflow has metadata manager" do
+    workflow = Roast::Workflow::BaseWorkflow.new(FILE_PATH)
+
+    assert_respond_to workflow, :metadata
+    assert_respond_to workflow, :metadata=
+  end
+
+  test "metadata returns DotAccessHash" do
+    workflow = Roast::Workflow::BaseWorkflow.new(FILE_PATH)
+    assert_instance_of Roast::Workflow::DotAccessHash, workflow.metadata
+  end
+
+  test "can set and get metadata" do
+    workflow = Roast::Workflow::BaseWorkflow.new(FILE_PATH)
+    workflow.metadata["step1"] = { "key" => "value" }
+
+    assert_equal "value", workflow.metadata.step1.key
+    assert_equal "value", workflow.metadata["step1"]["key"]
+  end
+
+  test "metadata is delegated to metadata manager" do
+    workflow = Roast::Workflow::BaseWorkflow.new(FILE_PATH)
+
+    # Set metadata
+    workflow.metadata = { "test" => "data" }
+
+    # Should be reflected in the manager
+    metadata_manager = workflow.instance_variable_get(:@metadata_manager)
+    assert_equal({ "test" => "data" }, metadata_manager.to_h)
+  end
+
+  test "metadata persists through workflow lifecycle" do
+    workflow = Roast::Workflow::BaseWorkflow.new(FILE_PATH)
+
+    # Add metadata during workflow execution
+    workflow.metadata["initialization"] = { "timestamp" => "2024-01-15" }
+    workflow.metadata["step1"] = { "duration" => 100 }
+    workflow.metadata["step2"] = { "success" => true }
+
+    # Verify all metadata is accessible
+    assert_equal "2024-01-15", workflow.metadata.initialization.timestamp
+    assert_equal 100, workflow.metadata.step1.duration
+    assert_equal true, workflow.metadata.step2.success
+
+    # Get full metadata snapshot
+    all_metadata = workflow.metadata.to_h
+    assert_equal 3, all_metadata.keys.size
+    assert all_metadata.key?("initialization")
+    assert all_metadata.key?("step1")
+    assert all_metadata.key?("step2")
+  end
+
+  test "metadata and output are separate stores" do
+    workflow = Roast::Workflow::BaseWorkflow.new(FILE_PATH)
+
+    # Set output
+    workflow.output["step1"] = "User visible output"
+
+    # Set metadata
+    workflow.metadata["step1"] = { "internal" => "tracking data" }
+
+    # Verify they are separate
+    assert_equal "User visible output", workflow.output["step1"]
+    assert_equal({ "internal" => "tracking data" }, workflow.metadata["step1"])
+
+    # Changing one doesn't affect the other
+    workflow.output["step1"] = "Updated output"
+    assert_equal({ "internal" => "tracking data" }, workflow.metadata["step1"])
+
+    workflow.metadata["step1"]["internal"] = "Updated metadata"
+    assert_equal "Updated output", workflow.output["step1"]
+  end
+
+  test "metadata survives workflow state changes" do
+    workflow = Roast::Workflow::BaseWorkflow.new(FILE_PATH)
+
+    # Set initial metadata
+    workflow.metadata["pre_execution"] = { "setup" => "complete" }
+
+    # Simulate workflow execution state changes
+    workflow.output["step1"] = "output1"
+    workflow.metadata["step1"] = { "executed" => true }
+
+    workflow.append_to_final_output("Final result")
+    workflow.metadata["post_execution"] = { "cleanup" => "done" }
+
+    # All metadata should still be present
+    assert_equal "complete", workflow.metadata.pre_execution.setup
+    assert_equal true, workflow.metadata.step1.executed
+    assert_equal "done", workflow.metadata.post_execution.cleanup
+  end
 end

--- a/test/roast/workflow/coerce_to_configuration_test.rb
+++ b/test/roast/workflow/coerce_to_configuration_test.rb
@@ -8,6 +8,7 @@ module Roast
       def setup
         @workflow = mock("workflow")
         @workflow.stubs(:output).returns({})
+        @workflow.stubs(:metadata).returns({})
         @workflow.stubs(:transcript).returns([])
         @workflow.stubs(:resource).returns(nil)
         @workflow.stubs(:append_to_final_output)

--- a/test/roast/workflow/conditional_step_test.rb
+++ b/test/roast/workflow/conditional_step_test.rb
@@ -10,6 +10,7 @@ module Roast
         @workflow_executor = mock("workflow_executor")
         @output = {}
         @workflow.stubs(:output).returns(@output)
+        @workflow.stubs(:metadata).returns({})
         @context_path = "/path/to/workflow.yml"
       end
 

--- a/test/roast/workflow/inline_prompt_configuration_test.rb
+++ b/test/roast/workflow/inline_prompt_configuration_test.rb
@@ -16,6 +16,7 @@ module Roast
         @workflow.stubs(:pause_step_name).returns(nil)
         @workflow.stubs(:tools).returns(nil)
         @workflow.stubs(:storage_type).returns(nil)
+        @workflow.stubs(:metadata).returns({})
 
         @config_hash = {
           "analyze the code" => {

--- a/test/roast/workflow/input_executor_test.rb
+++ b/test/roast/workflow/input_executor_test.rb
@@ -8,6 +8,7 @@ module Roast
       def setup
         @workflow = mock("workflow")
         @workflow.stubs(:output).returns({})
+        @workflow.stubs(:metadata).returns({})
         @context_path = "/test/context"
         @state_manager = mock("state_manager")
         @workflow_executor = mock("workflow_executor")

--- a/test/roast/workflow/input_step_integration_test.rb
+++ b/test/roast/workflow/input_step_integration_test.rb
@@ -27,6 +27,7 @@ module Roast
 
       test "StepExecutorCoordinator routes input steps correctly" do
         workflow = mock("workflow")
+        workflow.stubs(:metadata).returns({})
         workflow.stubs(:output).returns({})
         workflow.stubs(:pause_step_name).returns(nil)
 

--- a/test/roast/workflow/input_step_test.rb
+++ b/test/roast/workflow/input_step_test.rb
@@ -8,6 +8,7 @@ module Roast
       def setup
         @workflow = mock("workflow")
         @workflow.stubs(:output).returns({})
+        @workflow.stubs(:metadata).returns({})
         @workflow.stubs(:state).returns({})
         @workflow.stubs(:respond_to?).with(:state).returns(true)
         @workflow.stubs(:respond_to?).with(:resource).returns(false)

--- a/test/roast/workflow/iteration_config_hash_test.rb
+++ b/test/roast/workflow/iteration_config_hash_test.rb
@@ -7,6 +7,7 @@ module Roast
     class IterationConfigHashTest < ActiveSupport::TestCase
       def setup
         @workflow = mock("workflow")
+        @workflow.stubs(:metadata).returns({})
         @workflow.stubs(:output).returns({})
         @state_manager = mock("state_manager")
         @state_manager.stubs(:save_state)

--- a/test/roast/workflow/iteration_executor_test.rb
+++ b/test/roast/workflow/iteration_executor_test.rb
@@ -6,6 +6,7 @@ class RoastWorkflowIterationExecutorTest < ActiveSupport::TestCase
   def setup
     @workflow = mock("workflow")
     @workflow.stubs(:output).returns({})
+    @workflow.stubs(:metadata).returns({})
     @context_path = "/test/path"
     @state_manager = mock("state_manager")
     @executor = Roast::Workflow::IterationExecutor.new(@workflow, @context_path, @state_manager, {})

--- a/test/roast/workflow/iteration_step_configuration_test.rb
+++ b/test/roast/workflow/iteration_step_configuration_test.rb
@@ -8,6 +8,7 @@ module Roast
       def setup
         @workflow = mock("workflow")
         @workflow.stubs(:output).returns({})
+        @workflow.stubs(:metadata).returns({})
         @workflow.stubs(:transcript).returns([])
         @context_path = "/tmp/test"
         @state_manager = mock("state_manager")

--- a/test/roast/workflow/metadata_manager_test.rb
+++ b/test/roast/workflow/metadata_manager_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MetadataManagerTest < ActiveSupport::TestCase
+  def setup
+    @manager = Roast::Workflow::MetadataManager.new
+  end
+
+  test "initializes with empty metadata" do
+    assert_equal({}, @manager.to_h)
+    assert_instance_of Roast::Workflow::DotAccessHash, @manager.metadata
+  end
+
+  test "metadata accessor returns DotAccessHash wrapper" do
+    metadata = @manager.metadata
+    assert_instance_of Roast::Workflow::DotAccessHash, metadata
+
+    # Test dot notation access
+    @manager.metadata["step1"] = { "key" => "value" }
+    assert_equal "value", metadata.step1.key
+  end
+
+  test "metadata= sets new metadata and resets wrapper" do
+    original_wrapper = @manager.metadata
+
+    @manager.metadata = { "new" => "data" }
+
+    # Should have new wrapper instance
+    refute_same original_wrapper, @manager.metadata
+    assert_equal({ "new" => "data" }, @manager.to_h)
+  end
+
+  test "metadata= converts regular hash to HashWithIndifferentAccess" do
+    @manager.metadata = { "key" => "value" }
+
+    # Should work with both string and symbol keys
+    assert_equal "value", @manager.raw_metadata["key"]
+    assert_equal "value", @manager.raw_metadata[:key]
+  end
+
+  test "raw_metadata returns underlying hash" do
+    @manager.metadata["test"] = "value"
+
+    raw = @manager.raw_metadata
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, raw
+    assert_equal({ "test" => "value" }, raw)
+  end
+
+  test "to_h returns plain hash representation" do
+    @manager.metadata["step1"] = { "duration" => 100 }
+    @manager.metadata["step2"] = { "success" => true }
+
+    hash = @manager.to_h
+    assert_instance_of Hash, hash
+    assert_equal(
+      {
+        "step1" => { "duration" => 100 },
+        "step2" => { "success" => true },
+      },
+      hash,
+    )
+  end
+
+  test "from_h restores metadata from hash" do
+    data = {
+      "step1" => { "key1" => "value1" },
+      "step2" => { "key2" => "value2" },
+    }
+
+    @manager.from_h(data)
+
+    assert_equal data, @manager.to_h
+    assert_equal "value1", @manager.metadata.step1.key1
+    assert_equal "value2", @manager.metadata.step2.key2
+  end
+
+  test "from_h handles nil gracefully" do
+    @manager.metadata["existing"] = "data"
+    @manager.from_h(nil)
+
+    # Should not change existing data
+    assert_equal({ "existing" => "data" }, @manager.to_h)
+  end
+
+  test "metadata maintains nested structure" do
+    @manager.metadata["step1"] = {}
+    @manager.metadata["step1"]["metrics"] = {}
+    @manager.metadata["step1"]["metrics"]["duration_ms"] = 150
+    @manager.metadata["step1"]["metrics"]["api_calls"] = 3
+
+    assert_equal 150, @manager.metadata.step1.metrics.duration_ms
+    assert_equal 3, @manager.metadata.step1.metrics.api_calls
+  end
+
+  test "metadata changes are reflected in to_h" do
+    @manager.metadata["dynamic"] = "initial"
+    assert_equal({ "dynamic" => "initial" }, @manager.to_h)
+
+    @manager.metadata["dynamic"] = "updated"
+    assert_equal({ "dynamic" => "updated" }, @manager.to_h)
+
+    @manager.metadata["new_key"] = "new_value"
+    assert_equal(
+      {
+        "dynamic" => "updated",
+        "new_key" => "new_value",
+      },
+      @manager.to_h,
+    )
+  end
+end

--- a/test/roast/workflow/output_handler_test.rb
+++ b/test/roast/workflow/output_handler_test.rb
@@ -6,6 +6,7 @@ class RoastWorkflowOutputHandlerTest < ActiveSupport::TestCase
   def setup
     @handler = Roast::Workflow::OutputHandler.new
     @workflow = mock("workflow")
+    @workflow.stubs(:metadata).returns({})
   end
 
   def test_save_final_output_saves_when_conditions_met

--- a/test/roast/workflow/step_executor_coordinator_test.rb
+++ b/test/roast/workflow/step_executor_coordinator_test.rb
@@ -9,6 +9,7 @@ module Roast
         @workflow = mock("workflow")
         @workflow.stubs(:output).returns({})
         @workflow.stubs(:verbose).returns(false)
+        @workflow.stubs(:metadata).returns({})
 
         @config_hash = {}
 

--- a/test/roast/workflow/step_executor_with_reporting_test.rb
+++ b/test/roast/workflow/step_executor_with_reporting_test.rb
@@ -9,6 +9,7 @@ module Roast
         @base_executor = mock("base_executor")
         @context = mock("context")
         @workflow = mock("workflow")
+        @workflow.stubs(:metadata).returns({})
         @context_manager = mock("context_manager")
 
         @context.stubs(:workflow).returns(@workflow)

--- a/test/roast/workflow/step_executors/hash_step_executor_test.rb
+++ b/test/roast/workflow/step_executors/hash_step_executor_test.rb
@@ -9,6 +9,7 @@ module Roast
         def setup
           @workflow = mock("workflow")
           @workflow.stubs(:output).returns({})
+          @workflow.stubs(:metadata).returns({})
           @config_hash = {}
           @coordinator = mock("coordinator")
           @workflow_executor = mock("workflow_executor")

--- a/test/roast/workflow/step_executors/parallel_step_executor_test.rb
+++ b/test/roast/workflow/step_executors/parallel_step_executor_test.rb
@@ -8,6 +8,7 @@ module Roast
       class ParallelStepExecutorTest < ActiveSupport::TestCase
         def setup
           @workflow = mock("workflow")
+          @workflow.stubs(:metadata).returns({})
           @coordinator = mock("coordinator")
           @workflow_executor = mock("workflow_executor")
           @workflow_executor.stubs(:workflow).returns(@workflow)

--- a/test/roast/workflow/step_executors/string_step_executor_test.rb
+++ b/test/roast/workflow/step_executors/string_step_executor_test.rb
@@ -8,6 +8,7 @@ module Roast
       class StringStepExecutorTest < ActiveSupport::TestCase
         def setup
           @workflow = mock("workflow")
+          @workflow.stubs(:metadata).returns({})
           @config_hash = {}
           @workflow_executor = mock("workflow_executor")
           @workflow_executor.stubs(:workflow).returns(@workflow)

--- a/test/roast/workflow/targetless_workflow_test.rb
+++ b/test/roast/workflow/targetless_workflow_test.rb
@@ -38,6 +38,7 @@ class RoastWorkflowTargetlessWorkflowTest < ActiveSupport::TestCase
       workflow = mock("workflow")
       workflow.stubs(:output_file).returns(nil)
       workflow.stubs(:final_output).returns("")
+      workflow.stubs(:metadata).returns({})
       workflow.stubs(:session_name).returns("targetless")
       workflow.stubs(:file).returns(nil)
       workflow.stubs(:session_timestamp).returns(nil)

--- a/test/roast/workflow/workflow_context_test.rb
+++ b/test/roast/workflow/workflow_context_test.rb
@@ -7,6 +7,7 @@ module Roast
     class WorkflowContextTest < ActiveSupport::TestCase
       def setup
         @workflow = mock("workflow")
+        @workflow.stubs(:metadata).returns({})
         @config_hash = {
           "step1" => { "exit_on_error" => false },
           "step2" => { "exit_on_error" => true },

--- a/test/roast/workflow/workflow_executor_test.rb
+++ b/test/roast/workflow/workflow_executor_test.rb
@@ -5,10 +5,11 @@ require "test_helper"
 class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
   def setup
     @workflow = mock("workflow")
-    @output = {}
+    @output = Roast::Workflow::DotAccessHash.new({})
     @context_manager = mock("context_manager")
     @context_manager.stubs(:total_tokens).returns(0)
-    @workflow.stubs(output: @output, pause_step_name: nil, verbose: false, storage_type: nil, context_manager: @context_manager)
+    @metadata = Roast::Workflow::DotAccessHash.new({})
+    @workflow.stubs(output: @output, pause_step_name: nil, verbose: false, storage_type: nil, context_manager: @context_manager, metadata: @metadata)
     @config_hash = { "step1" => { "model" => "test-model" } }
     @context_path = "/tmp/test"
     @executor = Roast::Workflow::WorkflowExecutor.new(@workflow, @config_hash, @context_path)

--- a/test/roast/workflow_diagram_generator_test.rb
+++ b/test/roast/workflow_diagram_generator_test.rb
@@ -75,6 +75,7 @@ module Roast
 
     test "generates correct output filename from workflow path" do
       workflow = mock("workflow")
+      workflow.stubs(:metadata).returns({})
       workflow.stubs(:name).returns("Test Workflow")
       workflow.stubs(:steps).returns([])
 
@@ -89,6 +90,7 @@ module Roast
 
     test "generates fallback filename when no path provided" do
       workflow = mock("workflow")
+      workflow.stubs(:metadata).returns({})
       workflow.stubs(:name).returns("Test Workflow!")
       workflow.stubs(:steps).returns([])
 


### PR DESCRIPTION
# Add metadata store for tracking internal execution details

## What changed

- Added `MetadataManager` class to manage workflow metadata separately from user-visible output
- Integrated metadata tracking into `BaseWorkflow` with delegation to the metadata manager
- Created `MetadataAccess` helper module for tools to access metadata via Thread locals
- Updated `StepExecutorCoordinator` to set Thread locals for current step name and workflow metadata
- Extended `StateManager` to persist metadata alongside other workflow state
- Enhanced `ReplayHandler` to restore metadata when replaying workflows
- Added comprehensive test coverage for all new metadata functionality
- Updated many tests to include mock metadata along with their other fixtures
- Additional integration tests for parallel execution and interpolation will be added in a follow-up PR: #321 

## Why

This adds a parallel data structure to workflow output specifically for internal metadata that shouldn't be user-facing.
Tools and steps can now track internal state that should be programmatically available to them between invocations
without polluting the user-visible output. The metadata is automatically persisted and restored during workflow replay,
ensuring consistent behavior across sessions.

## Future considerations

The current implementation uses Thread locals to provide metadata access to tools. This approach was chosen for its simplicity and backward compatibility:

**Pros of Thread locals:**
- Tools can access metadata without changes to their method signatures
- No breaking changes to existing tool interfaces
- Simple implementation that works with the current architecture
- Automatic cleanup when threads complete

**Cons of Thread locals:**
- Implicit state that can be harder to test and debug
- Potential issues in multi-threaded scenarios if not carefully managed
- Less explicit data flow makes the code harder to understand
- Risk of accessing stale data if Thread locals aren't properly cleared

**Alternative architecture for future consideration:**
A more explicit approach would be to pass a context object to all tools that includes both the workflow and metadata references. This would require:
- Updating all tool interfaces to accept a context parameter
- Migrating existing tools to use the new interface
- Potentially supporting both patterns during a transition period

This would make data flow more explicit and testable, but requires more significant changes to the codebase.
