### PR TITLE
Add type annotations to Cog class and fix inheritance structure

### DIFF
--- a/lib/roast/dsl/cog.rb
+++ b/lib/roast/dsl/cog.rb
@@ -4,17 +4,21 @@
 module Roast
   module DSL
     class Cog
-      class CogAlreadyRanError < StandardError; end
+      class CogError < Roast::Error; end
+      class CogAlreadyRanError < CogError; end
 
       class << self
+
+        #: () -> void
         def on_create
           eigen = self
-          proc do |instance_name = Random.uuid, &action|
+          proc do |instance_name = Random.uuid, &cog_input_proc|
             #: self as Roast::DSL::ExecutionContext
-            add_cog_instance(instance_name, eigen.new(instance_name, action))
+            add_cog_instance(instance_name, eigen.new(instance_name, cog_input_proc))
           end
         end
 
+        #: () -> void
         def on_config
           eigen = self
           proc do |cog_name = nil, &configuration_proc|
@@ -29,26 +33,38 @@ module Roast
           end
         end
 
+        #: () -> singleton(Cog::Config)
         def config_class
           @config_class ||= find_child_config_or_default
         end
 
         private
 
+        #: () -> singleton(Cog::Config)
         def find_child_config_or_default
           config_constant = "#{name}::Config"
           const_defined?(config_constant) ? const_get(config_constant) : Cog::Config # rubocop:disable Sorbet/ConstantsFromStrings
         end
       end
 
-      attr_reader :name, :output
+      #: Symbol
+      attr_reader :name
 
+      #: untyped
+      attr_reader :output
+
+      #: (Symbol, Proc) -> void
       def initialize(name, cog_input_proc)
         @name = name
-        @cog_input_proc = cog_input_proc
-        @finished = false
+        @cog_input_proc = cog_input_proc #: Proc
+        @output = nil #: untyped
+        @finished = false #: bool
+
+        # Make sure a config is always defined, so we don't have to worry about nils
+        @config = self.class.config_class.new #: Cog::Config
       end
 
+      #: (Cog::Config, CogInputContext) -> void
       def run!(config, input_context)
         raise CogAlreadyRanError if ran?
 
@@ -57,11 +73,13 @@ module Roast
         @finished = true
       end
 
+      #: () -> bool
       def ran?
         @finished
       end
 
       # Inheriting cog must implement this
+      #: (untyped) -> untyped
       def execute(input)
         raise NotImplementedError
       end

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -45,8 +45,9 @@ module Roast
 
         #: (String) -> Output
         def execute(input)
+          config = @config #: as Config
           result = Output.new(*Roast::Helpers::CmdRunner.capture3(input))
-          puts result.command_output if @config.print_all?
+          puts result.command_output if config.print_all?
           result
         end
       end

--- a/lib/roast/dsl/cogs/graph.rb
+++ b/lib/roast/dsl/cogs/graph.rb
@@ -8,7 +8,7 @@ module Roast
         #: Proc
         attr_reader :block
 
-        #: (Symbol) { (Roast::DSL::Cogs::Graph) -> void } -> void
+        #: (Symbol) { (Method) -> untyped } -> void
         def initialize(name, &block)
           @name = name
           @block = block
@@ -36,7 +36,7 @@ module Roast
         end
 
         # Populates the provided graph in-place, with the definition of how to populate in the block
-        #: (Roast::DSL::Cogs::Graph) -> void
+        #: (Method) -> void
         def populate!(graph)
           return if @block.nil?
 


### PR DESCRIPTION
# Add type annotations to Cog DSL classes

This PR adds strict type annotations to the Cog DSL classes, improving type safety and documentation. Key changes include:

- Added return type annotations to methods in the Cog class
- Made CogAlreadyRanError inherit from a new CogError class, which inherits from Roast::Error
- Renamed the `action` parameter to `cog_input_proc` for clarity
- Added explicit initialization of instance variables with type annotations
- Fixed a type issue in the cmd.rb file by storing @config in a local variable
- Updated method signatures in graph.rb to use more accurate types

These changes help ensure type safety throughout the codebase and make the interfaces more explicit.