### PR TITLE
Add Map cog for parallel execution of workflow steps

### DIFF
--- a/dsl/map.rb
+++ b/dsl/map.rb
@@ -1,0 +1,45 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd do
+    print_all!
+  end
+end
+
+execute(:capitalize_a_word) do
+  cmd(:capitalize) do |my, word|
+    word ||= cmd(:word).out.strip
+    my.command = "sh"
+    my.args << "-c"
+    my.args << "echo '#{word}' | tr '[:lower:]' '[:upper:]'"
+  end
+end
+
+execute do
+  words = ["hello", "world", "goodnight", "moon"]
+
+  # WITHOUT MAP COG
+  # You can use plain Ruby to generate a collection of cogs programmatically
+  # This is equivalent to simply defining each of the cogs explicitly, one by one
+  # In this case, four copies of the `call` cog invoking :capitalize_a_word
+  words.each { |word| call(:capitalize_a_word) { word } }
+
+  cmd(:foo) { "echo" }
+
+  # USING MAP COG
+  # You can use the `map` cog to apply a scoped executor to each item in a collection of values
+  map(:capitalize_a_word, :some_name) do |my|
+    my.items = words
+  end
+
+  cmd { "echo" }
+
+  # USING MAP COG (SHORTHAND)
+  # - name of execute scope is required
+  # - name of the map cog itself can be omitted (anonymous cog)
+  # - items over which to map coerced from return value of input proc
+  map(:capitalize_a_word) { words.reverse }
+end

--- a/lib/roast/dsl/cog/registry.rb
+++ b/lib/roast/dsl/cog/registry.rb
@@ -11,6 +11,7 @@ module Roast
         def initialize
           @cogs = {}
           use(SystemCogs::Call)
+          use(SystemCogs::Map)
           use(Cogs::Cmd)
           use(Cogs::Chat)
         end

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -6,6 +6,7 @@ module Roast
     # Context in which the `execute` block of a workflow is evaluated
     class ExecutionManager
       include SystemCogs::Call::Manager
+      include SystemCogs::Map::Manager
 
       class ExecutionManagerError < Roast::Error; end
 
@@ -130,6 +131,8 @@ module Roast
           cog_params = T.unsafe(cog_class).params_class.new(*cog_args, **cog_kwargs)
           cog_instance = if cog_class == SystemCogs::Call
             create_call_system_cog(cog_params, cog_input_proc)
+          elsif cog_class == SystemCogs::Map
+            create_map_system_cog(cog_params, cog_input_proc)
           else
             raise NotImplementedError, "No system cog manager defined for #{cog_class}"
           end

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -1,0 +1,78 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module SystemCogs
+      class Map < SystemCog
+        class Params < SystemCog::Params
+          #: Symbol
+          attr_accessor :scope
+
+          #: (Symbol, ?Symbol?) -> void
+          def initialize(scope, name = nil)
+            super(name)
+            @scope = scope
+          end
+        end
+
+        class Input < Cog::Input
+          #: Array[untyped]
+          attr_accessor :items
+
+          def initialize
+            super
+            @items = []
+          end
+
+          #: () -> void
+          def validate!
+            raise Cog::Input::InvalidInputError, "'items' is required" if items.nil?
+            # raise a validation error items is empty and coercion has not been run, to allow coercion to proceed
+            raise Cog::Input::InvalidInputError if items.blank? && !permit_empty_items?
+          end
+
+          #: (Array[untyped]) -> void
+          def coerce(input_return_value)
+            @items = Array.wrap(input_return_value) unless @items.present?
+          end
+
+          private
+
+          #: () -> bool
+          def permit_empty_items?
+            @permit_empty_items ||= false
+          end
+        end
+
+        # @requires_ancestor: ExecutionManager
+        module Manager
+          private
+
+          #: (Params, ^(Cog::Input) -> untyped) -> SystemCogs::Map
+          def create_map_system_cog(params, input_proc)
+            SystemCogs::Map.new(params.name, input_proc) do |input|
+              input = input #: as Input
+              raise ExecutionManager::ExecutionScopeNotSpecifiedError unless params.scope.present?
+
+              # For now, just process each item sequentially in a single thread
+              input.items.each do |item|
+                em = ExecutionManager.new(
+                  @cog_registry,
+                  @config_manager,
+                  @all_execution_procs,
+                  params.scope,
+                  item,
+                )
+                em.prepare!
+                em.run!
+              end
+
+              Cog::Output.new
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -7,6 +7,9 @@ module Roast
       #: (Symbol) -> Roast::DSL::Cog::Output
       def call(name); end
 
+      #: (Symbol) -> Roast::DSL::Cog::Output
+      def map(name); end
+
       #: (Symbol) -> Roast::DSL::Cogs::Cmd::Output
       def cmd(name); end
 

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -7,6 +7,9 @@ module Roast
       #: (?Symbol?) {() [self: Roast::DSL::Cog::Config] -> void} -> void
       def call(name = nil, &block); end
 
+      #: (?Symbol?) {() [self: Roast::DSL::Cog::Config] -> void} -> void
+      def map(name = nil, &block); end
+
       #: (?Symbol?) {() [self: Roast::DSL::Cogs::Cmd::Config] -> void} -> void
       def cmd(name = nil, &block); end
 

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -7,6 +7,9 @@ module Roast
       #: (Symbol, ?Symbol?) ?{(Roast::DSL::SystemCogs::Call::Input, untyped) [self: Roast::DSL::CogInputContext] -> untyped} -> void
       def call(scope, name = nil, &block); end
 
+      #: (Symbol, ?Symbol?) {(Roast::DSL::SystemCogs::Map::Input, untyped) [self: Roast::DSL::CogInputContext] -> untyped} -> void
+      def map(scope, name = nil, &block); end
+
       #: (?Symbol?) {(Roast::DSL::Cogs::Cmd::Input, untyped) [self: Roast::DSL::CogInputContext] -> (String | Array[String] | void)} -> void
       def cmd(name = nil, &block); end
 

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -6,6 +6,30 @@ require "test_helper"
 module DSL
   module Functional
     class RoastDSLExamplesTest < FunctionalTest
+      test "map.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :prototype do
+          Roast::DSL::Workflow.from_file("dsl/map.rb")
+        end
+        expected_stdout = <<~EOF
+          HELLO
+          WORLD
+          GOODNIGHT
+          MOON
+
+          HELLO
+          WORLD
+          GOODNIGHT
+          MOON
+
+          MOON
+          GOODNIGHT
+          WORLD
+          HELLO
+        EOF
+        assert_equal expected_stdout, stdout
+        assert_empty stderr
+      end
+
       test "prototype.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :prototype do
           Roast::DSL::Workflow.from_file("dsl/prototype.rb")


### PR DESCRIPTION
# Add Map Cog for Parallel Execution in Workflows

This PR introduces a new `map` cog that allows workflows to apply a scoped executor to each item in a collection. This enables more concise and readable workflow definitions when performing the same operation on multiple items.

Key changes:
- Added `SystemCogs::Map` class with appropriate input and parameter handling
- Implemented `map` cog execution in the system cog manager
- Created a params base class for system cogs to standardize parameter handling
- Added type signatures and Sorbet RBI shims for the new functionality

## New Concept - SystemCog::Params

This PR adds an additional parameterization point for system cogs. This allows the cog method bound to the `execute` context to accept additional positional and/or keyword args in addition to the cog's name.

The rationale for keeping this new functionality restricted to system cogs only is that it is largely redundant with cog input (and/or cog config) for most purposes. The specific utility of the params concept for system cogs is that it allows parameters that would otherwise be specified in the cog's input block to be determined at the time the `execute` block is evaluated, before the cog's input block is evaluated.

This will make it possible for Roast to do more substantive 'static' analysis of a workflow definition before actually running the workflow. For example, by specifying the scope of the executor that the map cog should apply to its inputs at the level of the ExecutionContext instead of the CogInputContext, Roast could determine before execution begins what a flow diagram for the workflow would look like.
