### PR TITLE
Add ripgrep check to grep tool

### DIFF
--- a/lib/roast/tools/grep.rb
+++ b/lib/roast/tools/grep.rb
@@ -27,6 +27,10 @@ module Roast
       def call(string)
         Roast::Helpers::Logger.info("🔍 Grepping for string: #{string}\n")
 
+        unless system("command -v rg >/dev/null 2>&1")
+          raise "ripgrep is not available. Please install it using your package manager (e.g., brew install rg) and make sure it's on your PATH."
+        end
+
         # Use Open3 to safely pass the string as an argument, avoiding shell injection
         cmd = ["rg", "-C", "4", "--trim", "--color=never", "--heading", "-F", "--", string, "."]
         stdout, _stderr, _status = Open3.capture3(*cmd)

--- a/test/roast/tools/grep_test.rb
+++ b/test/roast/tools/grep_test.rb
@@ -66,6 +66,17 @@ class RoastToolsGrepTest < ActiveSupport::TestCase
     assert_match(/truncated to 100 lines/, result)
   end
 
+  test "raises error when ripgrep is not installed" do
+    # Mock system call to return false (command not found)
+    stub(:system, false) do
+      error = assert_raises(RuntimeError) do
+        Roast::Tools::Grep.call("ripgrep")
+      end
+
+      assert_match(/ripgrep is not available\./, error.message)
+    end
+  end
+
   test ".included adds function to the base class" do
     base_class = Class.new do
       class << self


### PR DESCRIPTION
Tests were failing because ripgrep was not installed. This adds a hint for the user to install it.

```
% brew remove rg
Uninstalling /opt/homebrew/Cellar/ripgrep/14.1.1... (14 files, 6MB)
% bundle exec rake
....
Finished in 30.431200s, 32.3681 runs/s, 83.1055 assertions/s.

  1) Failure:
RoastToolsGrepTest#test_limits_output_to_MAX_RESULT_LINES [test/roast/tools/grep_test.rb:66]:
Expected /truncated to 100 lines/ to match "Error grepping for string: ripgrep is not available. Please install it using your package manager (e.g., brew install rg) and make sure it's on your PATH.".

  2) Failure:
RoastToolsGrepTest#test_handles_curly_braces_in_search_string [test/roast/tools/grep_test.rb:53]:
Expected /react_file\.js/ to match "Error grepping for string: ripgrep is not available. Please install it using your package manager (e.g., brew install rg) and make sure it's on your PATH.".

  3) Failure:
RoastToolsGrepTest#test_searches_for_string_using_ripgrep [test/roast/tools/grep_test.rb:33]:
Expected /test_file1\.txt/ to match "Error grepping for string: ripgrep is not available. Please install it using your package manager (e.g., brew install rg) and make sure it's on your PATH.".

  4) Failure:
RoastToolsGrepTest#test_handles_errors_gracefully [test/roast/tools/grep_test.rb:42]:
--- expected
+++ actual
@@ -1 +1 @@
-"Error grepping for string: Command failed"
+"Error grepping for string: ripgrep is not available. Please install it using your package manager (e.g., brew install rg) and make sure it's on your PATH."


985 runs, 2529 assertions, 4 failures, 0 errors, 5 skips
...
% brew install rg
...
% bundle exec rake
...
Finished in 30.656391s, 32.1303 runs/s, 82.6908 assertions/s.

985 runs, 2535 assertions, 0 failures, 0 errors, 5 skips
...
%
```