### PR TITLE
Add type annotations to Cog DSL classes

### DIFF
--- a/lib/roast/dsl/cog/config.rb
+++ b/lib/roast/dsl/cog/config.rb
@@ -1,16 +1,20 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module Roast
   module DSL
     class Cog
       class Config
+
+        #: Hash[Symbol, untyped]
         attr_reader :values
 
+        #: (?Hash[Symbol, untyped]) -> void
         def initialize(initial = {})
           @values = initial
         end
 
+        #: (Cog::Config) -> Cog::Config
         def merge(config_object)
           self.class.new(values.merge(config_object.values))
         end
@@ -18,10 +22,12 @@ module Roast
         # It is recommended to implement a custom config object for a nicer interface,
         # but for simple cases where it would just be a key value store we provide one by default.
 
+        #: (Symbol, untyped) -> void
         def []=(key, value)
           @values[key] = value
         end
 
+        #: (Symbol) -> untyped
         def [](key)
           @values[key]
         end

--- a/lib/roast/dsl/cog/stack.rb
+++ b/lib/roast/dsl/cog/stack.rb
@@ -7,8 +7,9 @@ module Roast
       class Stack
         delegate :map, :push, :size, :empty?, to: :@queue
 
+        #: () -> void
         def initialize
-          @queue = []
+          @queue = [] #: Array[Cog]
         end
 
         #: () -> Roast::DSL::Cog?

--- a/lib/roast/dsl/cog/store.rb
+++ b/lib/roast/dsl/cog/store.rb
@@ -9,16 +9,19 @@ module Roast
 
         delegate :[], to: :store
 
+        #: Hash[Symbol, Cog]
+        attr_reader :store
+
+        #: () -> void
+        def initialize
+          @store = {}
+        end
+
         #: (Symbol, Roast::DSL::Cog) -> Roast::DSL::Cog
         def insert(id, inst)
           raise CogAlreadyDefinedError if store.key?(id)
 
           store[id] = inst
-        end
-
-        #: () -> Hash[Symbol, Roast::DSL::Cog]
-        def store
-          @store ||= {}
         end
       end
     end


### PR DESCRIPTION
This PR enhances type safety in the Roast DSL Cog module by adding signatures to all methods and instance variables in several classes.

The changes include:
- Adding method signatures with RBI-style type annotations to all methods in `Config`, `Stack`, and `Store` classes
- Explicitly typing instance variables and method parameters
- Refactoring the `Store` class to initialize the `@store` hash in the constructor rather than using a lazy-loaded accessor
- Making the `store` attribute reader public in the `Store` class

These changes improve the codebase's type safety and make the interfaces more explicit, which should help with static analysis and IDE tooling.