### PR TITLE
refactor(base_step): use workflow/steploader default model

### DIFF
--- a/lib/roast/workflow/base_step.rb
+++ b/lib/roast/workflow/base_step.rb
@@ -10,10 +10,9 @@ module Roast
       delegate :append_to_final_output, :transcript, to: :workflow
       delegate_missing_to :workflow
 
-      # TODO: is this really the model we want to default to, and is this the right place to set it?
-      def initialize(workflow, model: "anthropic:claude-opus-4", name: nil, context_path: nil)
+      def initialize(workflow, model: nil, name: nil, context_path: nil)
         @workflow = workflow
-        @model = model
+        @model = model || workflow.model || StepLoader::DEFAULT_MODEL
         @name = normalize_name(name)
         @context_path = context_path || ContextPathResolver.resolve(self.class)
         @print_response = false

--- a/lib/roast/workflow/step_loader.rb
+++ b/lib/roast/workflow/step_loader.rb
@@ -208,8 +208,8 @@ module Roast
       def configure_step(step, step_name, is_last_step: nil)
         step_config = config_hash[step_name]
 
-        # Always set the model
-        step.model = determine_model(step_config)
+        # Only set the model if explicitly specified for this step
+        step.model = step_config["model"] if step_config&.key?("model")
 
         # Pass resource to step if supported
         step.resource = workflow.resource if step.respond_to?(:resource=)
@@ -221,11 +221,6 @@ module Roast
         if is_last_step && !step_config&.key?("print_response")
           step.print_response = true
         end
-      end
-
-      # Determine which model to use for the step
-      def determine_model(step_config)
-        step_config&.dig("model") || config_hash["model"] || DEFAULT_MODEL
       end
 
       # Apply configuration settings to a step

--- a/test/roast/workflow/base_step_test.rb
+++ b/test/roast/workflow/base_step_test.rb
@@ -16,7 +16,7 @@ class RoastWorkflowBaseStepTest < ActiveSupport::TestCase
 
   test "initialize sets workflow and default model" do
     assert_equal @workflow, @step.workflow
-    assert_equal "anthropic:claude-opus-4", @step.model
+    assert_equal Roast::Workflow::StepLoader::DEFAULT_MODEL, @step.model
   end
 
   test "initialize accepts custom model" do

--- a/test/roast/workflow/step_loader_test.rb
+++ b/test/roast/workflow/step_loader_test.rb
@@ -100,7 +100,9 @@ module Roast
       end
 
       def test_uses_workflow_default_model
-        @config_hash["model"] = "workflow-default"
+        # With StepLoader no longer setting defaults from config_hash,
+        # the workflow-level default should be respected.
+        @workflow.model = "workflow-default"
 
         step = @step_loader.load("test")
 
@@ -111,6 +113,14 @@ module Roast
         step = @step_loader.load("test")
 
         assert_equal(StepLoader::DEFAULT_MODEL, step.model)
+      end
+
+      def test_step_model_override_workflow_model
+        @workflow.model = "workflow-default"
+        @config_hash["test"] = { "model" => "custom-model" }
+        step = @step_loader.load("test")
+
+        assert_equal("custom-model", step.model)
       end
 
       def test_applies_step_configuration


### PR DESCRIPTION
Summary
- Remove hardcoded default "anthropic:claude-opus-4".
- Model resolution: explicit param → workflow.model → StepLoader::DEFAULT_MODEL ("gpt-4o-mini").
- Remove default model in StepLoader
