### PR TITLE
Shorten error output unless in verbose mode

### DIFF
--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -69,6 +69,12 @@ module Roast
       raise Thor::Error, "Expected a Roast workflow configuration file, got directory: #{expanded_workflow_path}" if File.directory?(expanded_workflow_path)
 
       Roast::Workflow::WorkflowRunner.new(expanded_workflow_path, files, options.transform_keys(&:to_sym)).begin!
+    rescue => e
+      if options[:verbose]
+        raise e
+      else
+        $stderr.puts e.message
+      end
     end
 
     desc "resume WORKFLOW_FILE", "Resume a paused workflow with an event"


### PR DESCRIPTION
Errors in Roast default to dumping the entire exception. This PR changes the default to be the error message. The full exception is visible in verbose mode (`-v`).