### PR TITLE
Add type annotations for Roast::DSL::Executor

### DIFF
--- a/lib/roast/dsl/executor.rb
+++ b/lib/roast/dsl/executor.rb
@@ -5,16 +5,19 @@ module Roast
   module DSL
     class Executor
       class ExecutorError < Roast::Error; end
+      class ExecutorNotPreparedError < ExecutorError; end
       class ExecutorAlreadyPreparedError < ExecutorError; end
       class ExecutorAlreadyCompletedError < ExecutorError; end
 
       class << self
+        #: (String) -> void
         def from_file(workflow_path)
           run!(File.read(workflow_path))
         end
 
         private
 
+        #: (String) -> void
         def run!(workflow_definition)
           executor = new
           executor.prepare!(workflow_definition)
@@ -22,14 +25,20 @@ module Roast
         end
       end
 
-      def prepare!(input)
+      #: () -> void
+      def initialize
+        @cogs = Cog::Store.new #: Cog::Store
+        @cog_stack = Cog::Stack.new #: Cog::Stack
+        @config_context = nil #: ConfigContext?
+        @execution_context = nil #: WorkflowExecutionContext?
+      end
+
+      #: (String) -> void
+      def prepare!(workflow_definition)
         # You can only initialize an executor once.
-        raise ExecutorAlreadyPreparedError if @prepared
+        raise ExecutorAlreadyPreparedError if prepared?
 
-        extract_dsl_procs(input)
-        @cogs = Cog::Store.new
-        @cog_stack = Cog::Stack.new
-
+        extract_dsl_procs!(workflow_definition)
         @config_context = ConfigContext.new(@cogs, @config_proc)
         @config_context.prepare!
         @execution_context = WorkflowExecutionContext.new(@cogs, @cog_stack, @execution_proc)
@@ -38,10 +47,12 @@ module Roast
         @prepared = true
       end
 
+      #: () -> void
       def start!
         # Now we run the cogs!
         # You can only do this once, executors are not reusable to avoid state pollution
-        raise ExecutorAlreadyCompletedError if @completed
+        raise ExecutorNotPreparedError unless @config_context.present? && @execution_context.present?
+        raise ExecutorAlreadyCompletedError if completed?
 
         @cog_stack.map do |name, cog|
           cog.run!(
@@ -53,29 +64,34 @@ module Roast
         @completed = true
       end
 
+      #: () -> bool
       def prepared?
         @prepared ||= false
       end
 
+      #: () -> bool
       def completed?
         @completed ||= false
       end
 
-      #: { () [self: ConfigContext] -> void} -> void
+      #: { () [self: ConfigContext] -> void } -> ^() -> void
       def config(&block)
         @config_proc = block
       end
 
-      #: { () [self: WorkflowExecutionContext] -> void} -> void
+      #: { () [self: WorkflowExecutionContext] -> void } -> void
       def execute(&block)
         @execution_proc = block
       end
 
+      private
+
       # Separating the instance evals ensures that we can reuse the same cog method
       # names between config and execute, while have the backing objects be completely
       # different. This means we have an enforced separation between configuring and running.
-      def extract_dsl_procs(input)
-        instance_eval(input)
+      #: (String) -> void
+      def extract_dsl_procs!(workflow_definition)
+        instance_eval(workflow_definition)
       end
     end
   end


### PR DESCRIPTION
# Add type annotations for Roast::DSL::Executor

This PR adds type annotations for Roast::DSL::Executor.

- Moved `@cogs` and `@cog_stack` instance variable initializations to `initialize` to allow them to be non-nilable
- Moved `@config_context` and `@execution_context` to `initialize` to alllow them to be explicitly set as nillable but also not confuse sorbet that they are not nil where they are actually set.
- Made `extract_dsl_procs!` method private
