### PR TITLE
Fix README examples for input steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,20 +374,24 @@ Roast supports several types of steps:
     ```yaml
     steps:
       - analyze_code
-      - get_user_feedback:
+      - input:
+          name: get_user_feedback
           prompt: "Should we proceed with the refactoring? (yes/no)"
           type: confirm
-      - review_changes:
+      - input:
+          name: review_changes
           prompt: "Enter your review comments"
           type: text
-      - select_strategy:
+      - input:
+          name: select_strategy
           prompt: "Choose optimization strategy"
           type: select
           options:
             - "Performance optimization"
             - "Memory optimization"
             - "Code clarity"
-      - api_configuration:
+      - input:
+          name: api_configuration
           prompt: "Enter API key"
           type: password
     ```

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Roast supports several types of steps:
       - input:
           name: select_strategy
           prompt: "Choose optimization strategy"
-          type: select
+          type: choice
           options:
             - "Performance optimization"
             - "Memory optimization"


### PR DESCRIPTION
The examples for input steps seem to have incorrect syntax that will call the model instead of prompting the user for input.

Closes https://github.com/Shopify/roast/issues/409