### PR TITLE
Automatically use namespaced config class if present

### DIFF
--- a/lib/roast/dsl/cog.rb
+++ b/lib/roast/dsl/cog.rb
@@ -27,11 +27,16 @@ module Roast
           end
         end
 
-        def use_config_class(config_class)
-          @config_class = config_class
+        def config_class
+          @config_class ||= find_child_config_or_default
         end
 
-        attr_reader :config_class
+        private
+
+        def find_child_config_or_default
+          config_constant = "#{name}::Config"
+          const_defined?(config_constant) ? const_get(config_constant) : Cog::Config # rubocop:disable Sorbet/ConstantsFromStrings
+        end
       end
 
       attr_reader :output

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -15,7 +15,6 @@ module Roast
           #: Process::Status?
           attr_reader :status
 
-
           #: (
           #|  String? output,
           #|  String? error,
@@ -39,8 +38,6 @@ module Roast
             !!@values[:print_all]
           end
         end
-
-        use_config_class Config
 
         #: () -> Output
         def execute


### PR DESCRIPTION
Instead of a class macro, a cog can define its config class by convention. `CogName::Config` will be looked up by default, with a fallback to `Cog::Config` if not found.
