### PR TITLE
Add `reduce` output accessor method to reduce results of running a `map` cog

### DIFF
--- a/dsl/map_reduce.rb
+++ b/dsl/map_reduce.rb
@@ -1,0 +1,37 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd { display! }
+  cmd(/to_/) { no_display! }
+end
+
+execute(:capitalize_a_word) do
+  cmd(:to_original) { |_, word| "echo \"#{word}\"" }
+  cmd(:to_upper) do |my, word|
+    my.command = "sh"
+    my.args << "-c"
+    my.args << "echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"
+  end
+  cmd(:to_lower) do |my, word|
+    my.command = "sh"
+    my.args << "-c"
+    my.args << "echo \"#{word}\" | tr '[:upper:]' '[:lower:]'"
+  end
+end
+
+execute do
+  # Call a subroutine with `map`
+  map(:words, run: :capitalize_a_word) { ["Hello", "World"] }
+
+  cmd do
+    # Use `reduce` to apply a block to the input context of each executor scope run by `map` in turn.
+    # The return value of each invocation of the block will be passed as the 'accumulator' to the next invocation.
+    # You can provide an optional initial value for the accumulator as the second argument to `reduce`.
+    # If an initial value is present, the return type is non-nilable. If absent, the return type is nilable.
+    words = reduce(map!(:words), "lower case words:") { |acc| acc + " " + cmd!(:to_lower).out }
+    "echo \"#{words}\""
+  end
+end

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -91,6 +91,26 @@ module Roast
 
             ems.map { |em| em.cog_input_context.instance_exec(&block) unless em.nil? }
           end
+
+          #: [A] (Roast::DSL::SystemCogs::Map::Output, ?A?) {(A?) -> A} -> A?
+          def reduce(map_cog_output, initial_value = nil, &block)
+            ems = map_cog_output.instance_variable_get(:@execution_managers)
+            raise CogInputContext::ContextNotFoundError if ems.nil?
+
+            accumulator = initial_value
+            ems.each do |em|
+              new_accumulator = em.cog_input_context.instance_exec(accumulator, &block) unless em.nil?
+              case new_accumulator
+              when nil
+                # do not overwrite a non-nil value in the accumulator with a nil value,
+                # even if one is returned from the block
+              else
+                accumulator = new_accumulator #: as A
+              end
+            end
+
+            accumulator
+          end
         end
       end
     end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -4,6 +4,11 @@
 module Roast
   module DSL
     class CogInputContext
+
+      #: [A] (Roast::DSL::SystemCogs::Map::Output, ?NilClass) {(A?) -> A} -> A?
+      #: [A] (Roast::DSL::SystemCogs::Map::Output, ?A) {(A) -> A} -> A
+      def reduce(map_cog_output, initial_value = nil, &block); end
+
       #: (Symbol) -> Roast::DSL::SystemCogs::Call::Output?
       def call(name); end
 

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -64,6 +64,14 @@ module DSL
         assert_equal expected_stdout, stdout
       end
 
+      test "map_reduce.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :map_reduce do
+          Roast::DSL::Workflow.from_file("dsl/map_reduce.rb")
+        end
+        assert_empty stderr
+        assert_equal "lower case words: hello world", stdout.strip
+      end
+
       test "prototype.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :prototype do
           Roast::DSL::Workflow.from_file("dsl/prototype.rb")


### PR DESCRIPTION
This PR adds `reduce` output accessor method that mirrors the functionality of `collect` and `from` in downstack PRs.

The `reduce` output accessor has generally the same semantics as the normal Ruby `reduce` method on an iterable. You give it an optional initial_value, and a block that takes an accumulator as argument. The return value of the block becomes the value of the accumulator passed to the block the next time it is called, and the return value of the block the final time it is invoked becomes the return value of `reduce` itself.

There is one key semantic difference. Ruby's normal reduce, called on an iterable of objects, takes a block that accepts two arguments, the accumulator and each object from the iterable in turn. The `reduce` output accessor here only passes one argument, the accumulator, to its block. Instead, the block is executed __in the context of each execution scope from the map being reduced__. Thus, no second 'item' argument is necessary.