### PR TITLE
Fix #391: Make Roast::Graph::Error inherit from Roast::Error

### DIFF
--- a/lib/roast/graph.rb
+++ b/lib/roast/graph.rb
@@ -3,7 +3,7 @@
 
 module Roast
   class Graph
-    class Error < StandardError; end
+    class Error < Roast::Error; end
     class AddEdgeError < Error; end
     class EdgeTopologyError < Error; end
 

--- a/test/roast/error_test.rb
+++ b/test/roast/error_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  class ErrorTest < ActiveSupport::TestCase
+    test "Roast::Error inherits from StandardError" do
+      assert_equal StandardError, Roast::Error.superclass
+    end
+
+    test "Roast::Graph::Error inherits from Roast::Error" do
+      assert_equal Roast::Error, Roast::Graph::Error.superclass
+    end
+
+    test "Roast::Graph::AddEdgeError inherits from Roast::Graph::Error" do
+      assert_equal Roast::Graph::Error, Roast::Graph::AddEdgeError.superclass
+    end
+
+    test "Roast::Graph::EdgeTopologyError inherits from Roast::Graph::Error" do
+      assert_equal Roast::Graph::Error, Roast::Graph::EdgeTopologyError.superclass
+    end
+
+    test "all Roast errors are catchable with Roast::Error" do
+      assert_raises(Roast::Error) do
+        raise Roast::Graph::AddEdgeError, "test error"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changed Roast::Graph::Error to inherit from Roast::Error instead of
StandardError. This allows all Roast errors to be caught with a single
Roast::Error rescue clause, enabling graceful error handling.

Added comprehensive tests to verify the error hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>