### PR TITLE
Strip surrounding whitespace from cmd output by default

### DIFF
--- a/dsl/call.rb
+++ b/dsl/call.rb
@@ -14,7 +14,7 @@ execute(:capitalize_a_random_word) do
   cmd(:capitalize) do |my, value_from_call|
     # Optional second block argument lets you use a value passed to the sub-executor by `call`
     # from withing any cog in the sub-executor
-    word = value_from_call || cmd!(:word).out.strip
+    word = value_from_call || cmd!(:word).out
     my.command = "/bin/sh"
     my.args << "-c"
     my.args << "/bin/echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"

--- a/dsl/collect_from.rb
+++ b/dsl/collect_from.rb
@@ -39,18 +39,18 @@ execute do
 
     # Using `from`, you can access cogs from the executor scope that was run by a specific named `call`.
     # The block you pass to `from` runs in the input context of the specified scope, rather than the current scope.
-    original = from(call!(:hello)) { cmd!(:to_original).out.strip }
-    upper = from(call!(:hello)) { cmd!(:to_upper).out.strip }
-    lower = from(call!(:hello)) { cmd!(:to_lower).out.strip }
+    original = from(call!(:hello)) { cmd!(:to_original).out }
+    upper = from(call!(:hello)) { cmd!(:to_upper).out }
+    lower = from(call!(:hello)) { cmd!(:to_lower).out }
     "echo \"#{original} --> #{upper} --> #{lower}\""
   end
 
   cmd do
     # You can also grab the `call`'s output once and pass it to multiple `from` invocations.
     my_scope = call!(:world)
-    original = from(my_scope) { cmd!(:to_original).out.strip }
-    upper = from(my_scope) { cmd!(:to_upper).out.strip }
-    lower = from(my_scope) { cmd!(:to_lower).out.strip }
+    original = from(my_scope) { cmd!(:to_original).out }
+    upper = from(my_scope) { cmd!(:to_upper).out }
+    lower = from(my_scope) { cmd!(:to_lower).out }
     "echo \"#{original} --> #{upper} --> #{lower}\""
   end
 
@@ -58,9 +58,9 @@ execute do
     # Using `collect`, you can access cogs from the executor scopes that were run by a specific named `map`.
     # The block you pass to `collect` runs in the input context of each specified scope.
     # `collect` returns an array containing the output of each invocation of that block.
-    originals = collect(map!(:other_words)) { cmd!(:to_original).out.strip }
-    uppers = collect(map!(:other_words)) { cmd!(:to_upper).out.strip }
-    lowers = collect(map!(:other_words)) { cmd!(:to_lower).out.strip }
+    originals = collect(map!(:other_words)) { cmd!(:to_original).out }
+    uppers = collect(map!(:other_words)) { cmd!(:to_upper).out }
+    lowers = collect(map!(:other_words)) { cmd!(:to_lower).out }
     "echo \"#{originals.join(",")} --> #{uppers.join(",")} --> #{lowers.join(",")}\""
   end
 end

--- a/dsl/skip.rb
+++ b/dsl/skip.rb
@@ -12,7 +12,7 @@ execute do
 
   cmd(:even) do
     # `cmd!` output accessor bang method will raise an exception if the named cog did not complete successfully
-    seconds = cmd!(:seconds).out.strip.to_i
+    seconds = cmd!(:seconds).out.to_i
     # Use the `skip!` method in a cog's input proc to conditionally skip this cog
     # If `skip!` is called, the input proc will immediately terminate
     skip! if seconds.odd?
@@ -20,7 +20,7 @@ execute do
   end
 
   cmd(:odd) do
-    seconds = cmd!(:seconds).out.strip.to_i
+    seconds = cmd!(:seconds).out.to_i
     skip! if seconds.even?
     "echo '#{seconds} is odd'"
   end

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -84,6 +84,8 @@ module Roast
 
           # Configure the cog to write STDOUT to the console
           #
+          # Disabled by default
+          #
           #: () -> void
           def print_stdout!
             @values[:print_stdout] = true
@@ -98,6 +100,8 @@ module Roast
 
           # Configure the cog to write STDERR to the console
           #
+          # Disabled by default
+          #
           #: () -> void
           def print_stderr!
             @values[:print_stderr] = true
@@ -108,6 +112,24 @@ module Roast
           #: () -> void
           def no_print_stderr!
             @values[:print_stderr] = false
+          end
+
+          # Configure the cog to strip surrounding whitespace from the values in its output object
+          #
+          # Default: `true`
+          #
+          #: () -> void
+          def clean_output!
+            @values[:raw_output] = false
+          end
+
+          # Configure the cog __not__ to strip surrounding whitespace from the values in its output object
+          #
+          # Default: `false`
+          #
+          #: () -> void
+          def raw_output!
+            @values[:raw_output] = true
           end
 
           # Check if the cog is configured to write STDOUT to the console
@@ -122,6 +144,10 @@ module Roast
           #: () -> bool
           def print_stderr?
             !!@values[:print_stderr]
+          end
+
+          def raw_output?
+            !!@values[:raw_output]
           end
 
           alias_method(:display!, :print_all!)
@@ -160,6 +186,9 @@ module Roast
             # Wait for threads to finish
             stdout_thread.join
             stderr_thread.join
+
+            command_output = command_output.strip unless config.raw_output?
+            command_error = command_error.strip unless config.raw_output?
 
             [command_output, command_error, wait_thread.value]
           end #: as [String, String, Process::Status]

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -32,6 +32,8 @@ module Roast
       # - `no_print_stdout!` - Configure the cog __not__ to write STDOUT to the console
       # - `print_stderr!` - Configure the cog to write STDERR to the console
       # - `no_print_stderr!` - Configure the cog __not__ to write STDERR to the console
+      # - `clean_output!` - Configure the cog to strip surrounding whitespace from the values in its output object
+      # - `raw_output!` - Configure the cog __not__ to strip surrounding whitespace from the values in its output object
       #
       # ---
       #


### PR DESCRIPTION
This PR addresses a major annoyance I had with legacy Roast, that has so far been present in the DSL version as well:

__when you run a shell command that produces a single line of output and you want to consume that output into a variable and use it for something, you never want a trailing newline__

This PR switches the default behaviour of `cmd` to strip surrounding whitespace on its output, and adds a `raw_output!` config option to disable this behaviour