### PR TITLE
Add a `collect` output accessor for collecting outputs from each element of a map

### DIFF
--- a/dsl/collect_from.rb
+++ b/dsl/collect_from.rb
@@ -23,9 +23,10 @@ execute(:capitalize_a_word) do
 end
 
 execute do
-  # Call a subroutine with `call`
+  # Call a subroutine with `call` or `map`
   call(:hello, run: :capitalize_a_word) { "Hello" }
   call(:world, run: :capitalize_a_word) { "World" }
+  map(:other_words, run: :capitalize_a_word) { ["Goodnight", "Moon"] }
 
   cmd do
     # Normally, you can only reference the output of cogs that run in the same executor scope.
@@ -51,5 +52,15 @@ execute do
     upper = from(my_scope) { cmd!(:to_upper).out.strip }
     lower = from(my_scope) { cmd!(:to_lower).out.strip }
     "echo \"#{original} --> #{upper} --> #{lower}\""
+  end
+
+  cmd do
+    # Using `collect`, you can access cogs from the executor scopes that were run by a specific named `map`.
+    # The block you pass to `collect` runs in the input context of each specified scope.
+    # `collect` returns an array containing the output of each invocation of that block.
+    originals = collect(map!(:other_words)) { cmd!(:to_original).out.strip }
+    uppers = collect(map!(:other_words)) { cmd!(:to_upper).out.strip }
+    lowers = collect(map!(:other_words)) { cmd!(:to_lower).out.strip }
+    "echo \"#{originals.join(",")} --> #{uppers.join(",")} --> #{lowers.join(",")}\""
   end
 end

--- a/lib/roast/dsl/cog_input_context.rb
+++ b/lib/roast/dsl/cog_input_context.rb
@@ -6,6 +6,7 @@ module Roast
     # Context in which the individual cog input blocks within the `execute` block of a workflow definition are evaluated
     class CogInputContext
       include SystemCogs::Call::InputContext
+      include SystemCogs::Map::InputContext
 
       class CogInputContextError < Roast::Error; end
       class ContextNotFoundError < CogInputContextError; end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -13,10 +13,10 @@ module Roast
       #: (Symbol) -> bool
       def call?(name); end
 
-      #: (Symbol) -> Roast::DSL::Cog::Output?
+      #: (Symbol) -> Roast::DSL::SystemCogs::Map::Output?
       def map(name); end
 
-      #: (Symbol) -> Roast::DSL::Cog::Output
+      #: (Symbol) -> Roast::DSL::SystemCogs::Map::Output
       def map!(name); end
 
       #: (Symbol) -> bool

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -26,15 +26,16 @@ module DSL
         assert_empty lines
       end
 
-      test "from.rb workflow runs successfully" do
-        stdout, stderr = in_sandbox :from do
-          Roast::DSL::Workflow.from_file("dsl/from.rb")
+      test "collect_from.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :collect_from do
+          Roast::DSL::Workflow.from_file("dsl/collect_from.rb")
         end
         assert_empty stderr
         expected_stdout = <<~EOF
           Could not access :to_upper directly
           Hello --> HELLO --> hello
           World --> WORLD --> world
+          Goodnight,Moon --> GOODNIGHT,MOON --> goodnight,moon
         EOF
         assert_equal expected_stdout, stdout
       end


### PR DESCRIPTION
This PR adds `collect` output accessor method that mirrors the functionality of `from` in the downstack PR.

`collect` lets you retrieve output from all of the subordinate executors run by a `map` cog, and returns an array of the resulting values (whereas `from` pulls output from a single executor run by a `call` and returns a single value instance)

Refer to the downstack PR for adding `from` for a more complete explanation of the design rationale and structure.

## Questions

1. Should this method and `from` be named the same thing, and produce both single-item and array output based on whether they're called on the output of a `call` or a `map`?

I considered that idea and rejected it initially for 2 reasons:
* I generally don't like it when a method call sometimes returns a single object and sometimes returns an array based on some aspect of its input. (Python's `itertools` utilities do this a lot, and it's a huge frustration of mine with that library). So, I've opted for explicit method names that make it clear whether you're collecting results from a mapped iterable, or grabbing a single result from one call.
  * this is not insurmountable. we can overload the typing on a single method to return `T` if it is given a `Call:::Output` and Array[T] if it is given a `Map::Output`, so the type checking will be correct from the user's perspective.
* Having `call` and `map` work with different output accessors makes internal implementation very clean – they can each provide their own mix-in with their own accessors.
  * this is not insurmountable either, and I don't want to optimize for internal elegance over user-facing elegance. But, all else being equal, I prefer an internally elegant solution and it bends toward convincing me a design is sensible and correct.