### PR TITLE
Add skip! and fail! control flow methods to cogs, and bang- and question- versions of output accessors

### DIFF
--- a/dsl/call.rb
+++ b/dsl/call.rb
@@ -14,7 +14,7 @@ execute(:capitalize_a_random_word) do
   cmd(:capitalize) do |my, value_from_call|
     # Optional second block argument lets you use a value passed to the sub-executor by `call`
     # from withing any cog in the sub-executor
-    word = value_from_call || cmd(:word).out.strip
+    word = value_from_call || cmd!(:word).out.strip
     my.command = "/bin/sh"
     my.args << "-c"
     my.args << "/bin/echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"

--- a/dsl/map.rb
+++ b/dsl/map.rb
@@ -11,7 +11,11 @@ end
 
 execute(:capitalize_a_word) do
   cmd(:capitalize) do |my, word|
-    word ||= cmd(:word).out.strip
+    # Use the `fail!` method in a cog's input proc to terminate the cog with a failure state
+    # e.g., if a condition prevents its successful execution.
+    # If `fail!` is called, the input proc will immediately terminate.
+    # The entire workflow may or may not terminate as a result, based on its configuration and the cog's configuration.
+    fail! unless word.present?
     my.command = "sh"
     my.args << "-c"
     my.args << "echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"

--- a/dsl/skip.rb
+++ b/dsl/skip.rb
@@ -1,0 +1,36 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd { print_all! }
+end
+
+execute do
+  cmd(:seconds) { "date +'%S'" }
+
+  cmd(:even) do
+    # `cmd!` output accessor bang method will raise an exception if the named cog did not complete successfully
+    seconds = cmd!(:seconds).out.strip.to_i
+    # Use the `skip!` method in a cog's input proc to conditionally skip this cog
+    # If `skip!` is called, the input proc will immediately terminate
+    skip! if seconds.odd?
+    "echo '#{seconds} is even'"
+  end
+
+  cmd(:odd) do
+    seconds = cmd!(:seconds).out.strip.to_i
+    skip! if seconds.even?
+    "echo '#{seconds} is odd'"
+  end
+
+  cmd do |my|
+    my.command = "echo"
+    # `cmd` output accessor non-bang method will return the cog's output or
+    # nil if the named cog did not run yet or did not complete successfully
+    my.args << "'even' cog ran" unless cmd(:even).nil?
+    # `cmd?` output accessor question method will return true/false if the cog did / did not complete successfully yet
+    my.args << "'odd' cog ran" if cmd?(:odd)
+  end
+end

--- a/dsl/step_communication.rb
+++ b/dsl/step_communication.rb
@@ -15,8 +15,8 @@ execute do
   cmd(:echo) do |my|
     my.command = "echo"
     # TODO: this is a bespoke output object for cmd, is there a generic one we can offer
-    first_line = cmd(:ls).out.split("\n").second
-    last_line = cmd(:ls).out.split("\n").last
+    first_line = cmd!(:ls).out.split("\n").second
+    last_line = cmd!(:ls).out.split("\n").last
     my.args << first_line unless first_line.blank?
     my.args << "\n---\n"
     my.args << last_line if last_line != first_line && last_line.present?

--- a/lib/roast/dsl/cog/config.rb
+++ b/lib/roast/dsl/cog/config.rb
@@ -46,6 +46,16 @@ module Roast
             end
           end
         end
+
+        #: () -> bool
+        def exit_on_error?
+          @values[:exit_on_error] ||= true
+        end
+
+        #: () -> void
+        def continue_on_error!
+          @values[:exit_on_error] = false
+        end
       end
     end
   end

--- a/lib/roast/dsl/cog/output.rb
+++ b/lib/roast/dsl/cog/output.rb
@@ -6,19 +6,7 @@ module Roast
     class Cog
       # Generic output from running a cog.
       # Cogs should extend this class with their own output types.
-      class Output
-        #: bool
-        attr_reader :success
-
-        #: bool
-        attr_reader :abort
-
-        #: (?success: bool, ?abort_workflow: bool) -> void
-        def initialize(success: true, abort_workflow: false)
-          @success = success #: bool
-          @abort = abort_workflow #: bool
-        end
-      end
+      class Output; end
     end
   end
 end

--- a/lib/roast/dsl/cog/store.rb
+++ b/lib/roast/dsl/cog/store.rb
@@ -7,7 +7,7 @@ module Roast
       class Store
         class CogAlreadyDefinedError < Roast::Error; end
 
-        delegate :[], to: :store
+        delegate :[], :key?, to: :store
 
         #: Hash[Symbol, Cog]
         attr_reader :store

--- a/lib/roast/dsl/cog_input_context.rb
+++ b/lib/roast/dsl/cog_input_context.rb
@@ -4,6 +4,16 @@
 module Roast
   module DSL
     # Context in which the individual cog input blocks within the `execute` block of a workflow definition are evaluated
-    class CogInputContext; end
+    class CogInputContext
+      #: () -> void
+      def skip!
+        raise ControlFlow::SkipCog
+      end
+
+      #: () -> void
+      def fail!
+        raise ControlFlow::FailCog
+      end
+    end
   end
 end

--- a/lib/roast/dsl/control_flow.rb
+++ b/lib/roast/dsl/control_flow.rb
@@ -1,0 +1,17 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    # Errors that can be raised to control workflow execution
+    module ControlFlow
+      # Raised in a cog's input block or execute method to terminate the cog and mark it as 'skipped'
+      # without triggering any failure handling
+      class SkipCog < StandardError; end
+
+      # Raised in a cog's input block or execute method to terminate the cog and mark it as 'failed'
+      # without terminating the workflow
+      class FailCog < StandardError; end
+    end
+  end
+end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -4,17 +4,41 @@
 module Roast
   module DSL
     class CogInputContext
-      #: (Symbol) -> Roast::DSL::Cog::Output
+      #: (Symbol) -> Roast::DSL::Cog::Output?
       def call(name); end
 
       #: (Symbol) -> Roast::DSL::Cog::Output
+      def call!(name); end
+
+      #: (Symbol) -> bool
+      def call?(name); end
+
+      #: (Symbol) -> Roast::DSL::Cog::Output?
       def map(name); end
 
-      #: (Symbol) -> Roast::DSL::Cogs::Cmd::Output
+      #: (Symbol) -> Roast::DSL::Cog::Output
+      def map!(name); end
+
+      #: (Symbol) -> bool
+      def map?(name); end
+
+      #: (Symbol) -> Roast::DSL::Cogs::Cmd::Output?
       def cmd(name); end
 
-      #: (Symbol) -> Roast::DSL::Cogs::Chat::Output
+      #: (Symbol) -> Roast::DSL::Cogs::Cmd::Output
+      def cmd!(name); end
+
+      #: (Symbol) -> bool
+      def cmd?(name); end
+
+      #: (Symbol) -> Roast::DSL::Cogs::Chat::Output?
       def chat(name); end
+
+      #: (Symbol) -> Roast::DSL::Cogs::Chat::Output
+      def chat!(name); end
+
+      #: (Symbol) -> bool
+      def chat?(name); end
     end
   end
 end

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -38,9 +38,9 @@ module DSL
         assert_empty stderr
       end
 
-      test "scoped_executors.rb workflow runs successfully" do
-        stdout, stderr = in_sandbox :scoped_executors do
-          Roast::DSL::Workflow.from_file("dsl/scoped_executors.rb")
+      test "call.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :call do
+          Roast::DSL::Workflow.from_file("dsl/call.rb")
         end
 
         lines = stdout.lines.map(&:strip)


### PR DESCRIPTION
This PR include two related concepts that are hard to separate in terms of implementation. I think we should discuss them together.

# Introduce `skip!`, and `fail!` methods for cog flow control

## skip!

Sometimes, you may have a reason to conditionally skip a cog, based on the output of a previous cog. The `skip!` method available in the cog's input proc will do this.

For instance, if you have a step that fetches some data that could be in several formats, you may need to transform it in some way, but only if it is in one of its possible formats. You could define a workflow like this in a simple and clean way:

(I'm using a pseudo-code cog named `cog` as a stand-in for any kind of cog; it'd doesn't matter to the example)

```
cog(:fetch_data) { "... fetches some data..." }

cog(:clean_data) do
  skip! if cog(:fetch_data).clean? 
  "... cleans the data..."
end
```

## fail!

You may also have a case where, because of some aspect of a prior cog's output (not necessarily a failure on its part, though), you don't have a valid state in which to continue the workflow. You could, of course, just raise any old exception, but having a `fail!` method that allows you to communicate to the workflow manager than the failure was sort of intentional allows us to better handle this kind of failure (we definitely don't need to show a stack trace, for example).

For instance, if you have a step that fetches data from an API, you might want to gracefully fail the workflow if the API returns a 404. This is a case you expect to encounter sometimes, though, so you want Roast to handle this kind of failure more gracefully. (TBD, though, what that 'gracefully' will actually look like, in terms of process exit code, what we print to the console, etc.) A workflow that uses this method might look something like this example.

```
cog(:fetch_api_data) { "... fetches some data from a web api..." }

cog(:process_data) do
  fail! unless cog(:fetch_api_data).response.status == 200
  " ... does something with the data ..."
end
```

# Add bang, non-bang, and question versions of cog output accessors

In a world where cogs can be skipped, and/or where cogs can fail but the workflow proceed, it becomes possible, in a subsequent cog's input proc, for the user to request the output of a previous cog that did not complete successfully, or to want to know if a previous cog did or did not run successfully

The current implementation of the cog output accessor methods (what I'm calling the cog name method you call inside a cog's input proc to get a prior cog's output) will raise an exception if the cog did not run and successfully produce output.

I think it's ugly and verbose to expect the user to rescue these exceptions in the input proc, especially if they need to do it a bunch. So, I've added bang and non-bang versions of the output accessor methods, along with a question-mark version that just returns a boolean if the cog's output is / is not present.

Pros:
* clean, clear syntax that is good Ruby style
* simple for user to decide "i want this to throw if the cog didn't run successfully" or "I want to handle the case where the cog didn't run successfully myself" or "I want to ask if this cog ran, but I don't need the output right now"
* `cog?(:name)` is clearer and more idiomatic that calling `cog(:name).nil?` / `cog(:name).present?` as a way to ask "did this cog run successfully?"

Cons:
* most of the time, the user probably wants the bang version of the method (though tbh I'm less sure now that this is true than when I first raised this PR)
* maybe the user still wants some of the output access exceptions to be raised (like, give me nil if the cog was skipped, but raise if the cog failed)

When I was working on this, I thought I was going to kind of hate having to use the bang methods most of the time, but when I actually updated the prototype workflows, I found out that I actually liked it. Curious what you all think.

(Also, for the second con, if the user wants some of the exceptions to still be raised, they can just use the bang method and rescue the ones that want to. I don't think we need a custom mechanism for that in the DSL).


UPDATE: The `CogDoesNotExistError` will *always* raise even with the non-bang or question-mark versions of the output accessor method. In such a case, the workflow is actually invalid, in a way that we would ideally be able to catch at compile time (but can't because the problematic statement is inside a cog input block that we can't evaluate until runtime).
