### PR TITLE
Add shorthand syntax for `collect`

### DIFF
--- a/dsl/collect_from.rb
+++ b/dsl/collect_from.rb
@@ -42,7 +42,7 @@ execute do
     original = from(call!(:hello)) { cmd!(:to_original).out }
     # The type of the return value of `from` is the same type as the return value of the block.
     upper = from(call!(:hello)) { cmd!(:to_upper) }.out
-    # You can also use this shorthand `from` syntax to get the output of the last cog in its executor scope.
+    # You can also use this shorthand `from` syntax to get the output of the last cog in the call's executor scope.
     # In this syntax, the return value of `from` is untyped
     lower = from(call!(:hello)).out
     "echo \"#{original} --> #{upper} --> #{lower}\""
@@ -62,8 +62,11 @@ execute do
     # The block you pass to `collect` runs in the input context of each specified scope.
     # `collect` returns an array containing the output of each invocation of that block.
     originals = collect(map!(:other_words)) { cmd!(:to_original).out }
-    uppers = collect(map!(:other_words)) { cmd!(:to_upper).out }
-    lowers = collect(map!(:other_words)) { cmd!(:to_lower).out }
+    # The type of the return value of `call` is an Array of the same type as the return value of the block.
+    uppers = collect(map!(:other_words)) { cmd!(:to_upper) }.map(&:out)
+    # You can also use this shorthand `collect` syntax to get the output of the last cog in each of the map's executor scopes.
+    # In this syntax, the return value of `collect` is Array[untyped]
+    lowers = collect(map!(:other_words)).map(&:out)
     "echo \"#{originals.join(",")} --> #{uppers.join(",")} --> #{lowers.join(",")}\""
   end
 end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -9,6 +9,10 @@ module Roast
       #: (Roast::DSL::SystemCogs::Call::Output) -> untyped
       def from(call_cog_output, &block); end
 
+      #: [T] (Roast::DSL::SystemCogs::Map::Output) {() -> T} -> Array[T]
+      #: (Roast::DSL::SystemCogs::Map::Output) -> Array[untyped]
+      def collect(map_cog_output, &block); end
+
       #: [A] (Roast::DSL::SystemCogs::Map::Output, ?NilClass) {(A?) -> A} -> A?
       #: [A] (Roast::DSL::SystemCogs::Map::Output, ?A) {(A) -> A} -> A
       def reduce(map_cog_output, initial_value = nil, &block); end


### PR DESCRIPTION
Adds a shorthand version of `collect` when you just want the outputs of the last cog in the sub executor scopes run by `map`:

__Existing syntax (retained):__
```
collect(map(:foo)) { cog(:name) } # (with a block)
```
gets you an Array of the outputs of the block you pass, evaluated in the each of the map subroutine’s `CogInputContext`s

__New syntax (added):__
```
collect(map(:foo)) # (no block given)
```
gets you an Array of the outputs of the last cog in each of the map's subroutines (similar to the new shorthand version of `from`)