### PR TITLE
Define Ruby DSL executor

### DIFF
--- a/dsl/simple.rb
+++ b/dsl/simple.rb
@@ -1,0 +1,10 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Executor
+
+# This is a dead simple workflow that calls two shell scripts
+shell <<~SHELLSTEP
+  echo "I have no idea what's going on"
+SHELLSTEP
+shell "pwd"

--- a/lib/roast/dsl.rb
+++ b/lib/roast/dsl.rb
@@ -1,0 +1,7 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+  end
+end

--- a/lib/roast/dsl/executor.rb
+++ b/lib/roast/dsl/executor.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    class Executor
+      class << self
+        def from_file(workflow_path)
+          execute(File.read(workflow_path))
+        end
+
+        private
+
+        def execute(input)
+          new.instance_eval(input)
+        end
+      end
+
+      # Define methods to be used in workflows below.
+
+      def shell(command_string)
+        puts %x(#{command_string})
+      end
+    end
+  end
+end

--- a/test/roast/dsl/executor_test.rb
+++ b/test/roast/dsl/executor_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module DSL
+    class ExecutorTest < ActiveSupport::TestCase
+      test "from_file creates executor and evaluates workflow file" do
+        workflow_content = <<~RUBY
+          shell "echo 'test workflow'"
+        RUBY
+
+        Tempfile.create do |file|
+          file.write(workflow_content)
+          file.close
+
+          output, _err = capture_io do
+            Executor.from_file(file.path)
+          end
+
+          assert_match(/test workflow/, output)
+        end
+      end
+
+      test "workflow can chain multiple shell commands" do
+        workflow_content = <<~RUBY
+          shell "echo 'First'"
+          shell "echo 'Second'"
+          shell "echo 'Third'"
+        RUBY
+
+        Tempfile.create(["test_workflow", ".rb"]) do |file|
+          file.write(workflow_content)
+          file.close
+
+          output, _err = capture_io do
+            Executor.from_file(file.path)
+          end
+
+          lines = output.split("\n")
+          assert_equal("First", lines[0])
+          assert_equal("Second", lines[1])
+          assert_equal("Third", lines[2])
+        end
+      end
+
+      test "from_file raises error when file does not exist" do
+        assert_raises(Errno::ENOENT) do
+          Executor.from_file("/non/existent/file.rb")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add basic executor for a Ruby DSL. Further steps will be defined in the executor (such as agent definitions and step type inference as with the current yml standard).

This basic version lets us start iterating on the DSL design ([notes from earlier whiteboarding](https://github.com/Shopify/roast/blob/incubate-ruby-dsl/dsl.md?plain=1) with @juniper-shopify and @nfgrep). Nobody should use this yet, which is why it's hidden behind an explicit flag.

With `--executor=dsl`
<img width="687" height="168" alt="Screenshot 2025-08-19 at 10 22 12 AM" src="https://github.com/user-attachments/assets/eec3318f-3926-4a96-8f90-0a631a6ae0d7" />
