### PR TITLE
Add basic functional test for `roast execute`

### DIFF
--- a/test/functional/execute_test.rb
+++ b/test/functional/execute_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ExecuteTest < FunctionalTest
+  test "error if no workflow configuration provided" do
+    error_message = /Workflow configuration file is required/
+    assert_output(nil, error_message) do
+      roast("execute")
+    end
+  end
+
+  test "raised error bubbles out in verbose mode" do
+    assert_raises(Thor::Error) do
+      roast("execute", "-v")
+    end
+  end
+
+  test "simple workflow with command" do
+    _, err = in_sandbox(with_workflow: :simple) do
+      roast("execute", "simple")
+      assert(File.exist?("step_output.txt"))
+      assert_equal("Hello world! I am roast!", File.read("step_output.txt").strip)
+    end
+
+    assert_match(/Executing: hello_world/, err)
+  end
+end

--- a/test/functional/list_test.rb
+++ b/test/functional/list_test.rb
@@ -4,11 +4,11 @@ require "test_helper"
 
 class ListTest < FunctionalTest
   test "lists workflows visible to roast" do
-    in_sandbox(with_workflow: :simple) do
-      assert_output Regexp.new(Regexp.escape("simple (from project)")) do
-        roast("list")
-      end
+    output, _ = in_sandbox(with_workflow: :simple) do
+      roast("list")
     end
+
+    assert_match Regexp.new(Regexp.escape("simple (from project)")), output
   end
 
   test "outputs error if no roast directory found" do

--- a/test/support/functional_test.rb
+++ b/test/support/functional_test.rb
@@ -8,17 +8,21 @@ class FunctionalTest < ActiveSupport::TestCase
 
   # Set up a roast directory structure.
   # with_workflow will create the workflow defined in Workflows.:name
+  # Returns an array of strings [stdio_output, stderr_output]
   def in_sandbox(with_workflow: nil)
-    Dir.mktmpdir do |dir|
-      Dir.chdir(dir) do |dir|
-        roastdir = File.join(dir, "roast")
-        Dir.mkdir(roastdir)
+    capture_io do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do |dir|
+          Dir.mkdir(".roast")
+          roastdir = File.join(dir, "roast")
+          Dir.mkdir(roastdir)
 
-        Dir.chdir(roastdir) do
-          Workflows.build(with_workflow, roastdir) if with_workflow
+          Dir.chdir(roastdir) do
+            Workflows.build(with_workflow, roastdir) if with_workflow
+          end
+
+          yield
         end
-
-        yield
       end
     end
   end
@@ -37,10 +41,14 @@ class FunctionalTest < ActiveSupport::TestCase
 
       def simple
         <<~YAML
-          name: Basic Command Functions
+          name: Simple workflow
 
           steps:
-            - print_dir: "$(pwd)"
+            - hello_world: >
+                $(echo 'Hello world! I am roast!' > step_output.txt)
+
+          hello_world:
+            print_response: true
         YAML
       end
     end


### PR DESCRIPTION
Part 1 of https://github.com/Shopify/roast/issues/381

This is the absolute basic functional test. Define a workflow, call a step, verify the step did something.

`in_sandbox` now automatically captures output from stdout and stderr, which should prevent the output spam that we get in the main test suite.