### PR TITLE
Add shorthand syntax for `from`

### DIFF
--- a/dsl/collect_from.rb
+++ b/dsl/collect_from.rb
@@ -40,8 +40,11 @@ execute do
     # Using `from`, you can access cogs from the executor scope that was run by a specific named `call`.
     # The block you pass to `from` runs in the input context of the specified scope, rather than the current scope.
     original = from(call!(:hello)) { cmd!(:to_original).out }
-    upper = from(call!(:hello)) { cmd!(:to_upper).out }
-    lower = from(call!(:hello)) { cmd!(:to_lower).out }
+    # The type of the return value of `from` is the same type as the return value of the block.
+    upper = from(call!(:hello)) { cmd!(:to_upper) }.out
+    # You can also use this shorthand `from` syntax to get the output of the last cog in its executor scope.
+    # In this syntax, the return value of `from` is untyped
+    lower = from(call!(:hello)).out
     "echo \"#{original} --> #{upper} --> #{lower}\""
   end
 

--- a/lib/roast/dsl/cog/stack.rb
+++ b/lib/roast/dsl/cog/stack.rb
@@ -5,7 +5,7 @@ module Roast
   module DSL
     class Cog
       class Stack
-        delegate :map, :push, :size, :empty?, to: :@queue
+        delegate :empty?, :last, :map, :push, :size, to: :@queue
 
         #: () -> void
         def initialize

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -69,12 +69,18 @@ module Roast
 
         # @requires_ancestor: CogInputContext
         module InputContext
-          #: [T] (Roast::DSL::SystemCogs::Call::Output) {() -> T} -> T
+          # @rbs [T] (Roast::DSL::SystemCogs::Call::Output) {() -> T} -> T
+          #    | (Roast::DSL::SystemCogs::Call::Output) -> untyped
           def from(call_cog_output, &block)
             em = call_cog_output.instance_variable_get(:@execution_manager)
             raise CogInputContext::ContextNotFoundError if em.nil?
 
-            em.cog_input_context.instance_exec(&block) unless em.nil?
+            return em.cog_input_context.instance_exec(&block) if block_given?
+
+            last_cog = em.instance_variable_get(:@cog_stack).last
+            raise CogInputManager::CogDoesNotExistError, "no cogs defined in scope" unless last_cog
+
+            last_cog.output
           end
         end
       end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -5,6 +5,10 @@ module Roast
   module DSL
     class CogInputContext
 
+      #: [T] (Roast::DSL::SystemCogs::Call::Output) {() -> T} -> T
+      #: (Roast::DSL::SystemCogs::Call::Output) -> untyped
+      def from(call_cog_output, &block); end
+
       #: [A] (Roast::DSL::SystemCogs::Map::Output, ?NilClass) {(A?) -> A} -> A?
       #: [A] (Roast::DSL::SystemCogs::Map::Output, ?A) {(A) -> A} -> A
       def reduce(map_cog_output, initial_value = nil, &block); end


### PR DESCRIPTION
Adds a shorthand version of `from` when you just want the output of the last cog in the sub executor scope:

__Existing syntax (retained):__
```
from(call(:foo)) { cog(:name) } # (with a block)
```
gets you the output of the block you pass, evaluated in the subroutine’s `CogInputContext`

__New syntax (added):__
```
from(call(:foo)) # (no block given)
```
gets you the output of the last cog in the subroutine (just like you’d expect the return value of a ruby method to be)