### PR TITLE
Set up typechecking for DSL blocks

### DIFF
--- a/dsl/prototype.rb
+++ b/dsl/prototype.rb
@@ -1,5 +1,7 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
+
+#: self as Roast::DSL::Executor
 
 config do
   cmd(:echo) { print_all! }

--- a/lib/roast/dsl/cog/config.rb
+++ b/lib/roast/dsl/cog/config.rb
@@ -15,8 +15,15 @@ module Roast
           self.class.new(values.merge(config_object.values))
         end
 
-        def configure!(&block)
-          instance_exec(&block)
+        # It is recommended to implement a custom config object for a nicer interface,
+        # but for simple cases where it would just be a key value store we provide one by default.
+
+        def []=(key, value)
+          @values[key] = value
+        end
+
+        def [](key)
+          @values[key]
         end
       end
     end

--- a/lib/roast/dsl/config_context.rb
+++ b/lib/roast/dsl/config_context.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Roast

--- a/lib/roast/dsl/execution_context.rb
+++ b/lib/roast/dsl/execution_context.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Roast

--- a/lib/roast/dsl/executor.rb
+++ b/lib/roast/dsl/executor.rb
@@ -58,10 +58,12 @@ module Roast
         @completed ||= false
       end
 
+      #: { () [self: ConfigContext] -> void} -> void
       def config(&block)
         @config_proc = block
       end
 
+      #: { () [self: ExecutionContext] -> void} -> void
       def execute(&block)
         @execution_proc = block
       end

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -1,0 +1,11 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    class ConfigContext
+      #: (?Symbol?) {() [self: Roast::DSL::Cogs::Cmd::Config] -> void} -> void
+      def cmd(name = nil, &block); end
+    end
+  end
+end

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -1,0 +1,11 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    class ExecutionContext
+      #: (?Symbol?) {() [self: Roast::DSL::Cogs::Cmd] -> String} -> void
+      def cmd(name = nil, &block); end
+    end
+  end
+end


### PR DESCRIPTION
Second part of new Roast architecture. Sorbet typechecking will be used as a way to statically validate Roast workflows. Between Ruby syntax checking and Sorbet static analysis, we should be able to completely eliminate the frustrating syntax gotchas with the current default YAML workflow definitions.

Note: RBI shims are a placeholder, these will be replaced in the future with a tapioca compiler that will be able to generate RBIs for any cog.

I experimented with generics to apply types, but it ended up requiring the writing of some really ugly code. RBI generation with tapioca gives more idiomatic Ruby code while still providing the validations we want to supply.