### PR TITLE
DSL: passing output data between steps

### DIFF
--- a/dsl/step_communication.rb
+++ b/dsl/step_communication.rb
@@ -1,0 +1,18 @@
+# typed: false
+# frozen_string_literal: true
+
+# How do we pass information between steps?
+# Demonstrate by passing result of a command output to another step
+
+config do
+  cmd(:echo) { display! }
+end
+
+execute do
+  cmd(:ls) { "ls -al" }
+  cmd(:echo) do
+    # TODO: this is a bespoke output object for cmd, is there a generic one we can offer
+    first_line = cmd(:ls).command_output.split("\n").second
+    "echo '#{first_line}'"
+  end
+end

--- a/lib/roast/dsl/cog/store.rb
+++ b/lib/roast/dsl/cog/store.rb
@@ -7,10 +7,7 @@ module Roast
       class Store
         class CogAlreadyDefinedError < Roast::Error; end
 
-        #: (Symbol) -> Roast::DSL::Cog?
-        def find(id)
-          store[id]
-        end
+        delegate :[], to: :store
 
         #: (Symbol, Roast::DSL::Cog) -> Roast::DSL::Cog
         def insert(id, inst)

--- a/lib/roast/dsl/cog_execution_context.rb
+++ b/lib/roast/dsl/cog_execution_context.rb
@@ -1,0 +1,29 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    # Contains the cogs already executed in this run.
+    class CogExecutionContext
+      # Raises if you access a cog in an execution block that hasn't already been run.
+      class IncompleteCogExecutionAccessError < StandardError; end
+
+      def initialize(cogs, bound_names)
+        @cogs = cogs
+        bind_cog_methods(bound_names)
+      end
+
+      private
+
+      def bind_cog_methods(bound_names)
+        bound_names.map do |name|
+          define_singleton_method(name.to_sym, ->(name) do
+            @cogs[name].tap do |cog|
+              raise IncompleteCogExecutionAccessError unless cog.ran?
+            end.output
+          end)
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -7,7 +7,7 @@ module Roast
       class Cmd < Cog
         class Output
           #: String?
-          attr_reader :output
+          attr_reader :command_output
 
           #: String?
           attr_reader :err
@@ -21,7 +21,7 @@ module Roast
           #|  Process::Status? status
           #| ) -> void
           def initialize(output, error, status)
-            @output = output
+            @command_output = output
             @err = error
             @status = status
           end
@@ -37,12 +37,16 @@ module Roast
           def print_all?
             !!@values[:print_all]
           end
+
+          def display!
+            print_all!
+          end
         end
 
-        #: () -> Output
-        def execute
+        #: (String) -> Output
+        def execute(input)
           result = Output.new(*Roast::Helpers::CmdRunner.capture3(input))
-          puts result.output if @config.print_all?
+          puts result.command_output if @config.print_all?
           result
         end
       end

--- a/lib/roast/dsl/executor.rb
+++ b/lib/roast/dsl/executor.rb
@@ -32,7 +32,7 @@ module Roast
 
         @config_context = ConfigContext.new(@cogs, @config_proc)
         @config_context.prepare!
-        @execution_context = ExecutionContext.new(@cogs, @cog_stack, @execution_proc)
+        @execution_context = WorkflowExecutionContext.new(@cogs, @cog_stack, @execution_proc)
         @execution_context.prepare!
 
         @prepared = true
@@ -44,7 +44,10 @@ module Roast
         raise ExecutorAlreadyCompletedError if @completed
 
         @cog_stack.map do |name, cog|
-          cog.run!(@config_context.fetch_merged_config(cog.class, name.to_sym))
+          cog.run!(
+            @config_context.fetch_merged_config(cog.class, name.to_sym),
+            @execution_context.cog_execution_context,
+          )
         end
 
         @completed = true
@@ -63,7 +66,7 @@ module Roast
         @config_proc = block
       end
 
-      #: { () [self: ExecutionContext] -> void} -> void
+      #: { () [self: WorkflowExecutionContext] -> void} -> void
       def execute(&block)
         @execution_proc = block
       end

--- a/sorbet/rbi/shims/lib/roast/dsl/workflow_execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/workflow_execution_context.rbi
@@ -3,7 +3,7 @@
 
 module Roast
   module DSL
-    class ExecutionContext
+    class WorkflowExecutionContext
       #: (?Symbol?) {() [self: Roast::DSL::Cogs::Cmd] -> String} -> void
       def cmd(name = nil, &block); end
     end


### PR DESCRIPTION
More context rebinding shenanigans. Inside of a cog level execution block, `cmd(:ls)` returns the output object from executing that cog.

If the cog has not yet run, it will error, preventing access of cog output before you could possibly have it.

Added a `CogExecutionContext` to provide the execution environment for this purpose, and renamed the previous `ExecutionContext` to `WorkflowExecutionContext` to reflect its higher level purpose.