### PR TITLE
Make timeouts more robust

### DIFF
--- a/lib/roast/tools/bash.rb
+++ b/lib/roast/tools/bash.rb
@@ -17,14 +17,15 @@ module Roast
               "Execute any bash command without restrictions. ⚠️ WARNING: Use only in trusted environments!",
               command: { type: "string", description: "The bash command to execute" },
               timeout: { type: "integer", description: "Timeout in seconds (optional, default: 30)", required: false },
+              use_pgroup: { type: "boolean", description: "Use process group for better cleanup (optional, default: true)", required: false },
             ) do |params|
-              Roast::Tools::Bash.call(params[:command], timeout: params[:timeout])
+              Roast::Tools::Bash.call(params[:command], timeout: params[:timeout], use_pgroup: params[:use_pgroup])
             end
           end
         end
       end
 
-      def call(command, timeout: 30)
+      def call(command, timeout: 30, use_pgroup: true)
         Roast::Helpers::Logger.info("🚀 Executing bash command: #{command}\n")
 
         # Show warning unless explicitly disabled
@@ -36,6 +37,8 @@ module Roast
           "#{command} 2>&1",
           timeout: timeout,
           working_directory: Dir.pwd,
+          use_pgroup: use_pgroup,
+          grace_period: 0.5,
         )
 
         format_output(command, result, exit_status)

--- a/test/roast/helpers/timeout_handler_test.rb
+++ b/test/roast/helpers/timeout_handler_test.rb
@@ -45,7 +45,7 @@ module Roast
         start_time = Time.now
 
         error = assert_raises(Timeout::Error) do
-          @handler.call("sleep 5", timeout: 1)
+          @handler.call("sleep 5", timeout: 1, grace_period: 0.1)
         end
 
         elapsed = Time.now - start_time
@@ -56,7 +56,7 @@ module Roast
       test "timeout error message includes working directory" do
         Dir.mktmpdir do |tmpdir|
           error = assert_raises(Timeout::Error) do
-            @handler.call("sleep 3", timeout: 1, working_directory: tmpdir)
+            @handler.call("sleep 3", timeout: 1, working_directory: tmpdir, grace_period: 0.1)
           end
 
           assert_includes error.message, "sleep 3"
@@ -82,7 +82,7 @@ module Roast
 
         start_time = Time.now
         assert_raises(Timeout::Error) do
-          @handler.call("sleep 10", timeout: 1)
+          @handler.call("sleep 10", timeout: 1, grace_period: 0.1)
         end
         elapsed = Time.now - start_time
 
@@ -103,7 +103,7 @@ module Roast
         10.times do
           start_time = Time.now
           assert_raises(Timeout::Error) do
-            @handler.call("sleep 2", timeout: 1)
+            @handler.call("sleep 2", timeout: 1, grace_period: 0.1)
           end
           elapsed = Time.now - start_time
           assert_operator elapsed, :<, 1.5
@@ -157,7 +157,7 @@ module Roast
         start_time = Time.now
 
         assert_raises(Timeout::Error) do
-          @handler.call("sleep 10", timeout: 1)
+          @handler.call("sleep 10", timeout: 1, grace_period: 0.1)
         end
 
         elapsed = Time.now - start_time
@@ -181,14 +181,17 @@ module Roast
         mock_wait_thr.stubs(:alive?).returns(true)
         mock_wait_thr.stubs(:pid).returns(12345)
 
-        # Mock Process.kill to raise EPERM
-        Process.stubs(:kill).with("TERM", 12345).raises(Errno::EPERM)
+        # Mock Process.kill to raise EPERM (using negative PID for process group)
+        Process.stubs(:kill).with("TERM", -12345).raises(Errno::EPERM)
 
         # Capture debug logs
         Roast::Helpers::Logger.expects(:debug).with("Could not kill process 12345: Permission denied")
 
-        # Call the private cleanup method
-        @handler.send(:cleanup_process, mock_wait_thr)
+        # Call the private cleanup method (default use_pgroup=true)
+        @handler.send(:cleanup_process, mock_wait_thr, true, 0.1)
+
+        # Add assertion to ensure test passes
+        assert true
       end
 
       test "cleanup_process logs debug message for unexpected errors" do
@@ -197,15 +200,18 @@ module Roast
         mock_wait_thr.stubs(:alive?).returns(true)
         mock_wait_thr.stubs(:pid).returns(12345)
 
-        # Mock Process.kill to raise an unexpected error
+        # Mock Process.kill to raise an unexpected error (using negative PID for process group)
         unexpected_error = StandardError.new("Something went wrong")
-        Process.stubs(:kill).with("TERM", 12345).raises(unexpected_error)
+        Process.stubs(:kill).with("TERM", -12345).raises(unexpected_error)
 
         # Capture debug logs
         Roast::Helpers::Logger.expects(:debug).with("Unexpected error during process cleanup: Something went wrong")
 
-        # Call the private cleanup method
-        @handler.send(:cleanup_process, mock_wait_thr)
+        # Call the private cleanup method (default use_pgroup=true)
+        @handler.send(:cleanup_process, mock_wait_thr, true, 0.1)
+
+        # Add assertion to ensure test passes
+        assert true
       end
 
       test "cleanup_process handles ESRCH silently" do
@@ -214,16 +220,132 @@ module Roast
         mock_wait_thr.stubs(:alive?).returns(true)
         mock_wait_thr.stubs(:pid).returns(12345)
 
-        # Mock Process.kill to raise ESRCH (process already terminated)
-        Process.stubs(:kill).with("TERM", 12345).raises(Errno::ESRCH)
+        # Mock Process.kill to raise ESRCH (process already terminated, using negative PID for process group)
+        Process.stubs(:kill).with("TERM", -12345).raises(Errno::ESRCH)
 
         # Should not log anything for ESRCH
         Roast::Helpers::Logger.expects(:debug).never
 
-        # Call the private cleanup method - should not raise
+        # Call the private cleanup method - should not raise (default use_pgroup=true)
         assert_nothing_raised do
-          @handler.send(:cleanup_process, mock_wait_thr)
+          @handler.send(:cleanup_process, mock_wait_thr, true, 0.1)
         end
+      end
+
+      test "call with use_pgroup true spawns process in process group" do
+        # Mock Open3.popen3 to capture the options passed
+        mock_stdin = mock("stdin")
+        mock_stdout = mock("stdout")
+        mock_stderr = mock("stderr")
+        mock_wait_thr = mock("wait_thr")
+        mock_status = mock("status")
+
+        mock_stdin.stubs(:close)
+        mock_stdout.stubs(:read).returns("output")
+        mock_stderr.stubs(:read).returns("")
+        mock_stdout.stubs(:close)
+        mock_stderr.stubs(:close)
+        mock_wait_thr.stubs(:join)
+        mock_wait_thr.stubs(:value).returns(mock_status)
+        mock_status.stubs(:exitstatus).returns(0)
+
+        # Expect pgroup: true in options
+        Open3.expects(:popen3).with("echo test", { chdir: Dir.pwd, pgroup: true })
+          .returns([mock_stdin, mock_stdout, mock_stderr, mock_wait_thr])
+
+        output, exit_status = @handler.call("echo test", use_pgroup: true)
+
+        assert_equal "output", output
+        assert_equal 0, exit_status
+      end
+
+      test "call with use_pgroup false does not use process group" do
+        # Mock Open3.popen3 to capture the options passed
+        mock_stdin = mock("stdin")
+        mock_stdout = mock("stdout")
+        mock_stderr = mock("stderr")
+        mock_wait_thr = mock("wait_thr")
+        mock_status = mock("status")
+
+        mock_stdin.stubs(:close)
+        mock_stdout.stubs(:read).returns("output")
+        mock_stderr.stubs(:read).returns("")
+        mock_stdout.stubs(:close)
+        mock_stderr.stubs(:close)
+        mock_wait_thr.stubs(:join)
+        mock_wait_thr.stubs(:value).returns(mock_status)
+        mock_status.stubs(:exitstatus).returns(0)
+
+        # Expect NO pgroup option in options
+        Open3.expects(:popen3).with("echo test", { chdir: Dir.pwd })
+          .returns([mock_stdin, mock_stdout, mock_stderr, mock_wait_thr])
+
+        output, exit_status = @handler.call("echo test", use_pgroup: false)
+
+        assert_equal "output", output
+        assert_equal 0, exit_status
+      end
+
+      test "cleanup_process with use_pgroup true kills process group" do
+        # Mock a process that needs to be killed
+        mock_wait_thr = mock("wait_thr")
+        mock_wait_thr.stubs(:alive?).returns(true, false) # alive first, then dead after kill
+        mock_wait_thr.stubs(:pid).returns(12345)
+
+        # Expect negative PID (kills process group)
+        Process.expects(:kill).with("TERM", -12345)
+
+        # Call the private cleanup method with pgroup enabled
+        @handler.send(:cleanup_process, mock_wait_thr, true, 0.1)
+      end
+
+      test "cleanup_process with use_pgroup false kills individual process" do
+        # Mock a process that needs to be killed
+        mock_wait_thr = mock("wait_thr")
+        mock_wait_thr.stubs(:alive?).returns(true, false) # alive first, then dead after kill
+        mock_wait_thr.stubs(:pid).returns(12345)
+
+        # Expect positive PID (kills individual process)
+        Process.expects(:kill).with("TERM", 12345)
+
+        # Call the private cleanup method with pgroup disabled
+        @handler.send(:cleanup_process, mock_wait_thr, false, 0.1)
+      end
+
+      test "timeout cleanup uses correct pgroup setting" do
+        # Test that when use_pgroup is false, cleanup_process is called with false
+        # We can't easily mock the private method, so we'll test the behavior indirectly
+        # by checking that the process is killed with positive PID (individual process)
+
+        # Mock a process that will timeout
+        mock_wait_thr = mock("wait_thr")
+        mock_wait_thr.stubs(:alive?).returns(true, true, false) # alive during timeout, alive during cleanup, then dead after kill
+        mock_wait_thr.stubs(:pid).returns(12345)
+
+        # Mock stdin/stdout/stderr
+        mock_stdin = mock("stdin")
+        mock_stdout = mock("stdout")
+        mock_stderr = mock("stderr")
+        mock_stdin.stubs(:close)
+        mock_stdout.stubs(:read).returns("")
+        mock_stderr.stubs(:read).returns("")
+        mock_stdout.stubs(:close)
+        mock_stderr.stubs(:close)
+        mock_wait_thr.stubs(:join).raises(Timeout::Error) # Force timeout
+
+        # Mock Open3.popen3
+        Open3.stubs(:popen3).returns([mock_stdin, mock_stdout, mock_stderr, mock_wait_thr])
+
+        # Expect positive PID kill (individual process, not process group)
+        Process.expects(:kill).with("TERM", 12345) # Positive PID = individual process
+
+        # Should raise timeout error
+        assert_raises(Timeout::Error) do
+          @handler.call("sleep 5", timeout: 0.1, use_pgroup: false, grace_period: 0.1)
+        end
+
+        # Add assertion to ensure test passes
+        assert true
       end
     end
   end

--- a/test/roast/tools/bash_test.rb
+++ b/test/roast/tools/bash_test.rb
@@ -199,7 +199,7 @@ class RoastToolsBashTest < ActiveSupport::TestCase
 
     elapsed = Time.now - start_time
     assert_operator elapsed, :>=, 0.9
-    assert_operator elapsed, :<=, 1.5
+    assert_operator elapsed, :<=, 1.6
   end
 
   test "quick commands complete before timeout" do


### PR DESCRIPTION
- Don't set a MAX_TIMEOUT, we shouldn't assume what type of tasks folks are using the tool for.
- Offer a GRACE_PERIOD between `TERM` and `KILL` to give processes a chance to cleanup children.
- Invoke processes to be timed out with their own pgroup, so we can reliably kill all the child processes regardless of the parent's behaviour. 