### PR TITLE
Copy example workflows in test sandboxes

### DIFF
--- a/test/support/functional_test.rb
+++ b/test/support/functional_test.rb
@@ -10,16 +10,23 @@ class FunctionalTest < ActiveSupport::TestCase
   # with_workflow will create the workflow defined in Workflows.:name
   # Returns an array of strings [stdio_output, stderr_output]
   def in_sandbox(with_workflow: nil)
+    # have to save our current working directory before entering sandbox
+    candidate_example_path = File.join(Dir.pwd, "examples", with_workflow.to_s)
+
     capture_io do
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do |dir|
           Dir.mkdir(".roast")
-          roastdir = File.join(dir, "roast")
-          Dir.mkdir(roastdir)
+          workflow_directory = File.join(dir, "roast")
+          Dir.mkdir(workflow_directory)
 
-          Dir.chdir(roastdir) do
-            Workflows.build(with_workflow, roastdir) if with_workflow
-          end
+          Dir.chdir(workflow_directory) do
+            if File.exist?(candidate_example_path)
+              FileUtils.cp_r(candidate_example_path, with_workflow.to_s)
+            else
+              Workflows.build(with_workflow, workflow_directory)
+            end
+          end if with_workflow
 
           yield
         end
@@ -38,6 +45,8 @@ class FunctionalTest < ActiveSupport::TestCase
         Dir.mkdir(name.to_s)
         File.write(File.join(path, name.to_s, "workflow.yml"), send(name))
       end
+
+      private
 
       def simple
         <<~YAML


### PR DESCRIPTION
Adds an easy way to import workflow examples from the project `examples/` directory when using the `in_sandbox` test function. If the symbol passed to `with_workflow` matches a directory in `examples/`, the entire example will be copied into the `roast` directory in the sandbox.

This allows us to validate our examples via testing. If a feature would break an example, tests will fail.

Additionally, testing the examples by definition is testing features we care about and expose to users, in the way we expect them to be used.

Examples can be tested as follows:

```ruby
  test "example LLM workflow" do
    in_sandbox with_workflow: :apply_diff_demo do
      roast("execute", "apply_diff_demo")
    end
  end
```