### PR TITLE
Add validator block to field definition, and explicit use_default bang method

### DIFF
--- a/dsl/simple_agent.rb
+++ b/dsl/simple_agent.rb
@@ -4,8 +4,8 @@
 #: self as Roast::DSL::Workflow
 
 config do
-  agent(:foo) do
-    provider(:claude)
+  agent do
+    provider :claude
   end
 end
 

--- a/lib/roast/dsl/cog/config.rb
+++ b/lib/roast/dsl/cog/config.rb
@@ -32,17 +32,22 @@ module Roast
         end
 
         class << self
-          def field(key, default)
+          #: [T] (Symbol, T) ?{(T) -> T} -> void
+          def field(key, default, &validator)
             define_method(key) do |*args|
               if args.empty?
-                if @values[key].nil?
-                  @values[key] = default
-                end
-
-                @values[key]
+                # with no args, return the configured value, or the default
+                @values[key] || default
               else
-                @values[key] = args.first
+                # with an argument, set the configured value
+                new_value = args.first
+                @values[key] = validator ? validator.call(new_value) : new_value
               end
+            end
+
+            define_method("use_default_#{key}!".to_sym) do
+              # explicitly set the configured value to the default
+              @values[key] = default
             end
           end
         end

--- a/lib/roast/dsl/cogs/agent.rb
+++ b/lib/roast/dsl/cogs/agent.rb
@@ -45,7 +45,14 @@ module Roast
         end
 
         class Config < Cog::Config
-          field :provider, :claude
+          VALID_PROVIDERS = [:claude].freeze #: Array[Symbol]
+          field :provider, :claude do |provider|
+            unless VALID_PROVIDERS.include?(provider)
+              raise ArgumentError, "'#{provider}' is not a valid provider. Available providers include: #{VALID_PROVIDERS.join(", ")}"
+            end
+
+            provider
+          end
         end
 
         #: Roast::DSL::Cogs::Agent::Config

--- a/sorbet/rbi/shims/lib/roast/dsl/cogs/agent.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cogs/agent.rbi
@@ -6,8 +6,12 @@ module Roast
     module Cogs
       class Agent
         class Config
-          #: (?Symbol?) -> Symbol
-          def provider(value = nil); end
+          #: (Symbol) -> Symbol
+          #: () -> Symbol
+          def provider(value); end
+
+          #: () -> Symbol
+          def use_default_provider!; end
         end
       end
     end


### PR DESCRIPTION
This PR adds an optional validator block to the `field` definition functionality on cog input.
The validator, if present, can raise an error and optionally coerce the new user-provided value to
a canonical form.

---

This PR also provides a clearer way for users to explicitly indicate in their config blocks that they wish to explicitly use the default value of a config field, overriding a previously configured non-default value.

The field can be invoked in three ways:

```
config do
  agent do

  # sets the provider to :something
  provider :something

  # Sets the provider to be the configured default value for the field
  # NOTE: this sets the default explicitly, meaning that it will overwrite the value selected on a more generic config level
  use_default_provider!

  # Returns the current value of the provider, without changing it
  # (previously, this would have reset the provider to the default value)
  provider

  end
end
```

The utility of explicitly setting the default can be demonstrated in an example of some config-merging behaviour:

```
config do

  agent do
    provider :my_provider
    model "my-model"
  end

  agent(:special) do
    provider :special_provider
    model "special-model"
  end

  agent(:normal) do
    use_default_provider!
  end

  agent(:other) do
    model "other-model"
  end
end

execute do

  # uses :my_provider and "my-model" (set in the global `agent` config block)
  agent { ... }

  # uses :my_provider and "my-model" (set in the global `agent` config block)
  agent(:random_name) { ... }

  # uses :special_provider and "special-model" (set in the :special `agent` config block)
  agent(:special) { ... }

  # uses the Roast default provider (overriding the global `agent` config block)
  # and "my-model" (set in the global `agent` config block)
  agent(:normal) { ... }

  # uses :my_provider (set in the global `agent` config block)
  # and "other-model" (set in the :other `agent` config block)
  agent(:other) { ... }
end
```