### PR TITLE
Improve rake tasks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake rubocop_ci
-      - run: bin/srb tc
+      - run: bundle exec rake sorbet
       - run: bundle exec rake minitest_dsl
       - run: bundle exec rake minitest_functional
       - run: bundle exec rake minitest_old

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@ require "bundler/gem_tasks"
 require "rubocop/rake_task"
 require "rake/testtask"
 
+### Test Tasks
+
 Rake::TestTask.new(:minitest_all) do |t|
   t.libs << "test"
   t.libs << "lib"
@@ -28,7 +30,9 @@ Rake::TestTask.new(:minitest_dsl) do |t|
   t.test_files = FileList["test/dsl/**/*_test.rb"]
 end
 
-task test: [:minitest_all]
+task test: [:minitest_dsl, :minitest_functional, :minitest_old]
+
+### Rubocop Tasks
 
 RuboCop::RakeTask.new(:rubocop_ci)
 
@@ -36,6 +40,17 @@ RuboCop::RakeTask.new(:rubocop) do |task|
   task.options = ["--autocorrect"]
 end
 
-task default: [:test, :rubocop]
+### Sorbet Tasks
 
-task lint: [:rubocop]
+desc "Run Sorbet type checker"
+task :sorbet do
+  sh "bin/srb tc" do |ok, _|
+    abort "Sorbet type checking failed" unless ok
+  end
+end
+
+### Task Groups
+
+task default: [:sorbet, :rubocop, :minitest_dsl]
+
+task check: [:sorbet, :rubocop]


### PR DESCRIPTION
# Improve Rake tasks for easier local development on DSL

Most often right now, I think we want to run sorbet, rubocop, and the DSL test suite, since that's where we're most actively developing.

I set up `bundle exec rake check` to run sorbet and rubocop, and `bundle exec rake` to run sorbet, rubocop, and minitest_dsl.

`bundle exec rake test` will run the full test suite. And everything runs in CI.