### PR TITLE
Remove all sorbet-runtime references from the DSL

### DIFF
--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -131,7 +131,8 @@ module Roast
         #: (Input) -> Output
         def execute(input)
           config = @config #: as Config
-          result = T.unsafe(Roast::Helpers::CmdRunner).popen3(input.command, *input.args) do |stdin, stdout, stderr, wait_thread|
+          result = Roast::Helpers::CmdRunner #: as untyped
+            .popen3(input.command, *input.args) do |stdin, stdout, stderr, wait_thread|
             stdin.close
             command_output = ""
             command_error = ""

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -128,7 +128,8 @@ module Roast
         # Called when the cog method is invoked in the workflow's 'execute' block.
         # This creates the cog instance and prepares it for execution.
         if cog_class <= SystemCog
-          cog_params = T.unsafe(cog_class).params_class.new(*cog_args, **cog_kwargs)
+          untyped_cog_class = cog_class #: as untyped // to remove warning about splats of unknown length
+          cog_params = untyped_cog_class.params_class.new(*cog_args, **cog_kwargs)
           cog_instance = if cog_class == SystemCogs::Call
             create_call_system_cog(cog_params, cog_input_proc)
           elsif cog_class == SystemCogs::Map
@@ -138,7 +139,7 @@ module Roast
           end
         else
           cog_name = Array.wrap(cog_args).shift || Cog.generate_fallback_name
-          cog_instance = T.unsafe(cog_class).new(cog_name, cog_input_proc)
+          cog_instance = cog_class.new(cog_name, cog_input_proc)
         end
         add_cog_instance(cog_instance)
       end


### PR DESCRIPTION
# Remove all sorbet-runtime references from the DSL

I'd ultimately like to be able to remove the sorbet-runtime shims for version 1.0. This is the fist step. I plan to follow this up with a cop to disallow use of `T` in new DSL code.