### PR TITLE
Allow `map` to set a custom initial index

### DIFF
--- a/dsl/map_with_index.rb
+++ b/dsl/map_with_index.rb
@@ -37,4 +37,13 @@ execute do
     # It is possible to specify a custom index value when invoking `call`
     my.index = 23
   end
+
+  cmd { "echo" }
+
+  # `map` will also take a custom 'initial_index' value, at which to start the value of 'index' passed
+  # to the executors it invokes. This parallels the syntax of Ruby's `items.map.with_index(initial_value) { ... }`
+  map(run: :capitalize_a_word) do |my|
+    my.items = words[1, 2]
+    my.initial_index = 8
+  end
 end

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -20,9 +20,13 @@ module Roast
           #: Array[untyped]
           attr_accessor :items
 
+          #: Integer
+          attr_accessor :initial_index
+
           def initialize
             super
             @items = []
+            @initial_index = 0
           end
 
           #: () -> void
@@ -71,7 +75,7 @@ module Roast
                   @all_execution_procs,
                   params.run,
                   item,
-                  index,
+                  index + input.initial_index,
                 )
                 em.prepare!
                 em.run!

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -93,6 +93,9 @@ module DSL
 
           [0] DEFAULT
           [23] SPECIFIC
+
+          [8] WORLD
+          [9] GOODNIGHT
         EOF
         assert_equal expected_stdout, stdout
       end


### PR DESCRIPTION
This adds an optional `initial_index` input parameter to the `map` cog, allowing
it to start the index values it provides to the executors it invokes at a custom value,
instead of 0.

This parallels the syntax of Ruby's `items.map.with_index(initial_value) { ... }`