### PR TITLE
chore(deps): bump roast version to 0.4.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    roast-ai (0.4.9)
+    roast-ai (0.4.10)
       activesupport (>= 7.0)
       cli-kit (~> 5.0)
       cli-ui (= 2.3.0)

--- a/lib/roast/version.rb
+++ b/lib/roast/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Roast
-  VERSION = "0.4.9"
+  VERSION = "0.4.10"
 end


### PR DESCRIPTION
### TL;DR

Bump roast version from 0.4.9 to 0.4.10

### What changed?

includes:
- [fix 👮 rubocop complaints #439](https://github.com/Shopify/roast/pull/439)
- [Bump rack from 2.2.19 to 2.2.20 #438](https://github.com/Shopify/roast/pull/438)