### PR TITLE
Consolidate duplicated pre/post processing code

### DIFF
--- a/lib/roast/workflow/configuration.rb
+++ b/lib/roast/workflow/configuration.rb
@@ -87,6 +87,14 @@ module Roast
         @tool_configs[tool_name.to_s] || {}
       end
 
+      def pre_processing?
+        pre_processing.any?
+      end
+
+      def post_processing?
+        post_processing.any?
+      end
+
       private
 
       attr_reader :api_configuration

--- a/test/roast/workflow/pre_post_processing_test.rb
+++ b/test/roast/workflow/pre_post_processing_test.rb
@@ -109,7 +109,7 @@ module Roast
         runner.stub(:execute_workflow, ->(_workflow) { execution_order << :main_workflow }) do
           runner.stub(:run_pre_processing, -> { execution_order << :pre_processing }) do
             runner.stub(:run_post_processing, -> { execution_order << :post_processing }) do
-              runner.run_targetless
+              runner.begin!
             end
           end
         end
@@ -157,7 +157,7 @@ module Roast
           mock_executor.stubs(:execute_steps)
           mock_executor
         }) do
-          runner.run_for_targets
+          runner.begin!
         end
 
         # Verify workflows were executed for each file
@@ -235,7 +235,7 @@ module Roast
 
           mock_executor
         }) do
-          output = capture_io { runner.run_for_targets }
+          output = capture_io { runner.begin! }
 
           # Check that the template was applied
           assert_match(/=== Post-Processing Summary ===/, output[0])
@@ -285,7 +285,7 @@ module Roast
           mock_executor.stubs(:execute_steps)
           mock_executor
         }) do
-          output = capture_io { runner.run_for_targets }
+          output = capture_io { runner.begin! }
 
           # Verify all phases were executed in order
           assert_equal 3, execution_phases.size

--- a/test/roast/workflow/workflow_runner_test.rb
+++ b/test/roast/workflow/workflow_runner_test.rb
@@ -28,10 +28,10 @@ class RoastWorkflowRunnerTest < ActiveSupport::TestCase
     File.write(file2, "# File 2")
     files = [file1, file2]
 
-    runner = Roast::Workflow::WorkflowRunner.new(@workflow_path)
+    runner = Roast::Workflow::WorkflowRunner.new(@workflow_path, files)
     # Run and verify output
     assert_output(nil, /Running workflow for file: #{Regexp.escape(file1)}.*Running workflow for file: #{Regexp.escape(file2)}.*ROAST COMPLETE!/m) do
-      runner.run_for_files(files)
+      runner.begin!
     end
   end
 
@@ -45,14 +45,14 @@ class RoastWorkflowRunnerTest < ActiveSupport::TestCase
         - step1: $(echo "Step 1")
     YAML
 
-    runner = Roast::Workflow::WorkflowRunner.new(@workflow_path, { output: "/tmp/output.txt", verbose: true })
-
     file1 = File.join(@tmpdir, "file1.rb")
     File.write(file1, "# File 1")
     files = [file1]
 
+    runner = Roast::Workflow::WorkflowRunner.new(@workflow_path, files, { output: "/tmp/output.txt", verbose: true })
+
     assert_output(nil, /WARNING: Ignoring target parameter.*ignored_target\.rb/) do
-      runner.run_for_files(files)
+      runner.begin!
     end
   end
 
@@ -74,7 +74,7 @@ class RoastWorkflowRunnerTest < ActiveSupport::TestCase
 
     runner = Roast::Workflow::WorkflowRunner.new(@workflow_path, @options)
 
-    output = capture_io { runner.run_for_targets }
+    output = capture_io { runner.begin! }
     # The target appears as a single line with both files
     assert_match(/Running workflow for file:/, output.join)
     assert_match(/ROAST COMPLETE!/, output.join)
@@ -83,7 +83,7 @@ class RoastWorkflowRunnerTest < ActiveSupport::TestCase
   def test_run_targetless_creates_workflow_with_nil_file
     runner = Roast::Workflow::WorkflowRunner.new(@workflow_path)
     assert_output(nil, /Running targetless workflow.*ROAST COMPLETE!/m) do
-      runner.run_targetless
+      runner.begin!
     end
   end
 


### PR DESCRIPTION
The pre/post processing blocks are the same for all step types, extract from the `run*` methods.