### PR TITLE
Add an `outputs` declaration to an `execute` block to set a custom 'return value'

### DIFF
--- a/dsl/outputs.rb
+++ b/dsl/outputs.rb
@@ -1,0 +1,34 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd { display! }
+  cmd(/to_/) { no_display! }
+end
+
+execute(:capitalize_a_word) do
+  cmd(:to_original) { |_, word| "echo \"#{word}\"" }
+  cmd(:to_upper) do |my, word|
+    my.command = "sh"
+    my.args << "-c"
+    my.args << "echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"
+  end
+  cmd(:to_lower) do |my, word|
+    my.command = "sh"
+    my.args << "-c"
+    my.args << "echo \"#{word}\" | tr '[:upper:]' '[:lower:]'"
+  end
+  outputs { "Upper: #{cmd!(:to_upper).out}" } # `outputs` can return any kind of value
+end
+
+execute do
+  # Call a subroutine with `call` or `map`
+  call(:hello, run: :capitalize_a_word) { "Hello" }
+
+  cmd do
+    upper = from(call!(:hello))
+    "echo \"#{upper}\""
+  end
+end

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -77,10 +77,7 @@ module Roast
 
             return em.cog_input_context.instance_exec(&block) if block_given?
 
-            last_cog = em.instance_variable_get(:@cog_stack).last
-            raise CogInputManager::CogDoesNotExistError, "no cogs defined in scope" unless last_cog
-
-            last_cog.output
+            em.send(:final_output)
           end
         end
       end

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -4,6 +4,10 @@
 module Roast
   module DSL
     class ExecutionContext
+
+      #: () {() [self: Roast::DSL::CogInputContext] -> untyped} -> void
+      def outputs(&block); end
+
       #: (?Symbol?, run: Symbol) ?{(Roast::DSL::SystemCogs::Call::Input, untyped) [self: Roast::DSL::CogInputContext] -> untyped} -> void
       def call(name = nil, run:,  &block); end
 

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -40,6 +40,14 @@ module DSL
         assert_equal expected_stdout, stdout
       end
 
+      test "outputs.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :outputs do
+          Roast::DSL::Workflow.from_file("dsl/outputs.rb")
+        end
+        assert_empty stderr
+        assert_equal "Upper: HELLO", stdout.strip
+      end
+
       test "map.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :prototype do
           Roast::DSL::Workflow.from_file("dsl/map.rb")


### PR DESCRIPTION
Adds an optional `outputs` declaration to `execute` that allows you to specify a custom 'return value' for that scope when called as a subroutine. 

This lets you override the default 'return value' of the output of the final cog

Example:

```
execute(:sub) do
  cog(:one) { ... }
  cog(:two) { ... }
  cog(:three) { ... }
  outputs { cog(:two) }
end

execute do
  cog(:main) do
    val = from(call(:sub)) # now gives you the output of cog(:two) instead of cog(:three)
  end
end
```

The block given to `outputs` can return any value; it does not have to be the output of a cog.