### PR TITLE
Add support for scoped executors in Roast DSL

### DIFF
--- a/dsl/scoped_executors.rb
+++ b/dsl/scoped_executors.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd do
+    print_all!
+  end
+end
+
+# TODO: there is no way to execute this block yet...
+execute(:capitalize_a_random_word) do
+  cmd(:word) { "shuf /usr/share/dict/words -n 1" }
+  cmd(:capitalize) do |my|
+    word = cmd(:word).out.strip
+    my.command = "sh"
+    my.args << "-c"
+    my.args << "echo '#{word}' | tr '[:lower:]' '[:upper:]'"
+  end
+end
+
+execute do
+  cmd(:whatever) { "echo whatever" }
+end

--- a/lib/roast/dsl/config_manager.rb
+++ b/lib/roast/dsl/config_manager.rb
@@ -86,7 +86,7 @@ module Roast
         else
           fetch_name_scoped_config(cog_class, cog_name)
         end
-        # Note: Sorbet expects the proc passed to instance_exec to be declared as taking an argument
+        # NOTE: Sorbet expects the proc passed to instance_exec to be declared as taking an argument
         # but our cog_config_proc does not get an argument
         config_object.instance_exec(&T.unsafe(cog_config_proc)) if cog_config_proc
         config_object


### PR DESCRIPTION
# Add support for scoped executors in Roast DSL

This PR introduces the concept of scoped executors to the Roast DSL, allowing execution blocks to be organized and potentially executed independently. Key changes include:

1. Added the ability to name execution blocks with a `scope` parameter in the `execute` method at the workflow-definition level
2. Restructured the `ExecutionManager` to handle scoped execution blocks
3. Moved cog instantiation and cog-stack running responsibilities from the `Workflow` class to the `ExecutionManager`, paving the way to create and run multiple ExecutionManagers in an up-stack PR
4. Added error handling for execution states with a new `ExecutionManagerCurrentlyRunningError`
6. Created a sample DSL file demonstrating scoped executors with a `capitalize_a_random_word` example