### PR TITLE
Add Agent calls to counts overview

### DIFF
--- a/lib/roast/services/token_counting_service.rb
+++ b/lib/roast/services/token_counting_service.rb
@@ -11,12 +11,24 @@ module Roast
       # Base token overhead for message structure
       MESSAGE_OVERHEAD_TOKENS = 3
 
+      # Additional overhead for agent system prompts and structure. Maybe there's a better way to estimate this?
+      AGENT_OVERHEAD = 10
+
       def count_messages(messages)
         return 0 if messages.nil? || messages.empty?
 
         messages.sum do |message|
           count_message(message)
         end
+      end
+
+      def count_agent_call(prompt, response = nil)
+        return 0 if prompt.nil? || prompt.empty?
+
+        prompt_tokens = estimate_tokens(prompt.to_s)
+        response_tokens = response ? estimate_tokens(response.to_s) : 0
+
+        prompt_tokens + response_tokens + AGENT_OVERHEAD
       end
 
       private

--- a/lib/roast/workflow/step_completion_reporter.rb
+++ b/lib/roast/workflow/step_completion_reporter.rb
@@ -9,11 +9,23 @@ module Roast
         @output = output
       end
 
-      def report(step_name, tokens_consumed, total_tokens)
+      def report(step_name, tokens_consumed, total_tokens, context_manager: nil)
         formatted_consumed = number_with_delimiter(tokens_consumed)
         formatted_total = number_with_delimiter(total_tokens)
 
-        @output.puts "✓ Complete: #{step_name} (consumed #{formatted_consumed} tokens, total #{formatted_total})"
+        base_message = "✓ Complete: #{step_name} (consumed #{formatted_consumed} tokens, total #{formatted_total})"
+
+        # Add breakdown if context manager with agent stats is available
+        if context_manager&.respond_to?(:statistics)
+          stats = context_manager.statistics
+          if stats[:agent_tokens] && stats[:agent_tokens] > 0
+            general_tokens = stats[:general_tokens]
+            agent_tokens = stats[:agent_tokens]
+            base_message += " [general: #{number_with_delimiter(general_tokens)}, agent: #{number_with_delimiter(agent_tokens)}]"
+          end
+        end
+
+        @output.puts base_message
         @output.puts
         @output.puts
       end

--- a/lib/roast/workflow/step_executor_with_reporting.rb
+++ b/lib/roast/workflow/step_executor_with_reporting.rb
@@ -25,7 +25,7 @@ module Roast
 
         step_type = StepTypeResolver.resolve(step, @context)
         step_name = @name_extractor.extract(step, step_type)
-        @reporter.report(step_name, tokens_consumed, tokens_after)
+        @reporter.report(step_name, tokens_consumed, tokens_after, context_manager: @context.workflow.context_manager)
 
         result
       end

--- a/test/roast/services/token_counting_service_test.rb
+++ b/test/roast/services/token_counting_service_test.rb
@@ -76,6 +76,22 @@ module Roast
 
         assert token_count > 0
       end
+
+      test "counts tokens for agent calls with prompt and response" do
+        prompt = "Review this code and suggest improvements"
+        response = "I found several issues that need attention. Consider refactoring the main loop."
+
+        token_count = @service.count_agent_call(prompt, response)
+
+        assert token_count > 0
+        assert_kind_of Integer, token_count
+      end
+
+      test "returns zero for nil agent call prompt" do
+        token_count = @service.count_agent_call(nil)
+
+        assert_equal 0, token_count
+      end
     end
   end
 end

--- a/test/roast/workflow/agent_token_tracking_integration_test.rb
+++ b/test/roast/workflow/agent_token_tracking_integration_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Workflow
+    class AgentTokenTrackingIntegrationTest < ActiveSupport::TestCase
+      def setup
+        @mock_openai_client = mock
+        @mock_openai_client.stubs(:chat).returns("choices" => [{ "message" => { "content" => "Regular LLM response" } }])
+        OpenAI::Client.stubs(:new).returns(@mock_openai_client)
+
+        @original_openai_key = ENV["OPENAI_API_KEY"]
+        ENV["OPENAI_API_KEY"] = "test-key"
+      end
+
+      def teardown
+        OpenAI::Client.unstub(:new)
+        ENV["OPENAI_API_KEY"] = @original_openai_key
+      end
+
+      test "workflow tracks agent token usage separately from general usage" do
+        workflow = mock
+        context_manager = ContextManager.new
+        workflow.stubs(:context_manager).returns(context_manager)
+        workflow.stubs(:resource).returns(nil)
+        workflow.stubs(:output).returns({})
+        workflow.stubs(:transcript).returns([])
+        workflow.stubs(:append_to_final_output)
+        workflow.stubs(:file).returns(nil)
+        workflow.stubs(:config).returns({})
+        workflow.stubs(:model).returns("gpt-3.5-turbo")
+
+        Thread.current[:workflow_context] = { workflow: workflow }
+
+        messages = [{ role: "user", content: "Hello world" }]
+        context_manager.track_usage(messages)
+
+        initial_stats = context_manager.statistics
+        assert initial_stats[:total_tokens] > 0
+        assert_equal initial_stats[:total_tokens], initial_stats[:general_tokens]
+        assert_equal 0, initial_stats[:agent_tokens]
+
+        inline_prompt = "Review this code and identify performance bottlenecks"
+        agent_step = AgentStep.new(workflow, name: inline_prompt)
+
+        Roast::Tools::CodingAgent.expects(:run_claude_code)
+          .with(inline_prompt, include_context_summary: false, continue: false)
+          .returns("Found 3 bottlenecks in the main loop")
+
+        result = agent_step.call
+
+        assert_equal "Found 3 bottlenecks in the main loop", result
+
+        final_stats = context_manager.statistics
+        assert final_stats[:total_tokens] > initial_stats[:total_tokens]
+        assert final_stats[:agent_tokens] > 0
+        assert final_stats[:general_tokens] == initial_stats[:general_tokens]
+        assert_equal 1, final_stats[:agent_call_count]
+        assert final_stats[:average_tokens_per_agent_call] > 0
+
+        assert_equal final_stats[:total_tokens], final_stats[:general_tokens] + final_stats[:agent_tokens]
+      ensure
+        Thread.current[:workflow_context] = nil
+      end
+
+      test "tracks token usage for failed agent calls" do
+        workflow = mock
+        context_manager = ContextManager.new
+        workflow.stubs(:context_manager).returns(context_manager)
+
+        Thread.current[:workflow_context] = { workflow: workflow }
+
+        prompt = "Test prompt that will fail"
+
+        Roast::Tools::CodingAgent.expects(:run_claude_code).raises(Roast::Tools::CodingAgent::CodingAgentError.new("Simulated failure"))
+
+        initial_stats = context_manager.statistics
+
+        result = Roast::Tools::CodingAgent.call(prompt)
+
+        assert result.start_with?("🤖 Error running CodingAgent:")
+
+        final_stats = context_manager.statistics
+        assert final_stats[:agent_tokens] > initial_stats[:agent_tokens]
+        assert_equal 1, final_stats[:agent_call_count]
+      ensure
+        Thread.current[:workflow_context] = nil
+      end
+    end
+  end
+end

--- a/test/roast/workflow/step_completion_reporter_test.rb
+++ b/test/roast/workflow/step_completion_reporter_test.rb
@@ -42,6 +42,26 @@ module Roast
       ensure
         $stderr = original_stderr
       end
+
+      test "includes agent token breakdown when context manager provided with agent usage" do
+        context_manager = mock("context_manager")
+        context_manager.expects(:statistics).returns(total_tokens: 500, general_tokens: 300, agent_tokens: 200)
+
+        @reporter.report("step_with_agents", 150, 500, context_manager: context_manager)
+
+        expected = "✓ Complete: step_with_agents (consumed 150 tokens, total 500) [general: 300, agent: 200]\n\n\n"
+        assert_equal expected, @output.string
+      end
+
+      test "does not include breakdown when no agent tokens used" do
+        context_manager = mock("context_manager")
+        context_manager.expects(:statistics).returns(total_tokens: 300, general_tokens: 300, agent_tokens: 0)
+
+        @reporter.report("step_no_agents", 100, 300, context_manager: context_manager)
+
+        expected = "✓ Complete: step_no_agents (consumed 100 tokens, total 300)\n\n\n"
+        assert_equal expected, @output.string
+      end
     end
   end
 end


### PR DESCRIPTION
I'm not sure whether this is reasonable but I added an Agent overhead of `10`.
Maybe there's a better way in the long term.
This PR might help in the beginning though, I guess.

refs #343