### PR TITLE
Add optional index parameter when execution scopes are invoked with `map`

### DIFF
--- a/dsl/map_with_index.rb
+++ b/dsl/map_with_index.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd do
+    print_all!
+  end
+end
+
+execute(:capitalize_a_word) do
+  cmd(:capitalize) do |my, word, index|
+    fail! unless word.present?
+    my.command = "sh"
+    my.args << "-c"
+    # When this execution scope is called by the `map` cog, the optional 'index' argument to this block
+    # will contain the index of its element in the enumerable on which `map` is invoked
+    my.args << "echo \"[#{index}] #{word}\" | tr '[:lower:]' '[:upper:]'"
+  end
+end
+
+execute do
+  words = ["hello", "world", "goodnight", "moon"]
+  map(:some_name, run: :capitalize_a_word) { words }
+end

--- a/lib/roast/dsl/cog.rb
+++ b/lib/roast/dsl/cog.rb
@@ -57,13 +57,15 @@ module Roast
         @config = self.class.config_class.new #: untyped
       end
 
-      #: (Cog::Config, CogInputContext, untyped) -> void
-      def run!(config, input_context, executor_scope_value)
+      #: (Cog::Config, CogInputContext, untyped, Integer) -> void
+      def run!(config, input_context, executor_scope_value, executor_scope_index)
         raise CogAlreadyRanError if ran?
 
         @config = config
         input_instance = self.class.input_class.new
-        input_return = input_context.instance_exec(input_instance, executor_scope_value, &@cog_input_proc) if @cog_input_proc
+        input_return = input_context.instance_exec(
+          input_instance, executor_scope_value, executor_scope_index, &@cog_input_proc
+        ) if @cog_input_proc
         coerce_and_validate_input!(input_instance, input_return)
         @output = execute(input_instance)
       rescue ControlFlow::SkipCog

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -24,24 +24,29 @@ module Roast
 
       class OutputsAlreadyDefinedError < ExecutionManagerError; end
 
-      #: (Cog::Registry, ConfigManager, Hash[Symbol?, Array[^() -> void]], ?Symbol?, ?untyped?) -> void
+      #: (Cog::Registry, ConfigManager, Hash[Symbol?, Array[^() -> void]], ?Symbol?, ?untyped?, ?Integer) -> void
+      # TODO: we should refactor this class to reduce its number of instance variables and number of arguments here
+      # rubocop:disable Metrics/ParameterLists
       def initialize(
         cog_registry,
         config_manager,
         all_execution_procs,
         scope = nil,
-        scope_value = nil
+        scope_value = nil,
+        scope_index = 0
       )
         @cog_registry = cog_registry
         @config_manager = config_manager
         @all_execution_procs = all_execution_procs
         @scope = scope
         @scope_value = scope_value
+        @scope_index = scope_index
         @cogs = Cog::Store.new #: Cog::Store
         @cog_stack = Cog::Stack.new #: Cog::Stack
         @execution_context = ExecutionContext.new #: ExecutionContext
         @cog_input_manager = CogInputManager.new(@cog_registry, @cogs) #: CogInputManager
       end
+      # rubocop:enable Metrics/ParameterLists
 
       #: () -> void
       def prepare!
@@ -64,6 +69,7 @@ module Roast
             @config_manager.config_for(cog.class, cog.name),
             cog_input_context,
             @scope_value.deep_dup, # Pass a copy to each cog to guard against mutated values being passed between cogs
+            @scope_index,
           )
         end
         @running = false

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -64,13 +64,14 @@ module Roast
               raise ExecutionManager::ExecutionScopeNotSpecifiedError unless params.run.present?
 
               # For now, just process each item sequentially in a single thread
-              ems = input.items.map do |item|
+              ems = input.items.map.with_index do |item, index|
                 em = ExecutionManager.new(
                   @cog_registry,
                   @config_manager,
                   @all_execution_procs,
                   params.run,
                   item,
+                  index,
                 )
                 em.prepare!
                 em.run!

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -8,19 +8,19 @@ module Roast
       #: () {() [self: Roast::DSL::CogInputContext] -> untyped} -> void
       def outputs(&block); end
 
-      #: (?Symbol?, run: Symbol) ?{(Roast::DSL::SystemCogs::Call::Input, untyped) [self: Roast::DSL::CogInputContext] -> untyped} -> void
+      #: (?Symbol?, run: Symbol) ?{(Roast::DSL::SystemCogs::Call::Input, untyped, Integer) [self: Roast::DSL::CogInputContext] -> untyped} -> void
       def call(name = nil, run:,  &block); end
 
-      #: (?Symbol?, run: Symbol) {(Roast::DSL::SystemCogs::Map::Input, untyped) [self: Roast::DSL::CogInputContext] -> untyped} -> void
+      #: (?Symbol?, run: Symbol) {(Roast::DSL::SystemCogs::Map::Input, untyped, Integer) [self: Roast::DSL::CogInputContext] -> untyped} -> void
       def map(name = nil, run:, &block); end
 
-      #: (?Symbol?) {(Roast::DSL::Cogs::Cmd::Input, untyped) [self: Roast::DSL::CogInputContext] -> (String | Array[String] | void)} -> void
+      #: (?Symbol?) {(Roast::DSL::Cogs::Cmd::Input, untyped, Integer) [self: Roast::DSL::CogInputContext] -> (String | Array[String] | void)} -> void
       def cmd(name = nil, &block); end
 
-      #: (?Symbol?) {(Roast::DSL::Cogs::Chat::Input, untyped) [self: Roast::DSL::CogInputContext] -> (String | void)} -> void
+      #: (?Symbol?) {(Roast::DSL::Cogs::Chat::Input, untyped, Integer) [self: Roast::DSL::CogInputContext] -> (String | void)} -> void
       def chat(name = nil, &block); end
 
-      #: (?Symbol?) {(Roast::DSL::Cogs::Agent::Input, untyped) [self: Roast::DSL::CogInputContext] -> (String | void)} -> void
+      #: (?Symbol?) {(Roast::DSL::Cogs::Agent::Input, untyped, Integer) [self: Roast::DSL::CogInputContext] -> (String | void)} -> void
       def agent(name = nil, &block); end
     end
   end

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -80,6 +80,20 @@ module DSL
         assert_equal "lower case words: hello world", stdout.strip
       end
 
+      test "map_with_index.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :map_with_index do
+          Roast::DSL::Workflow.from_file("dsl/map_with_index.rb")
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          [0] HELLO
+          [1] WORLD
+          [2] GOODNIGHT
+          [3] MOON
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
       test "prototype.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :prototype do
           Roast::DSL::Workflow.from_file("dsl/prototype.rb")


### PR DESCRIPTION
This PR adds an optional third parameter `index` to a cog_input_proc when it is
invoked inside an `execute` block that has been invoked by map. This provides functionality
equivalent to Ruby's `.map.with_index` method, and allows cogs running inside that scope to know
their index in the source enumerable.

The value of `index` will always be 0 when the scope is not invoked by `map`
(e.g., if it instead invoked by `call`). I considered having the value in this case be `nil`, but
I didn't want users to have to constantly check for nils, and the executor can't know
when, its definition is evaluated, whether it will be invoked via `map` or `call` (or both).
Defaulting to 0 gives the best "it just works" experience for users.

So, with this change, a cog's input proc can look like this at its fullest:

```
execute(:foo) do
  cog(:bar) do |my, scope_value, index|

  end
end

execute do
  map(run: :foo) { ["one", "two", "three"] }
end
```

And the `:bar` cog will be run three times with:
```
my = it's config instance
scope_value = "one"
index = 0
```

then 

```
my = it's config instance
scope_value = "two"
index = 1
```

then 

```
my = it's config instance
scope_value = "three"
index = 2
```

If a cog is run in the main executor, then `scope_value` will be `nil` and `index` will be 0. If a cog is run in a sub-executor invoked by `call` instead of `map`. then the `scope value` will be what is set on the `call`'s input, and the `index` will be 0.