### PR TITLE
Add Regexp to apply config to several cog instances at once

### DIFF
--- a/dsl/prototype.rb
+++ b/dsl/prototype.rb
@@ -4,11 +4,8 @@
 #: self as Roast::DSL::Workflow
 
 config do
-  # TODO: make a way to do print_all on all and turn off printing on one
   cmd(:echo) { print_all! }
-  cmd(:date) { print_stdout! }
-  # TODO: add a way to apply config to a subset of named cog by pattern
-  # cmd(/^date.*/) { print_all! }
+  cmd(/date/) { print_all! }
 end
 
 execute do
@@ -20,5 +17,6 @@ execute do
   cmd(:echo) { |my| my.command = "echo 'Hello World!'" }
 
   # Cogs can implement input coercion for simple return values
-  cmd(:date) { "date" }
+  cmd(:date_today) { "date" }
+  cmd(:date_yesterday) { RUBY_PLATFORM.include?("darwin") ? "date -jv -1d" : "date -d '-1 day'" }
 end

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -62,14 +62,29 @@ module Roast
             @values[:print_stderr] = true
           end
 
+          def print_none!
+            @values[:print_stdout] = false
+            @values[:print_stderr] = false
+          end
+
           #: () -> void
           def print_stdout!
             @values[:print_stdout] = true
           end
 
           #: () -> void
+          def no_print_stdout!
+            @values[:print_stdout] = false
+          end
+
+          #: () -> void
           def print_stderr!
             @values[:print_stderr] = true
+          end
+
+          #: () -> void
+          def no_print_stderr!
+            @values[:print_stderr] = false
           end
 
           #: () -> bool
@@ -82,10 +97,8 @@ module Roast
             !!@values[:print_stderr]
           end
 
-          #: () -> void
-          def display!
-            print_all!
-          end
+          alias_method(:display!, :print_all!)
+          alias_method(:no_display!, :print_none!)
         end
 
         #: (Input) -> Output

--- a/lib/roast/dsl/config_manager.rb
+++ b/lib/roast/dsl/config_manager.rb
@@ -14,6 +14,7 @@ module Roast
         @config_procs = config_procs
         @config_context = ConfigContext.new #: ConfigContext
         @general_configs = {} #: Hash[singleton(Cog), Cog::Config]
+        @regexp_scoped_configs = {} #: Hash[singleton(Cog), Hash[Regexp, Cog::Config]]
         @name_scoped_configs = {} #: Hash[singleton(Cog), Hash[Symbol, Cog::Config]]
       end
 
@@ -43,6 +44,9 @@ module Roast
 
         # All cogs will always have a config; empty by default if the cog was never explicitly configured
         config = fetch_general_config(cog_class)
+        @regexp_scoped_configs.fetch(cog_class, {}).select do |pattern, _|
+          pattern.match?(name.to_s) unless name.nil?
+        end.values.each { |cfg| config = config.merge(cfg) }
         name_scoped_config = fetch_name_scoped_config(cog_class, name) unless name.nil?
         config = config.merge(name_scoped_config) if name_scoped_config
         config
@@ -53,6 +57,12 @@ module Roast
       #: (singleton(Cog)) -> Cog::Config
       def fetch_general_config(cog_class)
         @general_configs[cog_class] ||= cog_class.config_class.new
+      end
+
+      #: (singleton(Cog), Regexp) -> Cog::Config
+      def fetch_regexp_scoped_config(cog_class, pattern)
+        regexp_scoped_configs_for_cog = @regexp_scoped_configs[cog_class] ||= {}
+        regexp_scoped_configs_for_cog[pattern] ||= cog_class.config_class.new
       end
 
       #: (singleton(Cog), Symbol) -> Cog::Config
@@ -69,27 +79,38 @@ module Roast
       #: (Symbol, singleton(Cog)) -> void
       def bind_cog(cog_method_name, cog_class)
         on_config_method = method(:on_config)
-        cog_method = proc do |cog_name = nil, &cog_config_proc|
-          on_config_method.call(cog_class, cog_name, cog_config_proc)
+        cog_method = proc do |cog_name_or_pattern = nil, &cog_config_proc|
+          on_config_method.call(cog_class, cog_name_or_pattern, cog_config_proc)
         end
         @config_context.instance_eval do
           define_singleton_method(cog_method_name, cog_method)
         end
       end
 
-      #: (singleton(Cog), Symbol, ^() -> void ) -> void
-      def on_config(cog_class, cog_name, cog_config_proc)
+      #: (singleton(Cog), (Symbol | Regexp)?, ^() -> void ) -> void
+      def on_config(cog_class, cog_name_or_pattern, cog_config_proc)
         # Called when the cog method is invoked in the workflow's 'config' block.
         # This allows configuration parameters to be set for the cog generally or for a specific named instance
-        config_object = if cog_name.nil?
+
+        # NOTE: cast to untyped is to intentional handling the 'unreachable' else case here.
+        # This method takes user input directly so additional validation with a clearer exception message will be helpful
+        cog_name_or_pattern = cog_name_or_pattern #: untyped
+        config_object = case cog_name_or_pattern
+        when NilClass
           fetch_general_config(cog_class)
+        when Regexp
+          fetch_regexp_scoped_config(cog_class, cog_name_or_pattern)
+        when Symbol
+          fetch_name_scoped_config(cog_class, cog_name_or_pattern)
         else
-          fetch_name_scoped_config(cog_class, cog_name)
+          raise ArgumentError, "Invalid type '#{cog_name_or_pattern.class}' for cog_name_or_pattern"
         end
+
         # NOTE: Sorbet expects the proc passed to instance_exec to be declared as taking an argument
         # but our cog_config_proc does not get an argument
-        config_object.instance_exec(&T.unsafe(cog_config_proc)) if cog_config_proc
-        config_object
+        cog_config_proc = cog_config_proc #: as ^(untyped) -> void
+        config_object.instance_exec(&cog_config_proc) if cog_config_proc
+        nil
       end
     end
   end

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -10,8 +10,8 @@ module Roast
       #: (?Symbol?) {() [self: Roast::DSL::Cog::Config] -> void} -> void
       def map(name = nil, &block); end
 
-      #: (?Symbol?) {() [self: Roast::DSL::Cogs::Cmd::Config] -> void} -> void
-      def cmd(name = nil, &block); end
+      #: (?(Symbol | Regexp)?) {() [self: Roast::DSL::Cogs::Cmd::Config] -> void} -> void
+      def cmd(name_or_pattern = nil, &block); end
 
       #: (?Symbol?) {() [self: Roast::DSL::Cogs::Chat::Config] -> void} -> void
       def chat(name = nil, &block); end

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -10,6 +10,7 @@ module DSL
         stdout, stderr = in_sandbox :prototype do
           Roast::DSL::Workflow.from_file("dsl/map.rb")
         end
+        assert_empty stderr
         expected_stdout = <<~EOF
           HELLO
           WORLD
@@ -27,22 +28,27 @@ module DSL
           HELLO
         EOF
         assert_equal expected_stdout, stdout
-        assert_empty stderr
       end
 
       test "prototype.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :prototype do
           Roast::DSL::Workflow.from_file("dsl/prototype.rb")
         end
-        assert_match "Hello World!", stdout
         assert_empty stderr
+        lines = stdout.lines.map(&:strip)
+        assert_equal "Hello World!", lines.shift
+        2.times do
+          # match default `date` format
+          assert_match(/^\w+ \w+ \d{2} \d{2}:\d{2}:\d{2} \w+ \d{4}$/, lines.shift, "missing date line")
+        end
+        assert_empty lines
       end
 
       test "call.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :call do
           Roast::DSL::Workflow.from_file("dsl/call.rb")
         end
-
+        assert_empty stderr
         lines = stdout.lines.map(&:strip)
         assert_equal "--> before", lines.shift
         3.times do
@@ -56,19 +62,18 @@ module DSL
         assert_equal "SCOPE VALUE: OTHER", lines.shift
         assert_equal "--> after", lines.shift
         assert_empty lines
-        assert_empty stderr
       end
 
       test "step_communication.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :step_communication do
           Roast::DSL::Workflow.from_file("dsl/step_communication.rb")
         end
+        assert_empty stderr
         lines = stdout.lines.map(&:strip)
         assert_match(/^d([r-][w-][x-]){3}\s+\d+.*\.$/, lines.shift)
         assert_equal "---", lines.shift
         assert_match(/^d([r-][w-][x-]){3}\s+\d+.*\w+$/, lines.shift)
         assert_empty lines
-        assert_empty stderr
       end
     end
   end


### PR DESCRIPTION
This PR adds the capability of using a regex pattern in the `config` block to apply the same config to set of cogs with names matching the pattern. This is useful if you want to have several related named cogs all with the same config.

Example:

```
config do
  cmd { print_stdout! } # apply `print_stdout!` to the default config for all `cmd` cogs.
  cmd(:name) { print_all! } # apply `print_all!` to the config for the cog named `:name`
  cmd(/stuff/) { print_none! } # apply `print_none!` to the config for any cog with a name matching `/stuff`/, such as `:do_stuff` and `:do_other_stuff` etc.
end
```