### PR TITLE
Add optional parallelism to `map` cog

### DIFF
--- a/dsl/parallel_map.rb
+++ b/dsl/parallel_map.rb
@@ -1,0 +1,37 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd { display! }
+  map(:words) do
+    # By default, maximum parallelism is 1 and map executions will run synchronously
+    # Calling `parallel` with a larger value will allow multiple map items to be run in parallel, up to the limit given
+    # Calling `parallel!` or `parallel(0)` will allow unlimited parallelism, processing all map items in parallel
+    parallel 3
+  end
+end
+
+execute(:capitalize_a_word) do
+  cmd(:to_upper) do |_, word, index|
+    sleep(0.1) if index == 3 # "three" will be slow --> finishing second last
+    sleep(0.2) if index == 1 # "one" will be slowest --> finishing last
+    ["sh", "-c", "echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"]
+  end
+end
+
+execute do
+  # Call a subroutine with `map`
+  map(:words, run: :capitalize_a_word) do |my|
+    my.items = ["one", "two", "three", "four", "five", "six"]
+    my.initial_index = 1 # for convenience, just because our items begin with "one"
+  end
+
+  cmd do |my|
+    my.command = "echo"
+    # Regardless of the order in which the items were processed by a parallel map,
+    # their results will always be provided to `collect` and `reduce` in the order in which they were given.
+    my.args << collect(map!(:words)) { cmd!(:to_upper).out }.join(", ")
+  end
+end

--- a/lib/roast/dsl/system_cog.rb
+++ b/lib/roast/dsl/system_cog.rb
@@ -19,7 +19,7 @@ module Roast
         end
       end
 
-      #: (Symbol, ^(Cog::Input) -> untyped) { (Cog::Input) -> Cog::Output } -> void
+      #: (Symbol, ^(Cog::Input) -> untyped) { (Cog::Input, Cog::Config) -> Cog::Output } -> void
       def initialize(name, cog_input_proc, &on_execute)
         super(name, cog_input_proc)
         @on_execute = on_execute
@@ -29,7 +29,7 @@ module Roast
       def execute(input)
         # The `on_execute` callback allows a system cog to pass its execution back to the ExecutionManager
         # for special handling.
-        @on_execute.call(input)
+        @on_execute.call(input, @config)
       end
     end
   end

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -7,7 +7,7 @@ module Roast
       #: (?Symbol?) {() [self: Roast::DSL::Cog::Config] -> void} -> void
       def call(name = nil, &block); end
 
-      #: (?Symbol?) {() [self: Roast::DSL::Cog::Config] -> void} -> void
+      #: (?Symbol?) {() [self: Roast::DSL::SystemCogs::Map::Config] -> void} -> void
       def map(name = nil, &block); end
 
       # Configure the `cmd` cog

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -100,6 +100,28 @@ module DSL
         assert_equal expected_stdout, stdout
       end
 
+      test "parallel_map.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :parallel_map do
+          Roast::DSL::Workflow.from_file("dsl/parallel_map.rb")
+        end
+        assert_empty stderr
+        # first four lines may appear in a non-deterministic order
+        expected_stdout_first_four_lines = [
+          "TWO",
+          "FOUR",
+          "FIVE",
+          "SIX",
+        ].to_set
+        assert_equal expected_stdout_first_four_lines, stdout.lines[...4].map(&:strip).to_set
+        # last three lines will always appear in the same order
+        expected_stdout_last_three_lines = <<~EOF
+          THREE
+          ONE
+          ONE, TWO, THREE, FOUR, FIVE, SIX
+        EOF
+        assert_equal expected_stdout_last_three_lines, stdout.lines[4..].join("")
+      end
+
       test "prototype.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :prototype do
           Roast::DSL::Workflow.from_file("dsl/prototype.rb")


### PR DESCRIPTION
This PR makes it possible to use `map` to optionally process its items in parallel.

Syntax is:

```
config do
  map(:foo) do
    parallel! # allows unlimited parallelism; all items begin processing at the same time
  end

  map(:bar) do
    parallel(3) # allows up to 3 items to be processed in parallel at the same time.
  end
end
```

The items will begin executing in the order they were passed to `map`, but may complete in any order. When the output of the map is accessed, results will always be returned in the same order in which their respective inputs were given to `map`.