### PR TITLE
Output VCR result when recording

### DIFF
--- a/test/support/functional_test.rb
+++ b/test/support/functional_test.rb
@@ -71,7 +71,8 @@ class FunctionalTest < ActiveSupport::TestCase
     out.gsub!(path_regex, "/fake-testing-dir")
     err.gsub!(path_regex, "/fake-testing-dir")
 
-    if ENV["PRINT_OUTPUT"]
+    if ENV["RECORD_VCR"]
+      puts "Workflow result recorded with VCR, use this for assertions:"
       puts out
     end
 


### PR DESCRIPTION
We need the workflow output when recording VCR cassettes. This will check the env variable and output the result to be used when writing test assertions.