### PR TITLE
Run CI tasks separately

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rake ci
+      - run: bundle exec rake minitest_old
+      - run: bundle exec rake minitest_functional
+      - run: bundle exec rake rubocop_ci
       - run: bin/srb tc
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,11 +16,15 @@ Rake::TestTask.new(:minitest_functional) do |t|
   t.test_files = FileList["test/functional/**/*_test.rb"]
 end
 
+Rake::TestTask.new(:minitest_old) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/functional/**/*_test.rb"]
+end
+
 task test: [:minitest_all]
 
 RuboCop::RakeTask.new(:rubocop_ci)
-
-task ci: [:test, :rubocop_ci]
 
 RuboCop::RakeTask.new(:rubocop) do |task|
   task.options = ["--autocorrect"]


### PR DESCRIPTION
There's some state pollution in the test suites when running both default and functional tests. Split them on CI for now to prevent pollution between the two approaches until we can investigate and fix.