### PR TITLE
Rename Execute cog to Call for better semantics

### DIFF
--- a/dsl/scoped_executors.rb
+++ b/dsl/scoped_executors.rb
@@ -21,8 +21,8 @@ end
 
 execute do
   cmd(:before) { "echo '--> before'" }
-  execute { :capitalize_a_random_word }
-  execute { :capitalize_a_random_word }
-  execute { :capitalize_a_random_word }
+  call { :capitalize_a_random_word }
+  call { :capitalize_a_random_word }
+  call { :capitalize_a_random_word }
   cmd(:after) { "echo '--> after'" }
 end

--- a/lib/roast/dsl/cog/registry.rb
+++ b/lib/roast/dsl/cog/registry.rb
@@ -12,7 +12,7 @@ module Roast
           @cogs = {}
           use(Cogs::Cmd)
           use(Cogs::Chat)
-          use(Cogs::Execute)
+          use(Cogs::Call)
         end
 
         #: Hash[Symbol, singleton(Cog)]

--- a/lib/roast/dsl/cogs/call.rb
+++ b/lib/roast/dsl/cogs/call.rb
@@ -4,16 +4,10 @@
 module Roast
   module DSL
     module Cogs
-      class Execute < Cog
+      class Call < Cog
         class Input < Cog::Input
           #: Symbol?
           attr_accessor :scope
-
-          #: () -> void
-          def initialize
-            super
-            @scope = nil
-          end
 
           #: () -> void
           def validate!
@@ -22,7 +16,10 @@ module Roast
 
           #: (Symbol) -> void
           def coerce(input_return_value)
-            self.scope = input_return_value
+            case input_return_value
+            when Symbol
+              self.scope = input_return_value
+            end
           end
         end
 

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -111,16 +111,16 @@ module Roast
       def on_execute(cog_class, cog_name, &cog_input_proc)
         # Called when the cog method is invoked in the workflow's 'execute' block.
         # This creates the cog instance and prepares it for execution.
-        cog_instance = if cog_class == Cogs::Execute
-          create_special_execute_cog(cog_name, cog_input_proc)
+        cog_instance = if cog_class == Cogs::Call
+          create_special_call_cog(cog_name, cog_input_proc)
         else
           cog_class.new(cog_name, cog_input_proc)
         end
         add_cog_instance(cog_name, cog_instance)
       end
 
-      #: (Symbol, ^(Cogs::Execute::Input) -> untyped) -> Cogs::Execute
-      def create_special_execute_cog(cog_name, cog_input_proc)
+      #: (Symbol, ^(Cogs::Call::Input) -> untyped) -> Cogs::Call
+      def create_special_call_cog(cog_name, cog_input_proc)
         trigger = proc do |input|
           raise ExecutionScopeNotSpecifiedError unless input.scope.present?
 
@@ -130,7 +130,7 @@ module Roast
 
           # TODO: collect the outputs of the cogs in the execution manager that just ran and do something with them
         end
-        Cogs::Execute.new(cog_name, cog_input_proc, trigger)
+        Cogs::Call.new(cog_name, cog_input_proc, trigger)
       end
     end
   end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -4,14 +4,14 @@
 module Roast
   module DSL
     class CogInputContext
+      #: (Symbol) -> Roast::DSL::Cog::Output
+      def call(name); end
+
       #: (Symbol) -> Roast::DSL::Cogs::Cmd::Output
       def cmd(name); end
 
       #: (Symbol) -> Roast::DSL::Cogs::Chat::Output
       def chat(name); end
-
-      #: (Symbol) -> Roast::DSL::Cog::Output
-      def execute(name); end
     end
   end
 end

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -4,14 +4,14 @@
 module Roast
   module DSL
     class ConfigContext
+      #: (?Symbol?) {() [self: Roast::DSL::Cog::Config] -> void} -> void
+      def call(name = nil, &block); end
+
       #: (?Symbol?) {() [self: Roast::DSL::Cogs::Cmd::Config] -> void} -> void
       def cmd(name = nil, &block); end
 
       #: (?Symbol?) {() [self: Roast::DSL::Cogs::Chat::Config] -> void} -> void
       def chat(name = nil, &block); end
-
-      #: (?Symbol?) {() [self: Roast::DSL::Cog::Config] -> void} -> void
-      def execute(name = nil, &block); end
     end
   end
 end

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -4,14 +4,14 @@
 module Roast
   module DSL
     class ExecutionContext
+      #: (?Symbol?) {(Roast::DSL::Cogs::Call::Input) [self: Roast::DSL::CogInputContext] -> Symbol?} -> void
+      def call(name = nil, &block); end
+
       #: (?Symbol?) {(Roast::DSL::Cogs::Cmd::Input) [self: Roast::DSL::CogInputContext] -> (String | Array[String] | nil)} -> void
       def cmd(name = nil, &block); end
 
       #: (?Symbol?) {(Roast::DSL::Cogs::Chat::Input) [self: Roast::DSL::CogInputContext] -> String?} -> void
       def chat(name = nil, &block); end
-
-      #: (?Symbol?) {(Roast::DSL::Cogs::Execute::Input) [self: Roast::DSL::CogInputContext] -> (Symbol | nil)} -> void
-      def execute(name = nil, &block); end
     end
   end
 end


### PR DESCRIPTION
# Rename `execute` to `call` for better clarity in DSL

This PR renames the `execute` cog to `call` to better reflect its purpose and avoid confusion with the `execute` block. The change improves the readability of workflows by making it clearer when we're calling another scope.

Changes include:
- Renamed `Cogs::Execute` class to `Cogs::Call`
- Updated all references to use `call` instead of `execute` in DSL methods
- Improved the input coercion logic in the renamed class
- Removed redundant initialization code
- Updated type signatures in Sorbet RBI files

Example usage now looks like:
```ruby
execute do
  cmd(:before) { "echo '--> before'" }
  call { :capitalize_a_random_word }
  call { :capitalize_a_random_word }
  call { :capitalize_a_random_word }
  cmd(:after) { "echo '--> after'" }
end
```