### PR TITLE
Refactor config context to support multiple config blocks and improve type safety

### DIFF
--- a/lib/roast/dsl/cog.rb
+++ b/lib/roast/dsl/cog.rb
@@ -17,15 +17,15 @@ module Roast
 
         def on_config
           eigen = self
-          proc do |cog_name = nil, &configuration|
+          proc do |cog_name = nil, &configuration_proc|
             #: self as Roast::DSL::ConfigContext
             config_object = if cog_name.nil?
-              fetch_execution_scope(eigen)
+              fetch_general_config(eigen)
             else
-              fetch_or_create_cog_config(eigen, cog_name)
+              fetch_name_scoped_config(eigen, cog_name)
             end
-
-            config_object.instance_exec(&configuration) if configuration
+            config_object.instance_exec(&configuration_proc) if configuration_proc
+            config_object
           end
         end
 

--- a/lib/roast/dsl/config_context.rb
+++ b/lib/roast/dsl/config_context.rb
@@ -4,47 +4,63 @@
 module Roast
   module DSL
     class ConfigContext
-      def initialize(cogs, config_proc)
-        @cogs = cogs
-        @executor_scoped_configs = {}
-        @cog_scoped_configs = {}
-        @config_proc = config_proc
+      class ConfigContextError < Roast::Error; end
+      class ConfigContextNotPreparedError < ConfigContextError; end
+      class ConfigContextAlreadyPreparedError < ConfigContextError; end
+
+      #: (Cog::Store, Array[^() -> void]) -> void
+      def initialize(cogs, config_procs)
+        @cogs = cogs #: Cog::Store
+        @general_configs = {} #: Hash[singleton(Cog), Cog::Config]
+        @name_scoped_configs = {} #: Hash[singleton(Cog), Hash[Symbol, Cog::Config]]
+        @config_procs = config_procs #: Array[^() -> void]
       end
 
-      def fetch_merged_config(cog_class, name = nil)
-        # All configs have an entry, even if it's empty.
-        configs = fetch_execution_scope(cog_class)
-        instance_configs = fetch_cog_config(cog_class, name) unless name.nil?
-        configs = configs.merge(instance_configs) if instance_configs
-        configs
-      end
-
+      #: () -> void
       def prepare!
+        raise ConfigContextAlreadyPreparedError if prepared?
+
         bind_default_cogs
-        instance_eval(&@config_proc)
+        @config_procs.each { |cp| instance_eval(&cp) }
+        @prepared = true
       end
+
+      #: () -> bool
+      def prepared?
+        @prepared ||= false
+      end
+
+      #: (singleton(Cog), ?Symbol?) -> Cog::Config
+      def fetch_merged_config(cog_class, name = nil)
+        raise ConfigContextNotPreparedError unless prepared?
+
+        # All cogs will always have a config; empty by default if the cog was never explicitly configured
+        config = fetch_general_config(cog_class)
+        name_scoped_config = fetch_name_scoped_config(cog_class, name) unless name.nil?
+        config = config.merge(name_scoped_config) if name_scoped_config
+        config
+      end
+
+      #: (singleton(Cog)) -> Cog::Config
+      def fetch_general_config(cog_class)
+        @general_configs[cog_class] ||= cog_class.config_class.new
+      end
+
+      #: (singleton(Cog), Symbol) -> Cog::Config
+      def fetch_name_scoped_config(cog_class, name)
+        name_scoped_configs_for_cog = @name_scoped_configs[cog_class] ||= {}
+        name_scoped_configs_for_cog[name] ||= cog_class.config_class.new
+      end
+
+      private
 
       #: () -> void
       def bind_default_cogs
         bind_cog(Cogs::Cmd, :cmd)
       end
 
-      def fetch_cog_config(cog_class, name)
-        @cog_scoped_configs[cog_class][name]
-      end
-
-      def fetch_or_create_cog_config(cog_class, name)
-        @cog_scoped_configs[cog_class][name] = cog_class.config_class.new unless @cog_scoped_configs.key?(name)
-        @cog_scoped_configs[cog_class][name]
-      end
-
-      def fetch_execution_scope(cog_class)
-        @executor_scoped_configs[cog_class]
-      end
-
+      #: (singleton(Cog), Symbol) -> void
       def bind_cog(cog_class, method_name)
-        @cog_scoped_configs[cog_class] = {}
-        @executor_scoped_configs[cog_class] = cog_class.config_class.new
         instance_eval do
           define_singleton_method(method_name, &cog_class.on_config)
         end

--- a/lib/roast/dsl/executor.rb
+++ b/lib/roast/dsl/executor.rb
@@ -29,6 +29,8 @@ module Roast
       def initialize
         @cogs = Cog::Store.new #: Cog::Store
         @cog_stack = Cog::Stack.new #: Cog::Stack
+        @config_procs = [] #: Array[^() -> void]
+        @execution_procs = [] #: Array[^() -> void]
         @config_context = nil #: ConfigContext?
         @execution_context = nil #: WorkflowExecutionContext?
       end
@@ -39,9 +41,10 @@ module Roast
         raise ExecutorAlreadyPreparedError if prepared?
 
         extract_dsl_procs!(workflow_definition)
-        @config_context = ConfigContext.new(@cogs, @config_proc)
+
+        @config_context = ConfigContext.new(@cogs, @config_procs)
         @config_context.prepare!
-        @execution_context = WorkflowExecutionContext.new(@cogs, @cog_stack, @execution_proc)
+        @execution_context = WorkflowExecutionContext.new(@cogs, @cog_stack, @execution_procs)
         @execution_context.prepare!
 
         @prepared = true
@@ -74,14 +77,14 @@ module Roast
         @completed ||= false
       end
 
-      #: { () [self: ConfigContext] -> void } -> ^() -> void
+      #: { () [self: ConfigContext] -> void } -> void
       def config(&block)
-        @config_proc = block
+        @config_procs << block
       end
 
       #: { () [self: WorkflowExecutionContext] -> void } -> void
       def execute(&block)
-        @execution_proc = block
+        @execution_procs << block
       end
 
       private


### PR DESCRIPTION
# Refactor Configuration and Execution Context in Roast DSL

This PR refactors the configuration and execution context handling in the Roast DSL to improve clarity, type safety, and support multiple configuration blocks.

Key changes:
- Added proper error classes for configuration and execution contexts
- Renamed variables for better clarity (e.g., `configuration` → `configuration_proc`)
- Improved type annotations throughout the codebase
- Refactored configuration handling to support multiple config blocks
- Extracted configuration methods into more focused helper methods
- Added explicit `prepared?` state tracking with appropriate error handling
- Renamed internal data structures to better reflect their purpose
- Improved method organization with clearer public/private boundaries


Note: supporting multiple config/execute blocks was cleanest from a typing perspective, and there doesn't seem to be a strong reason why we wouldn't allow you to have multiple of these blocks. I have no objection to forbidding this, but it seems like we'd basically be raising and exception if you did have more than one when we could just evaluate them both with no negative consequences