### PR TITLE
Fix the path and format for the `date` command used in the 'prototype.rb' example workflow

### DIFF
--- a/dsl/prototype.rb
+++ b/dsl/prototype.rb
@@ -17,6 +17,7 @@ execute do
   cmd(:echo) { |my| my.command = "echo 'Hello World!'" }
 
   # Cogs can implement input coercion for simple return values
-  cmd(:date_today) { "date" }
-  cmd(:date_yesterday) { RUBY_PLATFORM.include?("darwin") ? "date -jv -1d" : "date -d '-1 day'" }
+  fmt = "\"+%a %b %d %T %Z %Y\""
+  cmd(:date_today) { "/bin/date #{fmt}" }
+  cmd(:date_yesterday) { RUBY_PLATFORM.include?("darwin") ? "/bin/date -jv -1d #{fmt}" : "/bin/date -d '-1 day' #{fmt}" }
 end


### PR DESCRIPTION
On MacOS with Nix, sometimes a different version of the `date` command is ending up
in $PATH when the functional tests are run. This change ensures that it is always the
expected executable when the `prototype.rb` functional test is run.

As well, different user locale settings can affect the default format printed by `date`

This PR sets both an explicit path and an explicit format when `date` is run in `prototype.rb`
to ensure that there are no spurious test failures on different machines and environments