### PR TITLE
Refactor system cogs to use keyword arguments for custom params

### DIFF
--- a/dsl/map.rb
+++ b/dsl/map.rb
@@ -14,7 +14,7 @@ execute(:capitalize_a_word) do
     word ||= cmd(:word).out.strip
     my.command = "sh"
     my.args << "-c"
-    my.args << "echo '#{word}' | tr '[:lower:]' '[:upper:]'"
+    my.args << "echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"
   end
 end
 
@@ -25,13 +25,13 @@ execute do
   # You can use plain Ruby to generate a collection of cogs programmatically
   # This is equivalent to simply defining each of the cogs explicitly, one by one
   # In this case, four copies of the `call` cog invoking :capitalize_a_word
-  words.each { |word| call(:capitalize_a_word) { word } }
+  words.each { |word| call(run: :capitalize_a_word) { word } }
 
   cmd(:foo) { "echo" }
 
   # USING MAP COG
   # You can use the `map` cog to apply a scoped executor to each item in a collection of values
-  map(:capitalize_a_word, :some_name) do |my|
+  map(:some_name, run: :capitalize_a_word) do |my|
     my.items = words
   end
 
@@ -41,5 +41,5 @@ execute do
   # - name of execute scope is required
   # - name of the map cog itself can be omitted (anonymous cog)
   # - items over which to map coerced from return value of input proc
-  map(:capitalize_a_word) { words.reverse }
+  map(run: :capitalize_a_word) { words.reverse }
 end

--- a/dsl/scoped_executors.rb
+++ b/dsl/scoped_executors.rb
@@ -24,21 +24,21 @@ end
 execute do
   cmd(:before) { "echo '--> before'" }
 
-  # First argument to `call` is the executor scope to run
-  # Second argument is the (optional) cog name
-  call(:capitalize_a_random_word, :first_call)
-  call(:capitalize_a_random_word, :other_named_call)
-  call(:capitalize_a_random_word) # anonymous call cog
+  # First positional argument is always the (optional) cog name
+  # Keyword argument "run" is the (required) scope name of the executor to run
+  call(:first_call, run: :capitalize_a_random_word)
+  call(:other_named_call, run: :capitalize_a_random_word)
+  call(run: :capitalize_a_random_word) # anonymous call cog
 
   cmd { "echo '---'" }
 
   # Can invoke a sub-executor with an executor-scoped value, that will be passed to each cog's input proc in that scope
-  call(:capitalize_a_random_word) do |my|
+  call(run: :capitalize_a_random_word) do |my|
     my.value = "scope value: roast"
   end
 
   # Shorthand input coercion for passing a scope value
-  call(:capitalize_a_random_word) { "scope value: other" }
+  call(run: :capitalize_a_random_word) { "scope value: other" }
 
   cmd(:after) { "echo '--> after'" }
 end

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -7,12 +7,12 @@ module Roast
       class Call < SystemCog
         class Params < SystemCog::Params
           #: Symbol
-          attr_accessor :scope
+          attr_accessor :run
 
-          #: (Symbol, ?Symbol?) -> void
-          def initialize(scope, name = nil)
+          #: (?Symbol?, run: Symbol) -> void
+          def initialize(name = nil, run:)
             super(name)
-            @scope = scope
+            @run = run
           end
         end
 
@@ -48,9 +48,9 @@ module Roast
           def create_call_system_cog(params, input_proc)
             SystemCogs::Call.new(params.name, input_proc) do |input|
               input = input #: as Input
-              raise ExecutionManager::ExecutionScopeNotSpecifiedError unless params.scope.present?
+              raise ExecutionManager::ExecutionScopeNotSpecifiedError unless params.run.present?
 
-              em = ExecutionManager.new(@cog_registry, @config_manager, @all_execution_procs, params.scope, input.value)
+              em = ExecutionManager.new(@cog_registry, @config_manager, @all_execution_procs, params.run, input.value)
               em.prepare!
               em.run!
 

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -7,12 +7,12 @@ module Roast
       class Map < SystemCog
         class Params < SystemCog::Params
           #: Symbol
-          attr_accessor :scope
+          attr_accessor :run
 
-          #: (Symbol, ?Symbol?) -> void
-          def initialize(scope, name = nil)
+          #: (?Symbol?, run: Symbol) -> void
+          def initialize(name = nil, run:)
             super(name)
-            @scope = scope
+            @run = run
           end
         end
 
@@ -53,7 +53,7 @@ module Roast
           def create_map_system_cog(params, input_proc)
             SystemCogs::Map.new(params.name, input_proc) do |input|
               input = input #: as Input
-              raise ExecutionManager::ExecutionScopeNotSpecifiedError unless params.scope.present?
+              raise ExecutionManager::ExecutionScopeNotSpecifiedError unless params.run.present?
 
               # For now, just process each item sequentially in a single thread
               input.items.each do |item|
@@ -61,7 +61,7 @@ module Roast
                   @cog_registry,
                   @config_manager,
                   @all_execution_procs,
-                  params.scope,
+                  params.run,
                   item,
                 )
                 em.prepare!

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -4,11 +4,11 @@
 module Roast
   module DSL
     class ExecutionContext
-      #: (Symbol, ?Symbol?) ?{(Roast::DSL::SystemCogs::Call::Input, untyped) [self: Roast::DSL::CogInputContext] -> untyped} -> void
-      def call(scope, name = nil, &block); end
+      #: (?Symbol?, run: Symbol) ?{(Roast::DSL::SystemCogs::Call::Input, untyped) [self: Roast::DSL::CogInputContext] -> untyped} -> void
+      def call(name = nil, run:,  &block); end
 
-      #: (Symbol, ?Symbol?) {(Roast::DSL::SystemCogs::Map::Input, untyped) [self: Roast::DSL::CogInputContext] -> untyped} -> void
-      def map(scope, name = nil, &block); end
+      #: (?Symbol?, run: Symbol) {(Roast::DSL::SystemCogs::Map::Input, untyped) [self: Roast::DSL::CogInputContext] -> untyped} -> void
+      def map(name = nil, run:, &block); end
 
       #: (?Symbol?) {(Roast::DSL::Cogs::Cmd::Input, untyped) [self: Roast::DSL::CogInputContext] -> (String | Array[String] | void)} -> void
       def cmd(name = nil, &block); end


### PR DESCRIPTION
# Refactor system cogs to use keyword arguments for custom params

Pursuant to our discussion this morning @dersam and @nfgrep, this PR changes the way system cogs accept their custom parameters (e.g., for the `call` and `map` cogs, the name of the execution scope they should run).

### Design Principles
- The cog's `name` argument should always be first
- The name argument should always be optional
  - Therefore, system cogs cannot take required positional arguments
- Keyword arguments provide better clarity to readers of the workflow anyway


Example:
```
  call(:named_call, run: :some_subroutine)
  call(run: :some_subroutine) # anonymous call
```
