### PR TITLE
Allow generic cogs to be run asynchronously

### DIFF
--- a/dsl/async_cogs.rb
+++ b/dsl/async_cogs.rb
@@ -1,0 +1,49 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd { print_all! }
+
+  # Any type of cog can be configured to run asynchronously in the background.
+  # The cog that follows it in the workflow will be able to begin running immediately.
+  cmd(/slow/) { async! }
+end
+
+execute do
+  # 'first' is synchronous; nothing else runs until it completes.
+  cmd(:first) { "echo first" }
+
+  # These cogs are async and slow, so we kick them off in the background (via the 'async!' config option)
+  # Other cogs can continue while these cog runs in the background
+  cmd(:slow_background_task_1) do
+    sleep 0.1
+    "echo slow background task 1"
+  end
+  cmd(:slow_background_task_2) do
+    sleep 0.2
+    "echo slow background task 2"
+  end
+
+  cmd(:second) { "echo second" }
+  cmd(:third) { "echo third" }
+
+  # 'fourth' accesses the output of 'slow_background_task_1'.
+  # It will block until 'slow_background_task_1' completes.
+  # 'fourth' is synchronous, so cogs that follow it will also be forced to wait (whether they are async or not)
+  cmd(:fourth) do
+    "echo \"fourth <-- '#{cmd!(:slow_background_task_1).out}'\""
+  end
+
+  cmd(:fifth) { "echo fifth" }
+
+  # The overall completion order of these cogs is:
+  # first
+  # second : run right after first; does not have to wait for the slow background tasks to complete
+  # third
+  # slow_background_task_1
+  # fourth : forced to wait for slow_background_task_1 to complete to access its input
+  # fifth
+  # slow_background_task_2 : the workflow will not complete until all async cogs have completed
+end

--- a/dsl/async_cogs_complex.rb
+++ b/dsl/async_cogs_complex.rb
@@ -1,0 +1,67 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd { print_all! }
+
+  # Any type of cog can be configured to run asynchronously.
+  # The cog that follows it in the workflow will be able to begin running immediately, before the async cog has finished.
+  cmd(:second) { async! }
+
+  # If there are a mix of sync and async cogs in a workflow, any synchronous cog may begin running before any
+  # async cogs above it have completed, but no cogs below it -- sync or async -- will start until it has completed.
+  cmd(:third) { no_async! } # NOTE: `no_async!` is redundant here (it's the default); but included here for extra clarity.
+  cmd(:fourth) { async! }
+  cmd(:fifth) { async! }
+  cmd(:sixth) { async! }
+end
+
+execute do
+  # 'first' is synchronous; nothing else runs until it completes.
+  cmd(:first) { "echo first" }
+
+  # 'second' is async and slow; it will not complete until after 'third' is done,
+  # but 'third' will be allowed to start right away.
+  cmd(:second) do
+    sleep 0.2
+    "echo second"
+  end
+
+  # 'third is synchronous and medium-speed; it will not wait for the async cogs above it,
+  # so it will complete before the slow, async 'second' cog.
+  cmd(:third) do
+    sleep 0.1
+    "echo third"
+  end
+
+  # 'fourth' is async, but it will not be allowed to start until the synchronous 'third' cog about it has completed.
+  # It will still complete before the slow-running 'second' cog, though.
+  cmd(:fourth) { "echo fourth" }
+
+  # 'fifth' is async, and fast, and will start before the slow-running 'second' cog.
+  # However, its input depends on the output of 'second', so it will automatically wait for 'second' to complete.
+  cmd(:fifth) do
+    # All the output accessors -- cmd?(:name), cmd(:name), cmd!(:name) -- will block
+    # until the named async cog is complete IF AND ONLY IF it has already started.
+    # If the named cog is defined later in the workflow and thus not already started,
+    # these methods will return immediately.
+    "echo \"fifth (second said: '#{cmd!(:second).out}')\""
+  end
+
+  # 'sixth' is async as well, and it will complete before the slow-running 'second' cog AND before the 'fifth' cog
+  # that is blocking on the output of 'second'
+  cmd(:sixth) do
+    sleep 0.01 # just to make sure this runs slightly slower than 'fourth' to maintain deterministic ordering
+    "echo sixth"
+  end
+
+  # The overall completion order of these cogs is:
+  # first : synchronous; nothing else started until it was done
+  # third : synchronous; did not block on the async 'second' cog
+  # fourth : async; could not start until after 'third'
+  # sixth : async; started at the same time as 'fourth', ran very slightly slower
+  # second : async, slow; started right after 'first', but didn't complete until now
+  # fifth : async; faster than 'second' but depended on its output, so it blocked until 'second' was complete
+end

--- a/lib/roast/dsl/cog/config.rb
+++ b/lib/roast/dsl/cog/config.rb
@@ -62,7 +62,23 @@ module Roast
           @values[:exit_on_error] ||= true
         end
 
+        #: () -> void
+        def async!
+          @values[:async] = true
+        end
+
+        #: () -> void
+        def no_async!
+          @values[:async] = false
+        end
+
+        #: () -> bool
+        def async?
+          !!@values[:async]
+        end
+
         alias_method(:continue_on_error!, :no_exit_on_error!)
+        alias_method(:sync!, :no_async!)
       end
     end
   end

--- a/lib/roast/dsl/cog/stack.rb
+++ b/lib/roast/dsl/cog/stack.rb
@@ -5,7 +5,7 @@ module Roast
   module DSL
     class Cog
       class Stack
-        delegate :empty?, :last, :map, :push, :size, to: :@queue
+        delegate :each, :empty?, :last, :map, :push, :size, to: :@queue
 
         #: () -> void
         def initialize

--- a/lib/roast/dsl/cog_input_manager.rb
+++ b/lib/roast/dsl/cog_input_manager.rb
@@ -15,6 +15,8 @@ module Roast
 
       class CogFailedError < CogOutputAccessError; end
 
+      class CogStoppedError < CogOutputAccessError; end
+
       #: (Cog::Registry, Cog::Store) -> void
       def initialize(cog_registry, cogs)
         @cog_registry = cog_registry
@@ -70,6 +72,7 @@ module Roast
           raise CogNotYetRunError, cog_name unless cog.ran?
           raise CogSkippedError, cog_name if cog.skipped?
           raise CogFailedError, cog_name if cog.failed?
+          raise CogStoppedError, cog_name if cog.stopped?
         end.output
       end
     end

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -110,17 +110,15 @@ module Roast
                 em
               end
 
-              ems = Async do
-                max_parallel_semaphore = Async::Semaphore.new(config.max_parallel_tasks) if config.max_parallel_tasks.present?
-                tasks = input.items.map.with_index do |item, index|
-                  if max_parallel_semaphore
-                    max_parallel_semaphore.async { create_and_run_execution_manager.call(item, index) }
-                  else
-                    Async { create_and_run_execution_manager.call(item, index) }
-                  end
+              max_parallel_semaphore = Async::Semaphore.new(config.max_parallel_tasks) if config.max_parallel_tasks.present?
+              tasks = input.items.map.with_index do |item, index|
+                if max_parallel_semaphore
+                  max_parallel_semaphore.async { create_and_run_execution_manager.call(item, index) }
+                else
+                  Async { create_and_run_execution_manager.call(item, index) }
                 end
-                tasks.map(&:wait)
-              end.wait
+              end
+              ems = tasks.map(&:wait)
 
               Output.new(ems)
             end

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -6,6 +6,39 @@ require "test_helper"
 module DSL
   module Functional
     class RoastDSLExamplesTest < FunctionalTest
+      test "async_cogs.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :async_cogs do
+          Roast::DSL::Workflow.from_file("dsl/async_cogs.rb")
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          first
+          second
+          third
+          slow background task 1
+          fourth <-- 'slow background task 1'
+          fifth
+          slow background task 2
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
+      test "async_cogs_complex.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :async_cogs_complex do
+          Roast::DSL::Workflow.from_file("dsl/async_cogs_complex.rb")
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          first
+          third
+          fourth
+          sixth
+          second
+          fifth (second said: 'second')
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
       test "call.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :call do
           Roast::DSL::Workflow.from_file("dsl/call.rb")


### PR DESCRIPTION
This PR adds the ability trigger async processing for any cog.

The motivation for this feature is somewhat distinct from async `map`s. In the map case, it's basically "process these items in parallel; but don't move on to the next cog in the overall stack until all items are processed". With individual async cogs, it's basically "fork this one cog and let it run in the background while execution continues down the cog stack"

One would generally do something like this:

```
config do
  cmd(:slow) do
    async!
  end
end

execute do
  cmd(:slow) { "kick off something to run in the background" }
  cmd(:foo) { "this does not depend on :slow, so it can start right away" }
  cmd(:bar) { "ditto for this one; it runs after :foo completes, like normal" }
  cmd(:use_output_of_slow) do
    result = cmd!(:slow).out
    "this one depends on the output of :slow, so it will block until :slow is done"
  end
  cmd(:baz) { "this does not need :slow, but it runs synchronously after :use_output_of_slow, so it doesn't start until that cog is done; like normal" }
end
```