### PR TITLE
Bump remaining files to typed true

### DIFF
--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -14,6 +14,7 @@ require "pathname"
 require "securerandom"
 require "shellwords"
 require "tempfile"
+require "timeout"
 require "uri"
 require "yaml"
 

--- a/lib/roast/helpers/logger.rb
+++ b/lib/roast/helpers/logger.rb
@@ -5,25 +5,21 @@ module Roast
   module Helpers
     # Central logger for the Roast application
     class Logger
-      VALID_LOG_LEVELS = ["DEBUG", "INFO", "WARN", "ERROR", "FATAL"].freeze
+      VALID_LOG_LEVELS = ["DEBUG", "INFO", "WARN", "ERROR", "FATAL"].freeze #: Array[String]
 
-      delegate_missing_to :@logger
+      delegate :debug, :info, :warn, :error, :fatal, to: :@logger
 
       attr_reader :logger
 
       class << self
-        delegate_missing_to :instance
+        delegate :debug, :info, :warn, :error, :fatal, to: :@instance
 
+        #: -> Roast::Helpers::Logger
         def instance
           @instance ||= new
         end
 
-        # Override Kernel#warn to ensure proper delegation
-        def warn(*args)
-          instance.warn(*args)
-        end
-
-        # For testing purposes
+        #: -> void
         def reset
           @instance = nil
         end

--- a/lib/roast/helpers/prompt_loader.rb
+++ b/lib/roast/helpers/prompt_loader.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Roast
@@ -59,7 +59,7 @@ module Roast
         glob_pattern = File.join(context_dir, "{#{base_name},prompt}.*+*.md")
         Dir.glob(glob_pattern).each do |combined_path|
           basename = File.basename(combined_path, ".md")
-          combined_exts = basename.split(".", 2)[1].split("+")
+          combined_exts = basename.split(".", 2)[1]&.split("+")
 
           # Return the first matching combined format
           return combined_path if extensions.intersect?(combined_exts)
@@ -78,7 +78,7 @@ module Roast
 
         if file_basename.end_with?(".md") && file_basename.count(".") > 1
           without_md = file_basename[0...-3] # Remove .md
-          without_md.split(".", 2)[1]&.split("+") || []
+          without_md&.split(".", 2)&.[](1)&.split("+") || []
         else
           ext = File.extname(target_file)[1..]
           ext&.empty? ? [] : [ext]

--- a/lib/roast/helpers/timeout_handler.rb
+++ b/lib/roast/helpers/timeout_handler.rb
@@ -1,8 +1,5 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
-
-require "timeout"
-require "open3"
 
 module Roast
   module Helpers
@@ -30,8 +27,8 @@ module Roast
         def call(command, timeout: DEFAULT_TIMEOUT, working_directory: Dir.pwd)
           timeout = validate_timeout(timeout)
           output = ""
-          exit_status = nil
-          wait_thr = nil
+          exit_status = nil #: Integer?
+          wait_thr = nil #: Process::Waiter?
 
           begin
             Timeout.timeout(timeout) do

--- a/lib/roast/initializers.rb
+++ b/lib/roast/initializers.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Roast

--- a/lib/roast/tools.rb
+++ b/lib/roast/tools.rb
@@ -1,7 +1,8 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Roast
+  # @requires_ancestor: Kernel
   module Tools
     extend self
 

--- a/lib/roast/workflow_diagram_generator.rb
+++ b/lib/roast/workflow_diagram_generator.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Roast
@@ -75,7 +75,7 @@ module Roast
       when Hash
         process_control_flow(step)
       else
-        ::CLI::Kit.logger.warn("Unexpected step type in workflow diagram: #{step.class} - #{step.inspect}")
+        Roast::Helpers::Logger.warn("Unexpected step type in workflow diagram: #{step.class} - #{step.inspect}")
         nil
       end
     end
@@ -113,7 +113,7 @@ module Roast
       elsif control_flow.key?("case")
         process_case(control_flow)
       else
-        ::CLI::Kit.logger.warn("Unexpected control flow structure in workflow diagram: #{control_flow.keys.join(", ")}")
+        Roast::Helpers::Logger.warn("Unexpected control flow structure in workflow diagram: #{control_flow.keys.join(", ")}")
         nil
       end
     end

--- a/sorbet/config
+++ b/sorbet/config
@@ -4,3 +4,5 @@
 --ignore=vendor/
 --ignore=test/
 --ignore=bin/
+--enable-experimental-requires-ancestor
+--enable-experimental-rbs-comments


### PR DESCRIPTION
33 files remain with type errors - this PR cleans up the remaining issues that prevent bumping to `typed: true`.