### PR TITLE
Add tests for `roast list`

### DIFF
--- a/examples/user_input/funny_name/workflow.yml
+++ b/examples/user_input/funny_name/workflow.yml
@@ -1,6 +1,5 @@
 name: funny_name_backstory
 description: Create a humorous backstory based on your name
-model: anthropic:claude-3-5-sonnet
 
 steps:
   # Collect user's name
@@ -8,7 +7,7 @@ steps:
       prompt: "What's your name?"
       name: user_name
       required: true
-  
+
   # Ask for preferences
   - input:
       prompt: "Pick a genre for your backstory:"
@@ -21,6 +20,6 @@ steps:
         - "Victorian-Era Vampire Hunter"
         - "Professional Cat Whisperer"
       name: genre
-  
+
   # Generate the backstory
   - create_backstory

--- a/test/functional/list_test.rb
+++ b/test/functional/list_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ListTest < FunctionalTest
+  test "lists workflows visible to roast" do
+    in_sandbox(with_workflow: :simple) do
+      assert_output Regexp.new(Regexp.escape("simple (from project)")) do
+        roast("list")
+      end
+    end
+  end
+
+  test "outputs error if no roast directory found" do
+    assert_cli_error(%r{No roast/ directory found in current path}) do
+      roast("list")
+    end
+  end
+
+  test "outputs error if no workflow files found" do
+    assert_cli_error(%r{No workflow.yml files found in roast/ directory}) do
+      in_sandbox do
+        roast("list")
+      end
+    end
+  end
+end

--- a/test/functional/version_test.rb
+++ b/test/functional/version_test.rb
@@ -4,8 +4,8 @@ require "test_helper"
 
 class VersionTest < FunctionalTest
   test "outputs the current version number" do
-    result = roast(["version"])
-
-    assert_match Regexp.new("Roast version #{Roast::VERSION}"), result.output
+    assert_output Regexp.new("Roast version #{Roast::VERSION}") do
+      roast("version")
+    end
   end
 end

--- a/test/support/functional_test.rb
+++ b/test/support/functional_test.rb
@@ -1,21 +1,48 @@
 # frozen_string_literal: true
 
 class FunctionalTest < ActiveSupport::TestCase
-  class ExecutionResult
-    attr_reader :output
-    attr_reader :error
+  def roast(*args)
+    # debug=true allows us to capture error messages in tests
+    Roast::CLI.start(args, { debug: true })
+  end
 
-    def initialize(output, error)
-      @output = output
-      @error = error
+  # Set up a roast directory structure.
+  # with_workflow will create the workflow defined in Workflows.:name
+  def in_sandbox(with_workflow: nil)
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do |dir|
+        roastdir = File.join(dir, "roast")
+        Dir.mkdir(roastdir)
+
+        Dir.chdir(roastdir) do
+          Workflows.build(with_workflow, roastdir) if with_workflow
+        end
+
+        yield
+      end
     end
   end
 
-  def roast(args = [])
-    output, err = capture_io do
-      Roast::CLI.start(args)
-    end
+  def assert_cli_error(match, &block)
+    assert_raises(Thor::Error, match:, &block)
+  end
 
-    ExecutionResult.new(output, err)
+  # Set up workflow files and paths
+  class Workflows
+    class << self
+      def build(name, path)
+        Dir.mkdir(name.to_s)
+        File.write(File.join(path, name.to_s, "workflow.yml"), send(name))
+      end
+
+      def simple
+        <<~YAML
+          name: Basic Command Functions
+
+          steps:
+            - print_dir: "$(pwd)"
+        YAML
+      end
+    end
   end
 end


### PR DESCRIPTION
Write functional tests for `roast list` as an excuse to figure out some test helpers.

Closes https://github.com/Shopify/roast/issues/376

This test demonstrates how to write functional tests for Roast.

- `in_sandbox` shifts execution into an automatically cleaned up temp directory, with the option to create a workflow file. 
- Extensive definitions of yaml and other supporting files can be set up in `FunctionalTest::Workflows`.
- `assert_cli_error` to validate error message output on exit.