### PR TITLE
Test warning clean up

### DIFF
--- a/lib/roast/tools/grep.rb
+++ b/lib/roast/tools/grep.rb
@@ -27,6 +27,10 @@ module Roast
       def call(string)
         Roast::Helpers::Logger.info("🔍 Grepping for string: #{string}\n")
 
+        unless system("command -v rg >/dev/null 2>&1")
+          raise "ripgrep is not available. Please install it using your package manager (e.g., brew install rg) and make sure it's on your PATH."
+        end
+
         # Use Open3 to safely pass the string as an argument, avoiding shell injection
         cmd = ["rg", "-C", "4", "--trim", "--color=never", "--heading", "-F", "--", string, "."]
         stdout, _stderr, _status = Open3.capture3(*cmd)

--- a/test/roast/tools/grep_test.rb
+++ b/test/roast/tools/grep_test.rb
@@ -66,6 +66,17 @@ class RoastToolsGrepTest < ActiveSupport::TestCase
     assert_match(/truncated to 100 lines/, result)
   end
 
+  test "raises error when ripgrep is not installed" do
+    # Mock system call to return false (command not found)
+    stub(:system, false) do
+      error = assert_raises(RuntimeError) do
+        Roast::Tools::Grep.call("ripgrep")
+      end
+
+      assert_match(/ripgrep is not available\./, error.message)
+    end
+  end
+
   test ".included adds function to the base class" do
     base_class = Class.new do
       class << self

--- a/test/roast/workflow/file_state_repository_test.rb
+++ b/test/roast/workflow/file_state_repository_test.rb
@@ -22,7 +22,6 @@ module Roast
           file: @file,
           session_name: @session_name,
           session_timestamp: nil,
-          object_id: 12345,
         )
         @workflow.stubs(:session_timestamp=)
       end
@@ -147,7 +146,6 @@ module Roast
           file: @file,
           session_name: @session_name,
           session_timestamp: timestamp,
-          object_id: 12345,
         )
         workflow.stubs(:session_timestamp=)
 


### PR DESCRIPTION
1. Multiple `include` calls in `workflow_initializer.rb`; e.g.,
```
/Users/travis/.gem/ruby/ruby-3.4.2/gems/raix-openai-eight-1.0.1/lib/raix/function_dispatch.rb:67: warning: method redefined; discarding old search_for_file
/Users/travis/.gem/ruby/ruby-3.4.2/gems/raix-openai-eight-1.0.1/lib/raix/function_dispatch.rb:67: warning: previous definition of search_for_file was here
```

Called out in #120. 

2. `workflow_initializer_test.rb` was not resetting the `BaseWorkflow` constant between tests.

This was a bit complicated, but the tests ended up coupled between execution. This removes that coupling.
Also changed the assertions from what APIs were called to what is the behavior of the targeted object.
(Behaviors vs. implementation.)

3. `warning: redefining 'object_id' may cause serious problems` warning fixed. Had no impact on the test, so removed.

Doesn't really address #297, but makes some progress towards it. 