### PR TITLE
Add bindings for cog? methods to CogInputContext

### DIFF
--- a/lib/roast/dsl/cog/config.rb
+++ b/lib/roast/dsl/cog/config.rb
@@ -47,15 +47,22 @@ module Roast
           end
         end
 
+        #: () -> void
+        def exit_on_error!
+          @values[:exit_on_error] = true
+        end
+
+        #: () -> void
+        def no_exit_on_error!
+          @values[:exit_on_error] = false
+        end
+
         #: () -> bool
         def exit_on_error?
           @values[:exit_on_error] ||= true
         end
 
-        #: () -> void
-        def continue_on_error!
-          @values[:exit_on_error] = false
-        end
+        alias_method(:continue_on_error!, :no_exit_on_error!)
       end
     end
   end

--- a/lib/roast/dsl/cog_input_manager.rb
+++ b/lib/roast/dsl/cog_input_manager.rb
@@ -6,9 +6,13 @@ module Roast
     # Context in which an individual cog block within the `execute` block of a workflow is evaluated
     class CogInputManager
       class CogOutputAccessError < Roast::Error; end
+
       class CogDoesNotExistError < CogOutputAccessError; end
+
       class CogNotYetRunError < CogOutputAccessError; end
+
       class CogSkippedError < CogOutputAccessError; end
+
       class CogFailedError < CogOutputAccessError; end
 
       #: (Cog::Registry, Cog::Store) -> void
@@ -31,11 +35,14 @@ module Roast
 
       #: (Symbol) -> void
       def bind_cog(cog_method_name)
+        cog_question_method_name = (cog_method_name.to_s + "?").to_sym
         cog_bang_method_name = (cog_method_name.to_s + "!").to_sym
         cog_output_method = method(:cog_output)
+        cog_output_question_method = method(:cog_output?)
         cog_output_bang_method = method(:cog_output!)
         @context.instance_eval do
           define_singleton_method(cog_method_name, proc { |cog_name| cog_output_method.call(cog_name) })
+          define_singleton_method(cog_question_method_name, proc { |cog_name| cog_output_question_method.call(cog_name) })
           define_singleton_method(cog_bang_method_name, proc { |cog_name| cog_output_bang_method.call(cog_name) })
         end
       end
@@ -50,6 +57,11 @@ module Roast
         nil
       end
 
+      #: (Symbol) -> bool
+      def cog_output?(cog_name)
+        !cog_output(cog_name).nil?
+      end
+
       #: (Symbol) -> Cog::Output
       def cog_output!(cog_name)
         raise CogDoesNotExistError, cog_name unless @cogs.key?(cog_name)
@@ -59,11 +71,6 @@ module Roast
           raise CogSkippedError, cog_name if cog.skipped?
           raise CogFailedError, cog_name if cog.failed?
         end.output
-      end
-
-      #: (Symbol) -> bool
-      def cog_output?(cog_name)
-        !cog_output(cog_name).nil?
       end
     end
   end

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -146,6 +146,9 @@ module Roast
             !!@values[:print_stderr]
           end
 
+          # Check if the cog is configured to write its output to the console in raw form
+          #
+          #: () -> bool
           def raw_output?
             !!@values[:raw_output]
           end


### PR DESCRIPTION
I forgot to actually bind the `cog?` methods when I added them to the .rbi file. Oops.