### PR TITLE
Add option for coding agent steps to resume specific session

### DIFF
--- a/lib/roast/tools/coding_agent.rb
+++ b/lib/roast/tools/coding_agent.rb
@@ -89,7 +89,7 @@ module Roast
           # parallel invocations of claude being run in the same working directory.
           session_id = nil
           if continue
-            session_id = workflow_metadata&.dig(current_step_name, "coding_agent_session_id")
+            session_id = step_metadata["coding_agent_session_id"]
           end
 
           # Build the command with continue option (may become resume if session_id exists)

--- a/test/roast/tools/coding_agent_options_test.rb
+++ b/test/roast/tools/coding_agent_options_test.rb
@@ -166,6 +166,34 @@ module Roast
         assert_equal "custom-claude-wrapper --some-flag --model opus", result
       end
 
+      test "build_command adds --resume flag with session_id when continue is true and session_id is provided" do
+        base_command = "claude -p --verbose --output-format stream-json"
+        session_id = "test-session-123"
+        result = CodingAgent.send(:build_command, base_command, continue: true, session_id: session_id)
+        assert_equal "claude --resume test-session-123 -p --verbose --output-format stream-json", result
+      end
+
+      test "build_command adds --continue flag when continue is true but no session_id" do
+        base_command = "claude -p --verbose --output-format stream-json"
+        result = CodingAgent.send(:build_command, base_command, continue: true, session_id: nil)
+        assert_equal "claude --continue -p --verbose --output-format stream-json", result
+      end
+
+      test "build_command handles --resume with non-standard commands" do
+        base_command = "custom-claude-wrapper --some-flag"
+        session_id = "test-session-456"
+        result = CodingAgent.send(:build_command, base_command, continue: true, session_id: session_id)
+        assert_equal "custom-claude-wrapper --some-flag --resume test-session-456", result
+      end
+
+      test "build_command includes both configured options and resume flag" do
+        CodingAgent.configured_options = { model: "opus", temperature: 0.5 }
+        base_command = "claude -p --verbose"
+        session_id = "test-session-789"
+        result = CodingAgent.send(:build_command, base_command, continue: true, session_id: session_id)
+        assert_equal "claude --resume test-session-789 --model opus --temperature 0.5 -p --verbose", result
+      end
+
       test "call uses configured retries as default when not specified" do
         CodingAgent.configured_options = { "retries" => 2 }
         ENV["CLAUDE_CODE_COMMAND"] = "claude --output-format stream-json"


### PR DESCRIPTION
# Add option for coding agent steps to resume specific session

Closes #302 

## What changed
- Added `resume` option to agent steps that allows resuming from a specific previous step's Claude Code session
- Modified CodingAgent tool to check metadata for stored session IDs when `continue: true` is specified
- Updated AgentStep to copy session IDs from referenced steps when using the resume option
- Enhanced CodingAgent to use `--resume <session_id>` flag when a session ID is available, falling back to `--continue` otherwise
- Added session ID persistence by extracting and storing session IDs from Claude Code JSON responses
- Added comprehensive tests for the resume functionality
- Updated README with documentation for the new resume option

## Why
The existing `continue: true` option only continues from the immediately previous Claude Code session, which can be problematic when:
- Multiple Claude Code sessions run in parallel in the same directory
- You want to resume from a specific earlier step rather than the most recent one
- You need more control over which session context to maintain

The resume option provides more precise control by allowing steps to explicitly reference which previous step's session they want to continue from, making workflows more reliable and predictable.

## Architectural Decisions

The implementation leverages the existing `continue` parameter in the CodingAgent tool rather than adding a separate `resume` parameter. This design choice was deliberate:

- **Simplicity of tool use**: The CodingAgent tool can be invoked by any step type, not just agent steps. Steps invoking the tool should not have to think about or track Claude Code session ID. By having the tool use the metadata tore to maintain its session ID state any step type can benefit from elegant session resumption simply by passing `continue: true`.

- **Multiple invocations**: Steps can invoke the CodingAgent tool multiple times. It would not make sense for every tool invocation to resume from the same previous step's session. The desired behavior would be:
  - First invocation: Resume from the previous step's session
  - Subsequent invocations: Continue from the most recent invocation within the current step
  - This is currently a moot point, as only the agent step loads prior session ID metadata, but it is the desirable semantics.
  
- **Separation of concerns**: The agent step handles the high-level logic of copying session IDs from referenced steps, while the CodingAgent tool remains agnostic about where the session ID came from. It simply checks if one exists in the current step's metadata and uses it when `continue: true`. Basically, a smarter form of `continue`.

This architecture elegantly achieves the desired behavior without complicating the tool's interface or requiring callers to manage session IDs directly.

Example workflow using the new functionality:
```yaml
steps:
  - ^analyze_codebase
  - ^implement_feature
  - regular_llm_step
  - ^polish_implementation

analyze_codebase:
  continue: false  # Start fresh

implement_feature:
  continue: true   # Continue from analyze_codebase

polish_implementation:
  resume: analyze_codebase  # Resume from specific earlier step
```
