### PR TITLE
Run CI on all branches instead of just main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: ci
 on:
   pull_request:
     branches:
-      - main
+      - '**'
   push:
     branches:
       - main


### PR DESCRIPTION
Updated CI workflow to run on pull requests targeting any branch, not just the main branch. This is needed so that CI will run on PRs higher up in a Graphite stack. Otherwise, they just never run.