### PR TITLE
Implement Execute cog for running named execution scopes

### DIFF
--- a/dsl/scoped_executors.rb
+++ b/dsl/scoped_executors.rb
@@ -9,7 +9,6 @@ config do
   end
 end
 
-# TODO: there is no way to execute this block yet...
 execute(:capitalize_a_random_word) do
   cmd(:word) { "shuf /usr/share/dict/words -n 1" }
   cmd(:capitalize) do |my|
@@ -21,5 +20,9 @@ execute(:capitalize_a_random_word) do
 end
 
 execute do
-  cmd(:whatever) { "echo whatever" }
+  cmd(:before) { "echo '--> before'" }
+  execute { :capitalize_a_random_word }
+  execute { :capitalize_a_random_word }
+  execute { :capitalize_a_random_word }
+  cmd(:after) { "echo '--> after'" }
 end

--- a/lib/roast/dsl/cog.rb
+++ b/lib/roast/dsl/cog.rb
@@ -57,7 +57,7 @@ module Roast
 
         @config = config
         input_instance = self.class.input_class.new
-        input_return = input_context.instance_exec(input_instance, &@cog_input_proc)
+        input_return = input_context.instance_exec(input_instance, &@cog_input_proc) if @cog_input_proc
         coerce_and_validate_input!(input_instance, input_return)
         @output = execute(input_instance)
         @finished = true

--- a/lib/roast/dsl/cog/registry.rb
+++ b/lib/roast/dsl/cog/registry.rb
@@ -14,6 +14,7 @@ module Roast
           [
             Cogs::Cmd,
             Cogs::Chat,
+            Cogs::Execute,
           ].to_h do |cog_class|
             cog_class_name = cog_class.name
             raise CouldNotDeriveCogNameError if cog_class_name.nil?

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -15,8 +15,8 @@ module Roast
           #: () -> void
           def initialize
             super
-            @command = nil #: String?
-            @args = [] #: Array[String]
+            @command = nil
+            @args = []
           end
 
           #: () -> void

--- a/lib/roast/dsl/cogs/execute.rb
+++ b/lib/roast/dsl/cogs/execute.rb
@@ -1,0 +1,46 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Execute < Cog
+        class Input < Cog::Input
+          #: Symbol?
+          attr_accessor :scope
+
+          #: () -> void
+          def initialize
+            super
+            @scope = nil
+          end
+
+          #: () -> void
+          def validate!
+            raise Cog::Input::InvalidInputError, "'scope' is required" unless scope.present?
+          end
+
+          #: (Symbol) -> void
+          def coerce(input_return_value)
+            self.scope = input_return_value
+          end
+        end
+
+        #: (Symbol, ^(Input) -> untyped, ^(Input) -> void) -> void
+        def initialize(name, cog_input_proc, trigger)
+          # NOTE: Sorbet expects the proc passed to super to be declared as taking a Cog::Input explicitly,
+          # not a subclass of Cog::Input.
+          cog_input_proc = cog_input_proc #: as ^(Cog::Input) -> untyped
+          super(name, cog_input_proc)
+          @trigger = trigger
+        end
+
+        #: (Input) -> Cog::Output
+        def execute(input)
+          @trigger.call(input)
+          Cog::Output.new
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/dsl/workflow.rb
+++ b/lib/roast/dsl/workflow.rb
@@ -27,7 +27,6 @@ module Roast
 
       #: () -> void
       def initialize
-        @cogs = Cog::Store.new #: Cog::Store
         @cog_registry = Cog::Registry.new #: Cog::Registry
         @config_procs = [] #: Array[^() -> void]
         @execution_procs = { nil: [] } #: Hash[Symbol?, Array[^() -> void]]
@@ -43,7 +42,7 @@ module Roast
         extract_dsl_procs!(workflow_definition)
         @config_manager = ConfigManager.new(@cog_registry, @config_procs)
         @config_manager.prepare!
-        @execution_manager = ExecutionManager.new(@cog_registry, @config_manager, @execution_procs[nil] || [])
+        @execution_manager = ExecutionManager.new(@cog_registry, @config_manager, @execution_procs)
         @execution_manager.prepare!
 
         @prepared = true

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -9,6 +9,9 @@ module Roast
 
       #: (Symbol) -> Roast::DSL::Cogs::Chat::Output
       def chat(name); end
+
+      #: (Symbol) -> Roast::DSL::Cog::Output
+      def execute(name); end
     end
   end
 end

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -9,6 +9,9 @@ module Roast
 
       #: (?Symbol?) {() [self: Roast::DSL::Cogs::Chat::Config] -> void} -> void
       def chat(name = nil, &block); end
+
+      #: (?Symbol?) {() [self: Roast::DSL::Cog::Config] -> void} -> void
+      def execute(name = nil, &block); end
     end
   end
 end

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -9,6 +9,9 @@ module Roast
 
       #: (?Symbol?) {(Roast::DSL::Cogs::Chat::Input) [self: Roast::DSL::CogInputContext] -> String?} -> void
       def chat(name = nil, &block); end
+
+      #: (?Symbol?) {(Roast::DSL::Cogs::Execute::Input) [self: Roast::DSL::CogInputContext] -> (Symbol | nil)} -> void
+      def execute(name = nil, &block); end
     end
   end
 end


### PR DESCRIPTION
# Implement Execute cog for running named execution scopes

This PR adds the ability to define and execute named execution blocks. It introduces a new `Execute` cog that allows referencing and running previously defined execution scopes.

Key changes:
- Added a new `Execute` cog class that can trigger execution of named scopes
- Modified the `ExecutionManager` to support instantiating subordinate scoped execution blocks
- Updated the workflow initialization to handle multiple execution scopes
- Fixed a bug in the `Cog` class to handle nil input procedures
- Added type definitions for the new `execute` method in various contexts

The example in `dsl/scoped_executors.rb` demonstrates how to define a named execution block (`capitalize_a_random_word`) and then call it multiple times from another execution block.