### PR TITLE
Add support for passing values to scoped executors

### DIFF
--- a/dsl/scoped_executors.rb
+++ b/dsl/scoped_executors.rb
@@ -11,8 +11,10 @@ end
 
 execute(:capitalize_a_random_word) do
   cmd(:word) { "shuf /usr/share/dict/words -n 1" }
-  cmd(:capitalize) do |my|
-    word = cmd(:word).out.strip
+  cmd(:capitalize) do |my, value_from_call|
+    # Optional second block argument lets you use a value passed to the sub-executor by `call`
+    # from withing any cog in the sub-executor
+    word = value_from_call || cmd(:word).out.strip
     my.command = "/bin/sh"
     my.args << "-c"
     my.args << "/bin/echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"
@@ -21,10 +23,22 @@ end
 
 execute do
   cmd(:before) { "echo '--> before'" }
+
   # First argument to `call` is the executor scope to run
   # Second argument is the (optional) cog name
   call(:capitalize_a_random_word, :first_call)
   call(:capitalize_a_random_word, :other_named_call)
   call(:capitalize_a_random_word) # anonymous call cog
+
+  cmd { "echo '---'" }
+
+  # Can invoke a sub-executor with an executor-scoped value, that will be passed to each cog's input proc in that scope
+  call(:capitalize_a_random_word) do |my|
+    my.value = "scope value: roast"
+  end
+
+  # Shorthand input coercion for passing a scope value
+  call(:capitalize_a_random_word) { "scope value: other" }
+
   cmd(:after) { "echo '--> after'" }
 end

--- a/lib/roast/dsl/cog.rb
+++ b/lib/roast/dsl/cog.rb
@@ -56,13 +56,13 @@ module Roast
         @config = self.class.config_class.new #: Cog::Config
       end
 
-      #: (Cog::Config, CogInputContext) -> void
-      def run!(config, input_context)
+      #: (Cog::Config, CogInputContext, untyped) -> void
+      def run!(config, input_context, executor_scope_value)
         raise CogAlreadyRanError if ran?
 
         @config = config
         input_instance = self.class.input_class.new
-        input_return = input_context.instance_exec(input_instance, &@cog_input_proc) if @cog_input_proc
+        input_return = input_context.instance_exec(input_instance, executor_scope_value, &@cog_input_proc) if @cog_input_proc
         coerce_and_validate_input!(input_instance, input_return)
         @output = execute(input_instance)
         @finished = true

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -19,12 +19,19 @@ module Roast
 
       class ExecutionScopeNotSpecifiedError < ExecutionManagerError; end
 
-      #: (Cog::Registry, ConfigManager, Hash[Symbol?, Array[^() -> void]], ?Symbol?) -> void
-      def initialize(cog_registry, config_manager, all_execution_procs, scope = nil)
+      #: (Cog::Registry, ConfigManager, Hash[Symbol?, Array[^() -> void]], ?Symbol?, ?untyped?) -> void
+      def initialize(
+        cog_registry,
+        config_manager,
+        all_execution_procs,
+        scope = nil,
+        scope_value = nil
+      )
         @cog_registry = cog_registry
         @config_manager = config_manager
         @all_execution_procs = all_execution_procs
         @scope = scope
+        @scope_value = scope_value
         @cogs = Cog::Store.new #: Cog::Store
         @cog_stack = Cog::Stack.new #: Cog::Stack
         @execution_context = ExecutionContext.new #: ExecutionContext
@@ -50,6 +57,7 @@ module Roast
           cog.run!(
             @config_manager.config_for(cog.class, cog.name),
             cog_input_manager,
+            @scope_value.deep_dup, # Pass a copy to each cog to guard against mutated values being passed between cogs
           )
         end
         @running = false

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -4,13 +4,13 @@
 module Roast
   module DSL
     class ExecutionContext
-      #: (Symbol, ?Symbol?) ?{(Roast::DSL::SystemCogs::Call::Input) [self: Roast::DSL::CogInputContext] -> Symbol?} -> void
+      #: (Symbol, ?Symbol?) ?{(Roast::DSL::SystemCogs::Call::Input, untyped) [self: Roast::DSL::CogInputContext] -> untyped} -> void
       def call(scope, name = nil, &block); end
 
-      #: (?Symbol?) {(Roast::DSL::Cogs::Cmd::Input) [self: Roast::DSL::CogInputContext] -> (String | Array[String] | nil)} -> void
+      #: (?Symbol?) {(Roast::DSL::Cogs::Cmd::Input, untyped) [self: Roast::DSL::CogInputContext] -> (String | Array[String] | void)} -> void
       def cmd(name = nil, &block); end
 
-      #: (?Symbol?) {(Roast::DSL::Cogs::Chat::Input) [self: Roast::DSL::CogInputContext] -> String?} -> void
+      #: (?Symbol?) {(Roast::DSL::Cogs::Chat::Input, untyped) [self: Roast::DSL::CogInputContext] -> (String | void)} -> void
       def chat(name = nil, &block); end
     end
   end

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -7,38 +7,44 @@ module DSL
   module Functional
     class RoastDSLExamplesTest < FunctionalTest
       test "prototype.rb workflow runs successfully" do
-        actual_stdout, actual_stderr = in_sandbox :prototype do
+        stdout, stderr = in_sandbox :prototype do
           Roast::DSL::Workflow.from_file("dsl/prototype.rb")
         end
-        assert_match "Hello World!", actual_stdout
-        assert_equal "", actual_stderr
+        assert_match "Hello World!", stdout
+        assert_empty stderr
       end
 
       test "scoped_executors.rb workflow runs successfully" do
-        actual_stdout, actual_stderr = in_sandbox :scoped_executors do
+        stdout, stderr = in_sandbox :scoped_executors do
           Roast::DSL::Workflow.from_file("dsl/scoped_executors.rb")
         end
 
-        lines = actual_stdout.lines
-        assert_equal "--> before\n", lines.shift
+        lines = stdout.lines.map(&:strip)
+        assert_equal "--> before", lines.shift
         3.times do
           word = lines.shift
           assert_equal word.upcase, lines.shift
         end
-        assert_equal "--> after\n", lines.shift
-        assert_equal 8, actual_stdout.lines.length
-        assert_equal "", actual_stderr
+        assert_equal "---", lines.shift
+        assert_match(/^[\w']+$/, lines.shift)
+        assert_equal "SCOPE VALUE: ROAST", lines.shift
+        assert_match(/^[\w']+$/, lines.shift)
+        assert_equal "SCOPE VALUE: OTHER", lines.shift
+        assert_equal "--> after", lines.shift
+        assert_empty lines
+        assert_empty stderr
       end
 
       test "step_communication.rb workflow runs successfully" do
-        actual_stdout, actual_stderr = in_sandbox :step_communication do
+        stdout, stderr = in_sandbox :step_communication do
           Roast::DSL::Workflow.from_file("dsl/step_communication.rb")
         end
-        assert_match(/^d([r-][w-][x-]){3}\s+\d+.*\. $/, actual_stdout.lines.first)
-        assert_equal "---\n", actual_stdout.lines.second
-        assert_match(/^ d([r-][w-][x-]){3}\s+\d+.*\w+$/, actual_stdout.lines.last)
-        assert_equal 3, actual_stdout.lines.length
-        assert_equal "", actual_stderr
+        lines = stdout.lines.map(&:strip)
+        assert_match(/^d([r-][w-][x-]){3}\s+\d+.*\.$/, lines.shift)
+        assert_equal "---", lines.shift
+        assert_match(/^d([r-][w-][x-]){3}\s+\d+.*\w+$/, lines.shift)
+        assert_empty lines
+        assert_empty stderr
       end
     end
   end


### PR DESCRIPTION
# Add support for passing values to scoped executors

This PR enhances the `execute` cog to allow passing values to scoped executors. This enables more flexible workflows by allowing data to be passed between different execution scopes, effectively creating a parameterized context in which the same scoped executor can be run multiple times with different parameters.

Key changes:
- Added a `value` attribute to the `Execute` cog's input class
- Modified the `Execute::Input`'s `coerce` method to handle arrays, where the first element is the scope and the second is the value
- Updated the `run!` method in `Cog` to pass the executor scope value to input procs
- Added a second optional block parameter to cog input procs to receive the scope value
- Updated the `ExecutionManager` to propagate scope values to sub-executors

The scope value is passed as a deep copy to each cog to prevent mutation between cogs

Notes:
- the `ExecutionManager` for a scoped execution block is created de novo each time the `Execute` cog is run, ensuring that there is no cross-block communication, and no concerns of duplicate runs or dirty state.
- There is currently no way to access the output of cogs from a differently scoped executor. Further design iteration is planned to define if/when cogs in one scope could access the output from cogs in another scope, or any kind of meaningful output from the `Execute` cog itself.