### PR TITLE
Add a `ruby` cog that just outputs the return value of the ruby code you write in its input block

### DIFF
--- a/dsl/ruby_cog.rb
+++ b/dsl/ruby_cog.rb
@@ -1,0 +1,37 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+class MyClass
+  class << self
+    def add_stuff(a, b)
+      a + b
+    end
+  end
+end
+
+config do
+  cmd { print_all! }
+end
+
+execute do
+  cmd(:roast) { "echo Roast" }
+
+  # The `ruby` cog just passes the return value from its input block directly to its output.
+  # Letting you write whatever ruby code you want to generate that output
+  ruby(:whatever) do
+    # Do whatever you want in this block
+    value = cmd!(:roast).out
+    puts "Hello, #{value.upcase}"
+    puts "Calling a method: #{MyClass.add_stuff(3, 4)}"
+    # The value you return will be exposed as the .value attribute on the cog's output
+    1..5
+  end
+
+  cmd(:numbers) do |my|
+    my.command = "echo"
+    value = ruby!(:whatever).value.map { |n| n.to_s * n }
+    my.args = value
+  end
+end

--- a/lib/roast/dsl/cog/input.rb
+++ b/lib/roast/dsl/cog/input.rb
@@ -23,7 +23,16 @@ module Roast
         # to coerce the input to a valid state.
         # Inheriting cog may implement this for its input class; it is optional
         #: (untyped) -> void
-        def coerce(input_return_value); end
+        def coerce(input_return_value)
+          @coerce_ran = true
+        end
+
+        private
+
+        #: () -> bool
+        def coerce_ran?
+          @coerce_ran ||= false
+        end
       end
     end
   end

--- a/lib/roast/dsl/cog/registry.rb
+++ b/lib/roast/dsl/cog/registry.rb
@@ -15,6 +15,7 @@ module Roast
           use(Cogs::Cmd)
           use(Cogs::Chat)
           use(Cogs::Agent)
+          use(Cogs::Ruby)
         end
 
         #: Hash[Symbol, singleton(Cog)]

--- a/lib/roast/dsl/cogs/ruby.rb
+++ b/lib/roast/dsl/cogs/ruby.rb
@@ -1,0 +1,46 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Ruby < Cog
+        class Config < Cog::Config; end
+
+        class Input < Cog::Input
+          # This value will be directly returned as the 'value' attribute on the cog's output object
+          #
+          #: untyped
+          attr_accessor :value
+
+          #: () -> void
+          def validate!
+            raise Cog::Input::InvalidInputError if value.nil? && !coerce_ran?
+          end
+
+          #: (untyped) -> void
+          def coerce(input_return_value)
+            super
+            @value = input_return_value
+          end
+        end
+
+        class Output < Cog::Output
+          #: untyped
+          attr_reader :value
+
+          #: (untyped) -> void
+          def initialize(value)
+            super()
+            @value = value
+          end
+        end
+
+        #: (Input) -> Output
+        def execute(input)
+          Output.new(input.value)
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -31,21 +31,12 @@ module Roast
 
           #: () -> void
           def validate!
-            # raise a validation error if value is nil and coercion has not been run, to allow coercion to proceed
-            raise Cog::Input::InvalidInputError, "'value' is required" if value.nil? && !permit_nil_value?
+            raise Cog::Input::InvalidInputError, "'value' is required" if value.nil? && !coerce_ran?
           end
 
           def coerce(input_return_value)
-            # Do not raise a validation error if value is nil when validation is called *after* coercion.
-            @permit_nil_value = true
+            super
             @value = input_return_value unless @value.present?
-          end
-
-          private
-
-          #: () -> bool
-          def permit_nil_value?
-            @permit_nil_value ||= false
           end
         end
 

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -32,20 +32,13 @@ module Roast
           #: () -> void
           def validate!
             raise Cog::Input::InvalidInputError, "'items' is required" if items.nil?
-            # raise a validation error items is empty and coercion has not been run, to allow coercion to proceed
-            raise Cog::Input::InvalidInputError if items.blank? && !permit_empty_items?
+            raise Cog::Input::InvalidInputError if items.empty? && !coerce_ran?
           end
 
           #: (Array[untyped]) -> void
           def coerce(input_return_value)
+            super
             @items = Array.wrap(input_return_value) unless @items.present?
-          end
-
-          private
-
-          #: () -> bool
-          def permit_empty_items?
-            @permit_empty_items ||= false
           end
         end
 

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -52,6 +52,15 @@ module Roast
 
       #: (Symbol) -> bool
       def chat?(name); end
+
+      #: (Symbol) -> Roast::DSL::Cogs::Ruby::Output?
+      def ruby(name); end
+
+      #: (Symbol) -> Roast::DSL::Cogs::Ruby::Output
+      def ruby!(name); end
+
+      #: (Symbol) -> bool
+      def ruby?(name); end
     end
   end
 end

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -45,6 +45,9 @@ module Roast
 
       #: (?Symbol?) {() [self: Roast::DSL::Cogs::Agent::Config] -> void} -> void
       def agent(name = nil, &block); end
+
+      #: (?Symbol?) {() [self: Roast::DSL::Cogs::Ruby::Config] -> void} -> void
+      def ruby(name_or_pattern = nil, &block); end
     end
   end
 end

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -22,6 +22,9 @@ module Roast
 
       #: (?Symbol?) {(Roast::DSL::Cogs::Agent::Input, untyped, Integer) [self: Roast::DSL::CogInputContext] -> (String | void)} -> void
       def agent(name = nil, &block); end
+
+      #: (?Symbol?) {(Roast::DSL::Cogs::Ruby::Input, untyped, Integer) [self: Roast::DSL::CogInputContext] -> untyped} -> void
+      def ruby(name = nil, &block); end
     end
   end
 end

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -197,6 +197,20 @@ module DSL
         assert_includes stdout, "Hi! How can I help you today?"
         assert_empty stderr
       end
+
+      test "ruby_cog.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :ruby_cog do
+          Roast::DSL::Workflow.from_file("dsl/ruby_cog.rb")
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          Roast
+          Hello, ROAST
+          Calling a method: 7
+          1 22 333 4444 55555
+        EOF
+        assert_equal expected_stdout, stdout
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds a `ruby` cog that just outputs the return value of the ruby code you write in its input block

This is a more powerful and flexible replacement for the Ruby step functionality in legacy Roast.

---

__You can pretty easily do any of the following__

In-line Ruby code:
```
execute do
  ruby(:foo) do
    # write any Ruby code you want
    # access the output of previous cogs; whatever
    # return anything you want
  end

  cmd do
    # return value of `ruby(:foo)` is available as the `value` attribute on its output object
    results = ruby(:foo).value
  end
end
```

external Ruby class step
```
require "path/to/something.rb"

execute do
  ruby(:foo) do
    something = Something.new("whatever")
    something.do_a_thing
  end
end
```

in-line Ruby, defined elsewhere in the workflow file:

```
# note, you need to put your method in a class, because the `basic` cog's block runs in a different context
class MyClass
  class << self
    def my_method(a, b)
      # write some code here
  end
end

execute do
  ruby(:foo) { MyClass.my_method(1, 2) }
  ruby(:bar) { MyClass.my_method(3, 4) }
end
```
