### PR TITLE
Refactor Call system cog to support named execution scopes

### DIFF
--- a/dsl/scoped_executors.rb
+++ b/dsl/scoped_executors.rb
@@ -21,8 +21,10 @@ end
 
 execute do
   cmd(:before) { "echo '--> before'" }
-  call { :capitalize_a_random_word }
-  call { :capitalize_a_random_word }
-  call { :capitalize_a_random_word }
+  # First argument to `call` is the executor scope to run
+  # Second argument is the (optional) cog name
+  call(:capitalize_a_random_word, :first_call)
+  call(:capitalize_a_random_word, :other_named_call)
+  call(:capitalize_a_random_word) # anonymous call cog
   cmd(:after) { "echo '--> after'" }
 end

--- a/lib/roast/dsl/cog.rb
+++ b/lib/roast/dsl/cog.rb
@@ -19,6 +19,11 @@ module Roast
           @input_class ||= find_child_input_or_default #: singleton(Cog::Input)?
         end
 
+        #: () -> Symbol
+        def generate_fallback_name
+          Random.uuid.to_sym
+        end
+
         private
 
         #: () -> singleton(Cog::Config)

--- a/lib/roast/dsl/cog/store.rb
+++ b/lib/roast/dsl/cog/store.rb
@@ -17,11 +17,11 @@ module Roast
           @store = {}
         end
 
-        #: (Symbol, Roast::DSL::Cog) -> Roast::DSL::Cog
-        def insert(id, inst)
-          raise CogAlreadyDefinedError if store.key?(id)
+        #: (Cog) -> Roast::DSL::Cog
+        def insert(cog)
+          raise CogAlreadyDefinedError, cog.name if store.key?(cog.name)
 
-          store[id] = inst
+          store[cog.name] = cog
         end
       end
     end

--- a/lib/roast/dsl/system_cog.rb
+++ b/lib/roast/dsl/system_cog.rb
@@ -4,6 +4,21 @@
 module Roast
   module DSL
     class SystemCog < Cog
+      class << self
+        #: () -> singleton(SystemCog::Params)
+        def params_class
+          @params_class ||= find_child_params_or_default
+        end
+
+        private
+
+        #: () -> singleton(SystemCog::Params)
+        def find_child_params_or_default
+          config_constant = "#{name}::Params"
+          const_defined?(config_constant) ? const_get(config_constant) : SystemCog::Params # rubocop:disable Sorbet/ConstantsFromStrings
+        end
+      end
+
       #: (Symbol, ^(Cog::Input) -> untyped) { (Cog::Input) -> Cog::Output } -> void
       def initialize(name, cog_input_proc, &on_execute)
         super(name, cog_input_proc)

--- a/lib/roast/dsl/system_cog/params.rb
+++ b/lib/roast/dsl/system_cog/params.rb
@@ -1,0 +1,28 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    class SystemCog
+      # Custom parameters allowable for system cogs only.
+      #
+      # These parameters are set via arguments passed to the cog method, not via the cog's input block
+      # This allows some aspects of system cogs' input to be set at workflow evaluation time,
+      # rather workflow execution time.
+      #
+      # Only name is required.
+      # System cogs should extend this class with their own params types if needed.
+      class Params
+        #: Symbol
+        attr_reader :name
+
+        #: (Symbol?) -> void
+        def initialize(name)
+          # Implementing classes should define an initialize method with the specific arguments they expect
+          # Implementations must provide the system cog's name (if set) via params
+          @name = name || Cog.generate_fallback_name
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -5,35 +5,32 @@ module Roast
   module DSL
     module SystemCogs
       class Call < SystemCog
-        class Input < Cog::Input
-          #: Symbol?
+        class Params < SystemCog::Params
+          #: Symbol
           attr_accessor :scope
 
-          #: () -> void
-          def validate!
-            raise Cog::Input::InvalidInputError, "'scope' is required" unless scope.present?
+          #: (Symbol, ?Symbol?) -> void
+          def initialize(scope, name = nil)
+            super(name)
+            @scope = scope
           end
+        end
 
-          #: (Symbol) -> void
-          def coerce(input_return_value)
-            case input_return_value
-            when Symbol
-              self.scope = input_return_value
-            end
-          end
+        class Input < Cog::Input
+          #: () -> void
+          def validate!; end
         end
 
         # @requires_ancestor: ExecutionManager
         module Manager
           private
 
-          #: (Symbol, ^(Cog::Input) -> untyped) -> SystemCogs::Call
-          def create_call_system_cog(name, input_proc)
-            SystemCogs::Call.new(name, input_proc) do |input|
-              input = input #: as SystemCogs::Call::Input
-              raise ExecutionManager::ExecutionScopeNotSpecifiedError unless input.scope.present?
+          #: (Params, ^(Cog::Input) -> untyped) -> SystemCogs::Call
+          def create_call_system_cog(params, input_proc)
+            SystemCogs::Call.new(params.name, input_proc) do |_input|
+              raise ExecutionManager::ExecutionScopeNotSpecifiedError unless params.scope.present?
 
-              em = ExecutionManager.new(@cog_registry, @config_manager, @all_execution_procs, input.scope)
+              em = ExecutionManager.new(@cog_registry, @config_manager, @all_execution_procs, params.scope)
               em.prepare!
               em.run!
 

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -4,8 +4,8 @@
 module Roast
   module DSL
     class ExecutionContext
-      #: (?Symbol?) {(Roast::DSL::SystemCogs::Call::Input) [self: Roast::DSL::CogInputContext] -> Symbol?} -> void
-      def call(name = nil, &block); end
+      #: (Symbol, ?Symbol?) ?{(Roast::DSL::SystemCogs::Call::Input) [self: Roast::DSL::CogInputContext] -> Symbol?} -> void
+      def call(scope, name = nil, &block); end
 
       #: (?Symbol?) {(Roast::DSL::Cogs::Cmd::Input) [self: Roast::DSL::CogInputContext] -> (String | Array[String] | nil)} -> void
       def cmd(name = nil, &block); end


### PR DESCRIPTION
# Update `call` system cog to accept scope as a parameter

This PR changes the `call` system cog to accept the executor scope as a parameter rather than through the input block.

Accepting the scope via the input block was a mistake in the initial implementation of this cog -- a design principal I consider foundational is that the shape of the workflow can be knowable in its entirety when the workflow definition is evaluated, before anything is run. In order to support this, the call relationships between blocks must be determinable without evaluating any cog's input block, which can depend on the output of running previous cogs in the workflow.

Key changes:
- Added a `Params` class to `SystemCog` to handle parameters passed directly to cog methods
- Modified `call` to accept the scope as its first parameter and an optional name as the second parameter
- Updated the execution manager to handle the new parameter structure
- Added a `generate_fallback_name` method to centralize the generation random names for unnamed cogs, since we're now invoking it from multiple places
- Simplified the cog store and cog stacks to just take a cog instance directly rather than separate name and instance

Example usage:
```ruby

cmd(:name_of_cog) {}     # Named regular cog
cmd {}                               # Anonymous regular cog

call(:capitalize_a_random_word, :name_of_call)    # Named call
call(:capitalize_a_random_word)                             # Anonymous call
```
