### PR TITLE
Allow `call` to provide a custom index value

### DIFF
--- a/dsl/map_with_index.rb
+++ b/dsl/map_with_index.rb
@@ -22,5 +22,19 @@ end
 
 execute do
   words = ["hello", "world", "goodnight", "moon"]
+
+  # When calling an execute scope with `map`, the index of the item in the enumerable
+  # will be provided to the cogs in that scope
   map(:some_name, run: :capitalize_a_word) { words }
+
+  cmd { "echo" }
+
+  # When calling an execute scope with `call`, the cogs in that scope will receive 0 as the index value by default
+  call(run: :capitalize_a_word) { "default" }
+
+  call(run: :capitalize_a_word) do |my|
+    my.value = "specific"
+    # It is possible to specify a custom index value when invoking `call`
+    my.index = 23
+  end
 end

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -20,6 +20,15 @@ module Roast
           #: untyped
           attr_accessor :value
 
+          # Integer
+          attr_accessor :index
+
+          #: () -> void
+          def initialize
+            super
+            @index = 0
+          end
+
           #: () -> void
           def validate!
             # raise a validation error if value is nil and coercion has not been run, to allow coercion to proceed
@@ -58,7 +67,7 @@ module Roast
               input = input #: as Input
               raise ExecutionManager::ExecutionScopeNotSpecifiedError unless params.run.present?
 
-              em = ExecutionManager.new(@cog_registry, @config_manager, @all_execution_procs, params.run, input.value)
+              em = ExecutionManager.new(@cog_registry, @config_manager, @all_execution_procs, params.run, input.value, input.index)
               em.prepare!
               em.run!
 

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -90,6 +90,9 @@ module DSL
           [1] WORLD
           [2] GOODNIGHT
           [3] MOON
+
+          [0] DEFAULT
+          [23] SPECIFIC
         EOF
         assert_equal expected_stdout, stdout
       end


### PR DESCRIPTION
By default (see downstack), an executor invoked by the `call` cog will receive 0
as its option index parameter (when invoked by `map`, it will receive the index of its item
in the source enumerable).

This PR adds an optional `index` input to the `call` cog that allows the user to
specify a custom index value when invoking `call`.

I doubt this will be a common
use case, but it aligns well with the philosophy that a user should be able to
think "hmm, I wonder if it will work if I do this ... oh, cool, it does!".