### PR TITLE
Refactor Cmd cog with strict typing and real-time output streaming

### DIFF
--- a/dsl/step_communication.rb
+++ b/dsl/step_communication.rb
@@ -12,7 +12,7 @@ execute do
   cmd(:ls) { "ls -al" }
   cmd(:echo) do
     # TODO: this is a bespoke output object for cmd, is there a generic one we can offer
-    first_line = cmd(:ls).command_output.split("\n").second
+    first_line = cmd(:ls).out.split("\n").second
     "echo '#{first_line}'"
   end
 end

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -7,7 +7,7 @@ module Roast
       class Cmd < Cog
         class Output
           #: String?
-          attr_reader :command_output
+          attr_reader :out
 
           #: String?
           attr_reader :err
@@ -15,29 +15,42 @@ module Roast
           #: Process::Status?
           attr_reader :status
 
-          #: (
-          #|  String? output,
-          #|  String? error,
-          #|  Process::Status? status
-          #| ) -> void
-          def initialize(output, error, status)
-            @command_output = output
-            @err = error
-            @status = status
+          #: ( String?, String?, Process::Status?) -> void
+          def initialize(out, err, status)
+            @out = out #: String?
+            @err = err #: String?
+            @status = status #: Process::Status?
           end
         end
 
         class Config < Cog::Config
           #: () -> void
           def print_all!
-            @values[:print_all] = true
+            @values[:print_stdout] = true
+            @values[:print_stderr] = true
+          end
+
+          #: () -> void
+          def print_stdout!
+            @values[:print_stdout] = true
+          end
+
+          #: () -> void
+          def print_stderr!
+            @values[:print_stderr] = true
           end
 
           #: () -> bool
-          def print_all?
-            !!@values[:print_all]
+          def print_stdout?
+            !!@values[:print_stdout]
           end
 
+          #: () -> bool
+          def print_stderr?
+            !!@values[:print_stderr]
+          end
+
+          #: () -> void
           def display!
             print_all!
           end
@@ -46,9 +59,39 @@ module Roast
         #: (String) -> Output
         def execute(input)
           config = @config #: as Config
-          result = Output.new(*Roast::Helpers::CmdRunner.capture3(input))
-          puts result.command_output if config.print_all?
-          result
+          result = Roast::Helpers::CmdRunner.popen3(input) do |stdin, stdout, stderr, wait_thread|
+            stdin.close
+            command_output = ""
+            command_error = ""
+
+            # Thread to read and accumulate stdout
+            stdout_thread = Thread.new do
+              stdout.each_line do |line|
+                command_output += line
+                $stdout.puts(line) if config.print_stdout?
+              end
+            rescue IOError => e
+              Roast::Helpers::Logger.debug("IOError while reading stdout: #{e.message}")
+            end
+
+            # Thread to read and accumulate stderr
+            stderr_thread = Thread.new do
+              stderr.each_line do |line|
+                command_error += line
+                $stderr.puts(line) if config.print_stderr?
+              end
+            rescue IOError => e
+              Roast::Helpers::Logger.debug("IOError while reading stderr: #{e.message}")
+            end
+
+            # Wait for threads to finish
+            stdout_thread.join
+            stderr_thread.join
+
+            [command_output, command_error, wait_thread.value]
+          end #: as [String, String, Process::Status]
+
+          Output.new(*result)
         end
       end
     end


### PR DESCRIPTION
# Refactor cmd cog to improve output handling and real-time streaming

This PR refactors the `Cmd` cog to provide better output handling capabilities:

- Renames `command_output` to `out` for consistency and clarity
- Replaces `capture3` with `popen3` to enable real-time output streaming
- Adds separate configuration options for stdout and stderr:
  - `print_stdout!` and `print_stderr!` to control output streams independently
  - `print_all!` now enables both stdout and stderr printing
- Implements multi-threaded handling of command output streams
- Updates the step communication example to use the new `out` attribute

These changes allow for more granular control over command output display and enable real-time streaming of command output rather than waiting for command completion.