### PR TITLE
Prototyping third party gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
       open_router (~> 0.3)
       raix (~> 1.0.2)
       ruby-graphviz (~> 1.2)
+      ruby_llm
       sqlite3 (~> 2.6)
       thor (~> 1.3)
       zeitwerk (~> 2.6)

--- a/dsl/demo/Gemfile
+++ b/dsl/demo/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+gem "roast-ai", path: "../.."
+gem "plugin-gem-example", path: "../plugin-gem-example"

--- a/dsl/demo/Gemfile.lock
+++ b/dsl/demo/Gemfile.lock
@@ -1,0 +1,120 @@
+PATH
+  remote: ../..
+  specs:
+    roast-ai (0.4.9)
+      activesupport (>= 7.0)
+      cli-kit (~> 5.0)
+      cli-ui (= 2.3.0)
+      diff-lcs (~> 1.5)
+      json-schema
+      open_router (~> 0.3)
+      raix (~> 1.0.2)
+      ruby-graphviz (~> 1.2)
+      ruby_llm
+      sqlite3 (~> 2.6)
+      thor (~> 1.3)
+      zeitwerk (~> 2.6)
+
+PATH
+  remote: ../plugin-gem-example
+  specs:
+    plugin-gem-example (0.1.0)
+      roast-ai
+
+GEM
+  specs:
+    activesupport (8.0.3)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.3.1)
+    cli-kit (5.0.1)
+      cli-ui (~> 2.0)
+    cli-ui (2.3.0)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
+    diff-lcs (1.6.2)
+    dotenv (3.1.8)
+    drb (2.2.3)
+    event_stream_parser (1.0.0)
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    json (2.15.1)
+    json-schema (6.0.0)
+      addressable (~> 2.8)
+      bigdecimal (~> 3.1)
+    logger (1.7.0)
+    marcel (1.1.0)
+    minitest (5.26.0)
+    multipart-post (2.4.1)
+    net-http (0.6.0)
+      uri
+    open_router (0.3.3)
+      activesupport (>= 6.0)
+      dotenv (>= 2)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
+    ostruct (0.6.3)
+    public_suffix (6.0.2)
+    raix (1.0.3)
+      activesupport (>= 6.0)
+      faraday-retry (~> 2.0)
+      open_router (~> 0.2)
+      ostruct
+      ruby-openai (~> 8.1)
+    rexml (3.4.4)
+    ruby-graphviz (1.2.5)
+      rexml
+    ruby-openai (8.3.0)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
+    ruby_llm (1.8.2)
+      base64
+      event_stream_parser (~> 1)
+      faraday (>= 1.10.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 1)
+      marcel (~> 1.0)
+      zeitwerk (~> 2)
+    securerandom (0.4.1)
+    sqlite3 (2.7.4-arm64-darwin)
+    thor (1.4.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.0.4)
+    zeitwerk (2.7.3)
+
+PLATFORMS
+  arm64-darwin
+
+DEPENDENCIES
+  plugin-gem-example!
+  roast-ai!
+
+BUNDLED WITH
+   2.6.8

--- a/dsl/demo/cogs/local.rb
+++ b/dsl/demo/cogs/local.rb
@@ -1,0 +1,15 @@
+# typed: true
+# frozen_string_literal: true
+
+class Local < Roast::DSL::Cog
+  class Input < Roast::DSL::Cog::Input
+    def validate!
+      true
+    end
+  end
+
+  #: (Input) -> void
+  def execute(input)
+    puts "I'm a workflow-specific cog!"
+  end
+end

--- a/dsl/demo/simple_external_cog.rb
+++ b/dsl/demo/simple_external_cog.rb
@@ -1,0 +1,17 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+use "simple", from: "plugin_gem_example"
+use "MyCogNamespace::Other", from: "plugin_gem_example"
+use "local"
+
+# Use multiple cogs
+# use ["simple", "other"], from: "plugin_gem_example"
+
+execute do
+  simple
+  other
+  local
+end

--- a/dsl/plugin-gem-example/.gitignore
+++ b/dsl/plugin-gem-example/.gitignore
@@ -1,0 +1,8 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/

--- a/dsl/plugin-gem-example/Gemfile
+++ b/dsl/plugin-gem-example/Gemfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in plugin-gem-example.gemspec
+gemspec
+
+gem "irb"
+gem "rake", "~> 13.0"
+
+gem "minitest", "~> 5.16"
+
+gem "rubocop", "~> 1.21"

--- a/dsl/plugin-gem-example/Gemfile.lock
+++ b/dsl/plugin-gem-example/Gemfile.lock
@@ -1,0 +1,178 @@
+PATH
+  remote: .
+  specs:
+    plugin-gem-example (0.1.0)
+      roast-ai
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.0.3)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    ast (2.4.3)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.3.1)
+    cli-kit (5.0.1)
+      cli-ui (~> 2.0)
+    cli-ui (2.3.0)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
+    date (3.4.1)
+    diff-lcs (1.6.2)
+    dotenv (3.1.8)
+    drb (2.2.3)
+    erb (5.1.1)
+    event_stream_parser (1.0.0)
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    io-console (0.8.1)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    json (2.15.1)
+    json-schema (6.0.0)
+      addressable (~> 2.8)
+      bigdecimal (~> 3.1)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    minitest (5.26.0)
+    multipart-post (2.4.1)
+    net-http (0.6.0)
+      uri
+    open_router (0.3.3)
+      activesupport (>= 6.0)
+      dotenv (>= 2)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
+    ostruct (0.6.3)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.6.0)
+    psych (5.2.6)
+      date
+      stringio
+    public_suffix (6.0.2)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    raix (1.0.3)
+      activesupport (>= 6.0)
+      faraday-retry (~> 2.0)
+      open_router (~> 0.2)
+      ostruct
+      ruby-openai (~> 8.1)
+    rake (13.3.0)
+    rdoc (6.15.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.11.3)
+    reline (0.6.2)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    roast-ai (0.4.9)
+      activesupport (>= 7.0)
+      cli-kit (~> 5.0)
+      cli-ui (= 2.3.0)
+      diff-lcs (~> 1.5)
+      json-schema
+      open_router (~> 0.3)
+      raix (~> 1.0.2)
+      ruby-graphviz (~> 1.2)
+      sqlite3 (~> 2.6)
+      thor (~> 1.3)
+      zeitwerk (~> 2.6)
+    rubocop (1.81.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.47.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-graphviz (1.2.5)
+      rexml
+    ruby-openai (8.3.0)
+      event_stream_parser (>= 0.3.0, < 2.0.0)
+      faraday (>= 1)
+      faraday-multipart (>= 1)
+    ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    sqlite3 (2.7.4-aarch64-linux-gnu)
+    sqlite3 (2.7.4-aarch64-linux-musl)
+    sqlite3 (2.7.4-arm-linux-gnu)
+    sqlite3 (2.7.4-arm-linux-musl)
+    sqlite3 (2.7.4-arm64-darwin)
+    sqlite3 (2.7.4-x86-linux-gnu)
+    sqlite3 (2.7.4-x86-linux-musl)
+    sqlite3 (2.7.4-x86_64-darwin)
+    sqlite3 (2.7.4-x86_64-linux-gnu)
+    sqlite3 (2.7.4-x86_64-linux-musl)
+    stringio (3.1.7)
+    thor (1.4.0)
+    tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
+    uri (1.0.4)
+    zeitwerk (2.7.3)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  irb
+  minitest (~> 5.16)
+  plugin-gem-example!
+  rake (~> 13.0)
+  rubocop (~> 1.21)
+
+BUNDLED WITH
+   2.6.8

--- a/dsl/plugin-gem-example/lib/other.rb
+++ b/dsl/plugin-gem-example/lib/other.rb
@@ -1,0 +1,17 @@
+# typed: true
+# frozen_string_literal: true
+
+module MyCogNamespace
+  class Other < Roast::DSL::Cog
+    class Input < Roast::DSL::Cog::Input
+      def validate!
+        true
+      end
+    end
+
+    #: (Input) -> void
+    def execute(input)
+      puts "I'm a different cog!"
+    end
+  end
+end

--- a/dsl/plugin-gem-example/lib/plugin_gem_example.rb
+++ b/dsl/plugin-gem-example/lib/plugin_gem_example.rb
@@ -1,0 +1,5 @@
+# typed: false
+# frozen_string_literal: true
+
+require "simple"
+require "other"

--- a/dsl/plugin-gem-example/lib/simple.rb
+++ b/dsl/plugin-gem-example/lib/simple.rb
@@ -1,0 +1,15 @@
+# typed: true
+# frozen_string_literal: true
+
+class Simple < Roast::DSL::Cog
+  class Input < Roast::DSL::Cog::Input
+    def validate!
+      true
+    end
+  end
+
+  #: (Input) -> void
+  def execute(input)
+    puts "I'm a cog!"
+  end
+end

--- a/dsl/plugin-gem-example/lib/version.rb
+++ b/dsl/plugin-gem-example/lib/version.rb
@@ -1,0 +1,10 @@
+# typed: false
+# frozen_string_literal: true
+
+module Plugin
+  module Gem
+    module Example
+      VERSION = "0.1.0"
+    end
+  end
+end

--- a/dsl/plugin-gem-example/plugin-gem-example.gemspec
+++ b/dsl/plugin-gem-example/plugin-gem-example.gemspec
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "lib/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "plugin-gem-example"
+  spec.version = Plugin::Gem::Example::VERSION
+  spec.authors = ["Sam Schmidt"]
+  spec.email = ["sam.schmidt@shopify.com"]
+
+  spec.summary = "TODO: Write a short summary, because RubyGems requires one."
+  spec.description = "TODO: Write a longer description or delete this line."
+  spec.homepage = "TODO: Put your gem's website or public repo URL here."
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.1.0"
+
+  spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
+  spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+
+  # Uncomment to register a new dependency of your gem
+  spec.add_dependency("roast-ai")
+
+  # For more information and examples about making a new gem, check out our
+  # guide at: https://bundler.io/guides/creating_gem.html
+end

--- a/lib/roast/dsl/cog/registry.rb
+++ b/lib/roast/dsl/cog/registry.rb
@@ -8,19 +8,30 @@ module Roast
         class CogRegistryError < Roast::Error; end
         class CouldNotDeriveCogNameError < CogRegistryError; end
 
-        #: () -> Hash[Symbol, singleton(Cog)]
-        def cogs
-          # Hard-coded for now; these cogs are available for workflows
-          [
-            Cogs::Cmd,
-            Cogs::Chat,
-            Cogs::Execute,
-          ].to_h do |cog_class|
-            cog_class_name = cog_class.name
-            raise CouldNotDeriveCogNameError if cog_class_name.nil?
+        def initialize
+          @cogs = {}
+          create_registration(Cogs::Cmd)
+          create_registration(Cogs::Chat)
+          create_registration(Cogs::Execute)
+        end
 
-            [cog_class_name.demodulize.underscore.to_sym, cog_class]
-          end
+        #: Hash[Symbol, singleton(Cog)]
+        attr_reader :cogs
+
+        #: (singleton(Roast::DSL::Cog)) -> void
+        def use(cog_class)
+          reg = create_registration(cog_class)
+          cogs[reg.first] = reg.second
+        end
+
+        private
+
+        #: (singleton(Roast::DSL::Cog)) -> Array(Symbol, singleton(Cog))
+        def create_registration(cog_class)
+          cog_class_name = cog_class.name
+          raise CouldNotDeriveCogNameError if cog_class_name.nil?
+
+          [cog_class_name.demodulize.underscore.to_sym, cog_class]
         end
       end
     end

--- a/roast.gemspec
+++ b/roast.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("open_router", "~> 0.3")
   spec.add_dependency("raix", "~> 1.0.2")
   spec.add_dependency("ruby-graphviz", "~> 1.2")
+  spec.add_dependency("ruby_llm")
   spec.add_dependency("sqlite3", "~> 2.6")
   spec.add_dependency("thor", "~> 1.3")
   spec.add_dependency("zeitwerk", "~> 2.6")

--- a/sorbet/config
+++ b/sorbet/config
@@ -6,5 +6,6 @@
 --ignore=vendor/
 --ignore=test/
 --ignore=bin/
+--ignore=dsl/demo
 --enable-experimental-requires-ancestor
 --enable-experimental-rbs-comments


### PR DESCRIPTION
Demonstration of using third party cogs and binding them into a workflow.

This adds a new syntax `use`, in which you declare the cog you want to use and the gem it is from. `use` will ensure the gem is required and then bind the cog classes into the registry.

For testing, I've set up a very simple demo gem, and a standalone "project" that contains a roast workflow with its own gemfile. This ensures that gem loading works properly in projects using Roast.

A workflow can _also_ define workflow specific cogs. If `use` does not have the `from:` parameter passed, the workflow will look in the cogs directory for that given workflow (conventionally, the `cogs/` dir in the same directory as the workflow file).