### PR TITLE
Fix old test suite and re-enable it in CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ end
 Rake::TestTask.new(:minitest_old) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/functional/**/*_test.rb"]
+  t.test_files = FileList["test/**/*_test.rb"].exclude("test/functional/**/*_test.rb", "test/dsl/**/*_test.rb")
 end
 
 Rake::TestTask.new(:minitest_dsl) do |t|

--- a/lib/roast/tools/apply_diff.rb
+++ b/lib/roast/tools/apply_diff.rb
@@ -64,7 +64,7 @@ module Roast
           Roast::Helpers::Logger.info(cancel_msg + "\n")
           cancel_msg
         end
-      rescue Roast::Error => e
+      rescue Roast::Error, Errno::EACCES, Errno::ENOENT => e
         error_message = "Error applying diff: #{e.message}"
         Roast::Helpers::Logger.error(error_message + "\n")
         Roast::Helpers::Logger.debug(e.backtrace.join("\n") + "\n") if ENV["DEBUG"]

--- a/lib/roast/tools/cmd.rb
+++ b/lib/roast/tools/cmd.rb
@@ -153,9 +153,10 @@ module Roast
         )
 
         format_output(command, result, status.exitstatus)
-      rescue Timeout::Error => e
-        Roast::Helpers::Logger.error(e.message + "\n")
-        e.message
+      rescue Timeout::Error, Errno::ENOENT => e
+        error_message = "Error running command: #{e.message}"
+        Roast::Helpers::Logger.error(error_message + "\n")
+        error_message
       end
 
       def format_output(command, result, exit_status)

--- a/lib/roast/tools/read_file.rb
+++ b/lib/roast/tools/read_file.rb
@@ -39,7 +39,7 @@ module Roast
         else
           File.read(path)
         end
-      rescue Roast::Error => e
+      rescue Roast::Error, Errno::ENOENT, Errno::EACCES => e
         "Error reading file: #{e.message}".tap do |error_message|
           Roast::Helpers::Logger.error(error_message + "\n")
           Roast::Helpers::Logger.debug(e.backtrace.join("\n") + "\n") if ENV["DEBUG"]

--- a/lib/roast/tools/update_files.rb
+++ b/lib/roast/tools/update_files.rb
@@ -306,7 +306,7 @@ module Roast
               if new_content_lines
                 content_lines = new_content_lines
               else
-                raise "Hunk could not be applied cleanly: #{hunk[:header]}"
+                raise Roast::Error, "Hunk could not be applied cleanly: #{hunk[:header]}"
               end
             end
 

--- a/lib/roast/tools/write_file.rb
+++ b/lib/roast/tools/write_file.rb
@@ -49,7 +49,7 @@ module Roast
           Roast::Helpers::Logger.error(restriction_message)
           "Error: Path must start with '#{restrict_path}' to use the write_file tool, try again."
         end
-      rescue Roast::Error => e
+      rescue Roast::Error, Errno::EACCES, Errno::ENOENT => e
         "Error writing file: #{e.message}".tap do |error_message|
           Roast::Helpers::Logger.error(error_message + "\n")
           Roast::Helpers::Logger.debug(e.backtrace.join("\n") + "\n") if ENV["DEBUG"]

--- a/lib/roast/workflow/base_workflow.rb
+++ b/lib/roast/workflow/base_workflow.rb
@@ -175,7 +175,11 @@ module Roast
 
           if error_detail && !error_detail.empty? && !message.include?(error_detail)
             " (#{error_detail})"
+          else
+            ""
           end
+        else
+          ""
         end
 
         message

--- a/lib/roast/workflow/step_loader.rb
+++ b/lib/roast/workflow/step_loader.rb
@@ -208,7 +208,12 @@ module Roast
       def configure_step(step, step_name, is_last_step: nil)
         step_config = config_hash[step_name]
 
-        # Only set the model if explicitly specified for this step
+        # Apply global model if no step-specific model is configured
+        if config_hash.key?("model") && !step_config&.key?("model")
+          step.model = config_hash["model"]
+        end
+
+        # Apply step-specific model (overrides global model)
         step.model = step_config["model"] if step_config&.key?("model")
 
         # Pass resource to step if supported

--- a/test/roast/workflow/agent_step_test.rb
+++ b/test/roast/workflow/agent_step_test.rb
@@ -45,6 +45,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:resource).returns(nil)
     workflow.stubs(:output).returns({})
     workflow.stubs(:transcript).returns([])
+    workflow.stubs(:model).returns(nil)
 
     # Create a temporary directory structure for the test
     Dir.mktmpdir do |tmpdir|
@@ -80,6 +81,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Create agent step
     agent_step = Roast::Workflow::AgentStep.new(workflow, name: "test_agent")
@@ -189,6 +191,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Create agent step with inline prompt
     inline_prompt = "Review this code and identify performance bottlenecks"
@@ -281,6 +284,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Create agent step with json: true
     agent_step = Roast::Workflow::AgentStep.new(workflow, name: "test_agent")
@@ -311,6 +315,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Create agent step with json: true
     agent_step = Roast::Workflow::AgentStep.new(workflow, name: "test_agent")
@@ -349,6 +354,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Create agent step with json: true
     agent_step = Roast::Workflow::AgentStep.new(workflow, name: "test_agent")
@@ -383,6 +389,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Create agent step with json: true
     agent_step = Roast::Workflow::AgentStep.new(workflow, name: "test_agent")
@@ -411,6 +418,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Create agent step with json: true
     agent_step = Roast::Workflow::AgentStep.new(workflow, name: "test_agent")
@@ -440,6 +448,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Create agent step with json: false (default)
     agent_step = Roast::Workflow::AgentStep.new(workflow, name: "test_agent")
@@ -469,6 +478,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Create agent step with json: true
     agent_step = Roast::Workflow::AgentStep.new(workflow, name: "test_agent")
@@ -515,6 +525,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Set up metadata with session ID from previous step
     metadata = {
@@ -555,6 +566,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Metadata without session ID
     metadata = {
@@ -596,6 +608,7 @@ class RoastWorkflowAgentStepTest < ActiveSupport::TestCase
     workflow.stubs(:append_to_final_output)
     workflow.stubs(:file).returns(nil)
     workflow.stubs(:config).returns({})
+    workflow.stubs(:model).returns(nil)
 
     # Create metadata with session ID for "some_step"
     metadata_with_session = {

--- a/test/roast/workflow/coerce_to_configuration_test.rb
+++ b/test/roast/workflow/coerce_to_configuration_test.rb
@@ -17,6 +17,7 @@ module Roast
         @workflow.stubs(:pause_step_name).returns(nil)
         @workflow.stubs(:tools).returns(nil)
         @workflow.stubs(:storage_type).returns(nil)
+        @workflow.stubs(:model).returns(nil)
       end
 
       test "step with coerce_to boolean returns boolean for truthy string" do

--- a/test/roast/workflow/conditional_step_test.rb
+++ b/test/roast/workflow/conditional_step_test.rb
@@ -11,6 +11,7 @@ module Roast
         @output = {}
         @workflow.stubs(:output).returns(@output)
         @workflow.stubs(:metadata).returns({})
+        @workflow.stubs(:model).returns(nil)
         @context_path = "/path/to/workflow.yml"
       end
 

--- a/test/roast/workflow/conditional_step_unit_test.rb
+++ b/test/roast/workflow/conditional_step_unit_test.rb
@@ -8,6 +8,7 @@ module Roast
       test "executes then branch for simple true condition" do
         workflow = Object.new
         workflow.define_singleton_method(:output) { {} }
+        workflow.define_singleton_method(:model) { nil }
 
         # Mock instance_eval to return true
         workflow.define_singleton_method(:instance_eval) do |expr|
@@ -41,6 +42,7 @@ module Roast
       test "executes else branch for simple false condition" do
         workflow = Object.new
         workflow.define_singleton_method(:output) { {} }
+        workflow.define_singleton_method(:model) { nil }
 
         # Mock instance_eval to return false
         workflow.define_singleton_method(:instance_eval) do |expr|
@@ -74,6 +76,7 @@ module Roast
       test "unless inverts the condition" do
         workflow = Object.new
         workflow.define_singleton_method(:output) { {} }
+        workflow.define_singleton_method(:model) { nil }
 
         # Mock instance_eval to return false
         workflow.define_singleton_method(:instance_eval) do |expr|
@@ -106,6 +109,7 @@ module Roast
       test "handles missing else branch" do
         workflow = Object.new
         workflow.define_singleton_method(:output) { {} }
+        workflow.define_singleton_method(:model) { nil }
 
         # Mock instance_eval to return false
         workflow.define_singleton_method(:instance_eval) do |expr|

--- a/test/roast/workflow/inline_prompt_configuration_test.rb
+++ b/test/roast/workflow/inline_prompt_configuration_test.rb
@@ -18,6 +18,7 @@ module Roast
         @workflow.stubs(:tools).returns(nil)
         @workflow.stubs(:storage_type).returns(nil)
         @workflow.stubs(:metadata).returns({})
+        @workflow.stubs(:model).returns(nil)
 
         @config_hash = {
           "analyze the code" => {
@@ -68,6 +69,9 @@ module Roast
           "model" => "claude-3-opus",
         }
         executor = WorkflowExecutor.new(@workflow, config_with_global_model, @context_path)
+
+        # Stub workflow to return the global model
+        @workflow.stubs(:model).returns("claude-3-opus")
 
         # Now expects loop: false due to new BaseStep behavior
         @workflow.expects(:chat_completion).with(

--- a/test/roast/workflow/input_executor_test.rb
+++ b/test/roast/workflow/input_executor_test.rb
@@ -9,6 +9,7 @@ module Roast
         @workflow = mock("workflow")
         @workflow.stubs(:output).returns({})
         @workflow.stubs(:metadata).returns({})
+        @workflow.stubs(:model).returns(nil)
         @context_path = "/test/context"
         @state_manager = mock("state_manager")
         @workflow_executor = mock("workflow_executor")

--- a/test/roast/workflow/input_step_test.rb
+++ b/test/roast/workflow/input_step_test.rb
@@ -12,6 +12,7 @@ module Roast
         @workflow.stubs(:state).returns({})
         @workflow.stubs(:respond_to?).with(:state).returns(true)
         @workflow.stubs(:respond_to?).with(:resource).returns(false)
+        @workflow.stubs(:model).returns(nil)
       end
 
       test "initializes with required prompt" do

--- a/test/roast/workflow/iteration_config_hash_test.rb
+++ b/test/roast/workflow/iteration_config_hash_test.rb
@@ -9,6 +9,7 @@ module Roast
         @workflow = mock("workflow")
         @workflow.stubs(:metadata).returns({})
         @workflow.stubs(:output).returns({})
+        @workflow.stubs(:model).returns(nil)
         @state_manager = mock("state_manager")
         @state_manager.stubs(:save_state)
 

--- a/test/roast/workflow/iteration_step_configuration_test.rb
+++ b/test/roast/workflow/iteration_step_configuration_test.rb
@@ -10,6 +10,7 @@ module Roast
         @workflow.stubs(:output).returns({})
         @workflow.stubs(:metadata).returns({})
         @workflow.stubs(:transcript).returns([])
+        @workflow.stubs(:model).returns(nil)
         @context_path = "/tmp/test"
         @state_manager = mock("state_manager")
         @state_manager.stubs(:save_state)

--- a/test/roast/workflow/prompt_step_print_response_test.rb
+++ b/test/roast/workflow/prompt_step_print_response_test.rb
@@ -34,6 +34,10 @@ module Roast
         def tools
           nil
         end
+
+        def model
+          nil
+        end
       end
 
       test "print_response true appends response to final output" do
@@ -51,7 +55,7 @@ module Roast
         assert_equal(
           {
             openai: false,
-            model: "anthropic:claude-opus-4",
+            model: "gpt-4o-mini",
             json: false,
             params: {},
             available_tools: nil,
@@ -88,7 +92,7 @@ module Roast
         assert_equal(
           {
             openai: false,
-            model: "anthropic:claude-opus-4",
+            model: "gpt-4o-mini",
             json: true,
             params: { temperature: 0.5 },
             available_tools: nil,

--- a/test/roast/workflow/workflow_executor_test.rb
+++ b/test/roast/workflow/workflow_executor_test.rb
@@ -9,7 +9,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
     @context_manager = mock("context_manager")
     @context_manager.stubs(:total_tokens).returns(0)
     @metadata = Roast::Workflow::DotAccessHash.new({})
-    @workflow.stubs(name: "test_workflow", output: @output, pause_step_name: nil, verbose: false, storage_type: nil, context_manager: @context_manager, metadata: @metadata)
+    @workflow.stubs(name: "test_workflow", output: @output, pause_step_name: nil, verbose: false, storage_type: nil, context_manager: @context_manager, metadata: @metadata, model: nil)
     @config_hash = { "step1" => { "model" => "test-model" } }
     @context_path = "/tmp/test"
     @executor = Roast::Workflow::WorkflowExecutor.new(@workflow, @config_hash, @context_path)
@@ -54,6 +54,7 @@ class RoastWorkflowWorkflowExecutorTest < ActiveSupport::TestCase
     @workflow.stubs(:openai?).returns(true)
     @workflow.stubs(:storage_type).returns(nil)
     @workflow.stubs(:tools).returns(nil)
+    @workflow.stubs(:model).returns("gpt-4o")
 
     # Expect chat_completion to be called with the configured model
     # Now expects loop: false due to new BaseStep behavior

--- a/test/workflow/shell_script_step_test.rb
+++ b/test/workflow/shell_script_step_test.rb
@@ -274,6 +274,10 @@ module Roast
           @appended_output = []
         end
 
+        def model
+          nil
+        end
+
         def append_to_final_output(text)
           @appended_output << text
         end


### PR DESCRIPTION
# Fix old test suite and re-enable it in CI

The legacy test suite was not running in CI, and about 80 test cases were failing. This PR fixes those tests (hopefully even correctly) and re-enables the full test suite in CI.