### PR TITLE
Do a normal sigint on SIGINT

### DIFF
--- a/lib/roast/tools.rb
+++ b/lib/roast/tools.rb
@@ -31,7 +31,9 @@ module Roast
       Signal.trap("INT") do
         puts "\n\nCaught CTRL-C! Printing before exiting:\n"
         puts JSON.pretty_generate(object_to_inspect)
-        exit(1)
+
+        Signal.trap("INT", "DEFAULT")
+        Process.kill("INT", Process.pid)
       end
     end
 


### PR DESCRIPTION
Instead of doing an exit(1) on sigint, just point the TERM trap back to the default handler and SIGINT the process again.

Towards: https://github.com/Shopify/roast/issues/363