### PR TITLE
Add `from` output accessor to get context from other execution scopes

### DIFF
--- a/dsl/from.rb
+++ b/dsl/from.rb
@@ -1,0 +1,55 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd { display! }
+  cmd(/to_/) { no_display! }
+end
+
+execute(:capitalize_a_word) do
+  cmd(:to_original) { |_, word| "echo \"#{word}\"" }
+  cmd(:to_upper) do |my, word|
+    my.command = "sh"
+    my.args << "-c"
+    my.args << "echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"
+  end
+  cmd(:to_lower) do |my, word|
+    my.command = "sh"
+    my.args << "-c"
+    my.args << "echo \"#{word}\" | tr '[:upper:]' '[:lower:]'"
+  end
+end
+
+execute do
+  # Call a subroutine with `call`
+  call(:hello, run: :capitalize_a_word) { "Hello" }
+  call(:world, run: :capitalize_a_word) { "World" }
+
+  cmd do
+    # Normally, you can only reference the output of cogs that run in the same executor scope.
+    begin
+      # There is no :to_upper cog that this could sensibly be referring to
+      cmd(:to_upper)
+    rescue Roast::DSL::CogInputManager::CogDoesNotExistError
+      puts "Could not access :to_upper directly"
+    end
+
+    # Using `from`, you can access cogs from the executor scope that was run by a specific named `call`.
+    # The block you pass to `from` runs in the input context of the specified scope, rather than the current scope.
+    original = from(call!(:hello)) { cmd!(:to_original).out.strip }
+    upper = from(call!(:hello)) { cmd!(:to_upper).out.strip }
+    lower = from(call!(:hello)) { cmd!(:to_lower).out.strip }
+    "echo \"#{original} --> #{upper} --> #{lower}\""
+  end
+
+  cmd do
+    # You can also grab the `call`'s output once and pass it to multiple `from` invocations.
+    my_scope = call!(:world)
+    original = from(my_scope) { cmd!(:to_original).out.strip }
+    upper = from(my_scope) { cmd!(:to_upper).out.strip }
+    lower = from(my_scope) { cmd!(:to_lower).out.strip }
+    "echo \"#{original} --> #{upper} --> #{lower}\""
+  end
+end

--- a/lib/roast/dsl/cog_input_context.rb
+++ b/lib/roast/dsl/cog_input_context.rb
@@ -5,6 +5,11 @@ module Roast
   module DSL
     # Context in which the individual cog input blocks within the `execute` block of a workflow definition are evaluated
     class CogInputContext
+      include SystemCogs::Call::InputContext
+
+      class CogInputContextError < Roast::Error; end
+      class ContextNotFoundError < CogInputContextError; end
+
       #: () -> void
       def skip!
         raise ControlFlow::SkipCog

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -57,7 +57,7 @@ module Roast
         @cog_stack.map do |cog|
           cog.run!(
             @config_manager.config_for(cog.class, cog.name),
-            cog_input_manager,
+            cog_input_context,
             @scope_value.deep_dup, # Pass a copy to each cog to guard against mutated values being passed between cogs
           )
         end
@@ -80,7 +80,7 @@ module Roast
       end
 
       #: () -> CogInputContext
-      def cog_input_manager
+      def cog_input_context
         raise ExecutionManagerNotPreparedError unless prepared?
 
         @cog_input_manager.context

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -40,6 +40,14 @@ module Roast
           end
         end
 
+        class Output < Cog::Output
+          #: (ExecutionManager) -> void
+          def initialize(execution_manager)
+            super()
+            @execution_manager = execution_manager
+          end
+        end
+
         # @requires_ancestor: ExecutionManager
         module Manager
           private
@@ -54,8 +62,19 @@ module Roast
               em.prepare!
               em.run!
 
-              Cog::Output.new
+              Output.new(em)
             end
+          end
+        end
+
+        # @requires_ancestor: CogInputContext
+        module InputContext
+          #: [T] (Roast::DSL::SystemCogs::Call::Output) {() -> T} -> T
+          def from(call_cog_output, &block)
+            em = call_cog_output.instance_variable_get(:@execution_manager)
+            raise CogInputContext::ContextNotFoundError if em.nil?
+
+            em.cog_input_context.instance_exec(&block) unless em.nil?
           end
         end
       end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -4,10 +4,10 @@
 module Roast
   module DSL
     class CogInputContext
-      #: (Symbol) -> Roast::DSL::Cog::Output?
+      #: (Symbol) -> Roast::DSL::SystemCogs::Call::Output?
       def call(name); end
 
-      #: (Symbol) -> Roast::DSL::Cog::Output
+      #: (Symbol) -> Roast::DSL::SystemCogs::Call::Output
       def call!(name); end
 
       #: (Symbol) -> bool

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -6,6 +6,39 @@ require "test_helper"
 module DSL
   module Functional
     class RoastDSLExamplesTest < FunctionalTest
+      test "call.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :call do
+          Roast::DSL::Workflow.from_file("dsl/call.rb")
+        end
+        assert_empty stderr
+        lines = stdout.lines.map(&:strip)
+        assert_equal "--> before", lines.shift
+        3.times do
+          word = lines.shift
+          assert_equal word.upcase, lines.shift
+        end
+        assert_equal "---", lines.shift
+        assert_match(/^[\w']+$/, lines.shift)
+        assert_equal "SCOPE VALUE: ROAST", lines.shift
+        assert_match(/^[\w']+$/, lines.shift)
+        assert_equal "SCOPE VALUE: OTHER", lines.shift
+        assert_equal "--> after", lines.shift
+        assert_empty lines
+      end
+
+      test "from.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :from do
+          Roast::DSL::Workflow.from_file("dsl/from.rb")
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          Could not access :to_upper directly
+          Hello --> HELLO --> hello
+          World --> WORLD --> world
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
       test "map.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :prototype do
           Roast::DSL::Workflow.from_file("dsl/map.rb")
@@ -41,26 +74,6 @@ module DSL
           # match default `date` format
           assert_match(/^\w+ \w+ \d{2} \d{2}:\d{2}:\d{2} \w+ \d{4}$/, lines.shift, "missing date line")
         end
-        assert_empty lines
-      end
-
-      test "call.rb workflow runs successfully" do
-        stdout, stderr = in_sandbox :call do
-          Roast::DSL::Workflow.from_file("dsl/call.rb")
-        end
-        assert_empty stderr
-        lines = stdout.lines.map(&:strip)
-        assert_equal "--> before", lines.shift
-        3.times do
-          word = lines.shift
-          assert_equal word.upcase, lines.shift
-        end
-        assert_equal "---", lines.shift
-        assert_match(/^[\w']+$/, lines.shift)
-        assert_equal "SCOPE VALUE: ROAST", lines.shift
-        assert_match(/^[\w']+$/, lines.shift)
-        assert_equal "SCOPE VALUE: OTHER", lines.shift
-        assert_equal "--> after", lines.shift
         assert_empty lines
       end
 


### PR DESCRIPTION
This is the first PR in a stack of new 'meta' output accessors to allow access to the outputs of cogs that were run in a subroutine via `call` or `map`, etc.

## Basic design paradigm

The output of the `call` and `map` cogs themselves do not themselves contain the output of the cogs that ran in their subordinate executor blocks. I considered this but determined that it gets really messy and/or gives the user limited flexibility when it comes to how they want to consume the output, and/or requires us to re-implement big chunks of the `CogInputManager`.

Instead, there should be a simple way to say "run this output accessor logic **in the context of the `CogInputContext` of the subordinate executor**, instead of in the `CogInputContext` of the current executor.

## Example

```
execute(:some_scope) do
  cog(:other) { ... does something ... }
end

execute do
  cog(:normal) { ... does something ... }
  call(:subroutine, run: :some_scope)
  other_cog {
    value_from_own_scope = cog(:normal).value
    value_from_subroutine_scope = from(:subroutine) { cog(:other).value }
  }
end
```

---

## Flow Diagram

This diagram illustrates how the `from` method enables cross-scope output access when writing Roast workflows. See
`dsl/from.rb` for a complete working example.

### The Problem: Scope Isolation

```
┌─────────────────────────────────────────────────────────────────┐
│ execute(:capitalize_a_word) do                                  │
│   cmd(:to_original) { |_, word| "echo \"#{word}\"" }            │
│   cmd(:to_upper) { ... }                                        │
│   cmd(:to_lower) { ... }                                        │
│ end                                                             │
└─────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────┐
│ execute do                                                      │
│   call(:hello, run: :capitalize_a_word) { "Hello" }             │
│                                                                 │
│   cmd do                                                        │
│     # ❌ ERROR: :to_upper doesn't exist in this scope           │
│     cmd(:to_upper)                                              │
│   end                                                           │
│ end                                                             │
└─────────────────────────────────────────────────────────────────┘
```

**Why?** Each `execute` block has its own isolated CogInputContext. The cogs defined in `:capitalize_a_word` are not
accessible from the main execute block.

### The Solution: Context Switching with `from`

```
┌─────────────────────────────────────────────────────────────────┐
│ execute do                                                      │
│   call(:hello, run: :capitalize_a_word) { "Hello" }             │
│                                                                 │
│   cmd do                                                        │
│     # ✅ Works: `from` switches to :hello's context             │
│     upper = from(call!(:hello)) { cmd!(:to_upper).out.strip }   │
│   end                                                           │
│ end                                                             │
└─────────────────────────────────────────────────────────────────┘
```

### Execution Stack Detail

From `dsl/from.rb` lines 41-44:

```ruby
cmd do
  original = from(call!(:hello)) { cmd!(:to_original).out.strip }
  upper = from(call!(:hello)) { cmd!(:to_upper).out.strip }
  lower = from(call!(:hello)) { cmd!(:to_lower).out.strip }
  "echo \"#{original} --> #{upper} --> #{lower}\""
end
```

**Visual Flow:**

```
Main CogInputContext
│
│  You are here (inside cmd block)
│  Available: call(:hello), call(:world)
│  NOT available: cmd(:to_upper), cmd(:to_lower)
│
├─ Call: from(call!(:hello)) { cmd!(:to_original).out.strip }
│   │
│   ├─ Step 1: call!(:hello) retrieves the Call output
│   │           └─> This output "remembers" its CogInputContext
│   │
│   ├─ Step 2: from(...) switches context
│   │           │
│   │           ▼
│   │  ┌────────────────────────────────────────────────┐
│   │  │ :capitalize_a_word CogInputContext             │
│   │  │                                                │
│   │  │ Available: cmd(:to_original)                   │
│   │  │            cmd(:to_upper)                      │
│   │  │            cmd(:to_lower)                      │
│   │  │                                                │
│   │  │ Execute: cmd!(:to_original).out.strip          │
│   │  │           └─> Returns: "Hello"                 │
│   │  └────────────────────────────────────────────────┘
│   │           │
│   │           ▼
│   └─ Step 3: Return to main context with result
│              └─> original = "Hello"
│
├─ Call: from(call!(:hello)) { cmd!(:to_upper).out.strip }
│   └─> Switches context again → returns "HELLO"
│       upper = "HELLO"
│
├─ Call: from(call!(:hello)) { cmd!(:to_lower).out.strip }
│   └─> Switches context again → returns "hello"
│       lower = "hello"
│
└─ Back in main context, build command string
    "echo \"Hello --> HELLO --> hello\""
```