### PR TITLE
Revert to standard Raix gem now that OpenAI 8 is supported

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       diff-lcs (~> 1.5)
       json-schema
       open_router (~> 0.3)
-      raix-openai-eight (~> 1.0)
+      raix (~> 1.0.2)
       ruby-graphviz (~> 1.2)
       sqlite3 (~> 2.6)
       thor (~> 1.3)
@@ -99,16 +99,7 @@ GEM
       json (~> 2.0)
       mime-types (~> 3.4)
       rack (< 3)
-    ffi (1.17.2-aarch64-linux-gnu)
-    ffi (1.17.2-aarch64-linux-musl)
-    ffi (1.17.2-arm-linux-gnu)
-    ffi (1.17.2-arm-linux-musl)
     ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86-linux-gnu)
-    ffi (1.17.2-x86-linux-musl)
-    ffi (1.17.2-x86_64-darwin)
-    ffi (1.17.2-x86_64-linux-gnu)
-    ffi (1.17.2-x86_64-linux-musl)
     formatador (1.1.0)
     guard (2.19.1)
       formatador (>= 0.2.4)
@@ -174,7 +165,7 @@ GEM
     racc (1.8.1)
     rack (2.2.17)
     rainbow (3.1.1)
-    raix-openai-eight (1.0.1)
+    raix (1.0.2)
       activesupport (>= 6.0)
       faraday-retry (~> 2.0)
       open_router (~> 0.2)
@@ -212,16 +203,7 @@ GEM
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
     shellany (0.0.1)
-    sqlite3 (2.7.0-aarch64-linux-gnu)
-    sqlite3 (2.7.0-aarch64-linux-musl)
-    sqlite3 (2.7.0-arm-linux-gnu)
-    sqlite3 (2.7.0-arm-linux-musl)
     sqlite3 (2.7.0-arm64-darwin)
-    sqlite3 (2.7.0-x86-linux-gnu)
-    sqlite3 (2.7.0-x86-linux-musl)
-    sqlite3 (2.7.0-x86_64-darwin)
-    sqlite3 (2.7.0-x86_64-linux-gnu)
-    sqlite3 (2.7.0-x86_64-linux-musl)
     thor (1.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -238,16 +220,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  aarch64-linux-gnu
-  aarch64-linux-musl
-  arm-linux-gnu
-  arm-linux-musl
   arm64-darwin
-  x86-linux-gnu
-  x86-linux-musl
-  x86_64-darwin
-  x86_64-linux-gnu
-  x86_64-linux-musl
 
 DEPENDENCIES
   cgi

--- a/roast.gemspec
+++ b/roast.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("diff-lcs", "~> 1.5")
   spec.add_dependency("json-schema")
   spec.add_dependency("open_router", "~> 0.3")
-  spec.add_dependency("raix-openai-eight", "~> 1.0")
+  spec.add_dependency("raix", "~> 1.0.2")
   spec.add_dependency("ruby-graphviz", "~> 1.2")
   spec.add_dependency("sqlite3", "~> 2.6")
   spec.add_dependency("thor", "~> 1.3")


### PR DESCRIPTION
`raix-openai-eight` is no longer necessary, as mainline Raix has now bumped the openai gem. Revert back to the standard gem.