### PR TITLE
Add doc comments to `cmd` cog config

### DIFF
--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -55,43 +55,70 @@ module Roast
           end
         end
 
+        # TODO: User-facing doc comment about the cog's configuration options would ideally go here,
+        #   and then get copied to config_context.rbi by the tapioca compiler.
+        #   For now, just writing the doc comments there to avoid duplication
         class Config < Cog::Config
+          # Configure the cog to write both STDOUT and STDERR to the console
+          #
+          # - Alias: `print_all!`
+          # - Alias: `display!`
+          #
           #: () -> void
           def print_all!
+            # comment about how this method works
             @values[:print_stdout] = true
             @values[:print_stderr] = true
           end
 
+          # Configure the cog to write __no output__ to the console, neither STDOUT nor STDERR
+          #
+          # - Alias: `no_print_all!`
+          # - Alias: `no_display!`
+          #
+          #: () -> void
           def print_none!
             @values[:print_stdout] = false
             @values[:print_stderr] = false
           end
 
+          # Configure the cog to write STDOUT to the console
+          #
           #: () -> void
           def print_stdout!
             @values[:print_stdout] = true
           end
 
+          # Configure the cog __not__ to write STDOUT to the console
+          #
           #: () -> void
           def no_print_stdout!
             @values[:print_stdout] = false
           end
 
+          # Configure the cog to write STDERR to the console
+          #
           #: () -> void
           def print_stderr!
             @values[:print_stderr] = true
           end
 
+          # Configure the cog __not__ to write STDERR to the console
+          #
           #: () -> void
           def no_print_stderr!
             @values[:print_stderr] = false
           end
 
+          # Check if the cog is configured to write STDOUT to the console
+          #
           #: () -> bool
           def print_stdout?
             !!@values[:print_stdout]
           end
 
+          # Check if the cog is configured to write STDERR to the console
+          #
           #: () -> bool
           def print_stderr?
             !!@values[:print_stderr]

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -10,6 +10,31 @@ module Roast
       #: (?Symbol?) {() [self: Roast::DSL::Cog::Config] -> void} -> void
       def map(name = nil, &block); end
 
+      # Configure the `cmd` cog
+      #
+      # ### Usage
+      # - `cmd { &blk }` - Apply configuration to all instances of the `cmd` cog.
+      # - `cmd(:name) { &blk }` - Apply configuration to the instance of the `cmd` cog named `:name`
+      # - `cmd(/regexp/) { &blk }` - Apply configuration to any instance of the `cmd` cog whose name matches `/regexp/`
+      #
+      # ---
+      #
+      # ### Available Options
+      #
+      # Apply configuration within the block passed to `cmd`.
+      #
+      # These methods are available to apply configuration options to the `cmd` cog:
+      # - `print_all!` – Configure the cog to write both STDOUT and STDERR to the console
+      #   - alias `display!`
+      # - `print_none!` -  Configure the cog to write __no output__ to the console, neither STDOUT nor STDERR
+      #   - alias `no_display!`
+      # - `print_stdout!` - Configure the cog to write STDOUT to the console
+      # - `no_print_stdout!` - Configure the cog __not__ to write STDOUT to the console
+      # - `print_stderr!` - Configure the cog to write STDERR to the console
+      # - `no_print_stderr!` - Configure the cog __not__ to write STDERR to the console
+      #
+      # ---
+      #
       #: (?(Symbol | Regexp)?) {() [self: Roast::DSL::Cogs::Cmd::Config] -> void} -> void
       def cmd(name_or_pattern = nil, &block); end
 


### PR DESCRIPTION
This PR adds reasonable comprehensive user-facing documentation comments to the `cmd` cog's Config class`. These comments will show up in the user's IDE when they are developing a workflow, making discovery of configuration options for this cog, and information on what these options do and how to use the readily available.

Eventually, we should ship similar doc comments for all cogs, and for the execute and cog_input contexts as well, once the framework settles down. This PR is a first demonstration of what doing this could look like.

---

## Examples

Mousing over the `cmd` method in the `config` block, in RubyMine:
![Screenshot 2025-10-21 at 1.42.23 PM.png](https://app.graphite.dev/user-attachments/assets/65906ab2-ade5-42eb-aa31-5e44ca35e417.png)

Mousing over the `cmd` method in the `config` block, in RubyMine (continued):
![Screenshot 2025-10-21 at 1.42.29 PM.png](https://app.graphite.dev/user-attachments/assets/a41f60fb-265c-4bf9-94ed-71b9dd37bbb1.png)

Mousing over the `print_all!` method in the `cmd` cog's config block, in RubyMine:
![Screenshot 2025-10-21 at 1.42.35 PM.png](https://app.graphite.dev/user-attachments/assets/908f94ea-b880-45f3-99e3-e8a9ec9e347a.png)



