### PR TITLE
Reorder Config, Params, Input, Output classes in Cog definitions

### DIFF
--- a/lib/roast/dsl/cogs/agent.rb
+++ b/lib/roast/dsl/cogs/agent.rb
@@ -10,6 +10,17 @@ module Roast
         class MissingProviderError < AgentCogError; end
         class MissingPromptError < AgentCogError; end
 
+        class Config < Cog::Config
+          VALID_PROVIDERS = [:claude].freeze #: Array[Symbol]
+          field :provider, :claude do |provider|
+            unless VALID_PROVIDERS.include?(provider)
+              raise ArgumentError, "'#{provider}' is not a valid provider. Available providers include: #{VALID_PROVIDERS.join(", ")}"
+            end
+
+            provider
+          end
+        end
+
         class Input < Cog::Input
           #: String?
           attr_accessor :prompt
@@ -44,18 +55,7 @@ module Roast
           end
         end
 
-        class Config < Cog::Config
-          VALID_PROVIDERS = [:claude].freeze #: Array[Symbol]
-          field :provider, :claude do |provider|
-            unless VALID_PROVIDERS.include?(provider)
-              raise ArgumentError, "'#{provider}' is not a valid provider. Available providers include: #{VALID_PROVIDERS.join(", ")}"
-            end
-
-            provider
-          end
-        end
-
-        #: Roast::DSL::Cogs::Agent::Config
+        #: Agent::Config
         attr_reader :config
 
         #: (Input) -> Output

--- a/lib/roast/dsl/cogs/chat.rb
+++ b/lib/roast/dsl/cogs/chat.rb
@@ -5,6 +5,14 @@ module Roast
   module DSL
     module Cogs
       class Chat < Cog
+        class Config < Cog::Config
+          field :model, "gpt-4o-mini"
+          field :api_key, ENV["OPENAI_API_KEY"]
+          field :base_url, ENV.fetch("OPENAI_API_BASE_URL", "https://api.openai.com/v1")
+          field :provider, :openai
+          field :assume_model_exists, false
+        end
+
         class Input < Cog::Input
           #: String?
           attr_accessor :prompt
@@ -31,14 +39,6 @@ module Roast
             super()
             @response = response
           end
-        end
-
-        class Config < Cog::Config
-          field :model, "gpt-4o-mini"
-          field :api_key, ENV["OPENAI_API_KEY"]
-          field :base_url, ENV.fetch("OPENAI_API_BASE_URL", "https://api.openai.com/v1")
-          field :provider, :openai
-          field :assume_model_exists, false
         end
 
         #: Roast::DSL::Cogs::Chat::Config

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -5,56 +5,6 @@ module Roast
   module DSL
     module Cogs
       class Cmd < Cog
-        class Input < Cog::Input
-          #: String?
-          attr_accessor :command
-
-          #: Array[String]
-          attr_accessor :args
-
-          #: () -> void
-          def initialize
-            super
-            @args = []
-          end
-
-          #: () -> void
-          def validate!
-            raise Cog::Input::InvalidInputError, "'command' is required" unless command.present?
-          end
-
-          #: (String | Array[untyped]) -> void
-          def coerce(input_return_value)
-            case input_return_value
-            when String
-              self.command = input_return_value
-            when Array
-              input_return_value.map!(&:to_s)
-              self.command = input_return_value.shift
-              self.args = input_return_value
-            end
-          end
-        end
-
-        class Output < Cog::Output
-          #: String
-          attr_reader :out
-
-          #: String
-          attr_reader :err
-
-          #: Process::Status
-          attr_reader :status
-
-          #: ( String, String, Process::Status) -> void
-          def initialize(out, err, status)
-            super()
-            @out = out #: String
-            @err = err #: String
-            @status = status #: Process::Status
-          end
-        end
-
         # TODO: User-facing doc comment about the cog's configuration options would ideally go here,
         #   and then get copied to config_context.rbi by the tapioca compiler.
         #   For now, just writing the doc comments there to avoid duplication
@@ -155,6 +105,56 @@ module Roast
 
           alias_method(:display!, :print_all!)
           alias_method(:no_display!, :print_none!)
+        end
+
+        class Input < Cog::Input
+          #: String?
+          attr_accessor :command
+
+          #: Array[String]
+          attr_accessor :args
+
+          #: () -> void
+          def initialize
+            super
+            @args = []
+          end
+
+          #: () -> void
+          def validate!
+            raise Cog::Input::InvalidInputError, "'command' is required" unless command.present?
+          end
+
+          #: (String | Array[untyped]) -> void
+          def coerce(input_return_value)
+            case input_return_value
+            when String
+              self.command = input_return_value
+            when Array
+              input_return_value.map!(&:to_s)
+              self.command = input_return_value.shift
+              self.args = input_return_value
+            end
+          end
+        end
+
+        class Output < Cog::Output
+          #: String
+          attr_reader :out
+
+          #: String
+          attr_reader :err
+
+          #: Process::Status
+          attr_reader :status
+
+          #: ( String, String, Process::Status) -> void
+          def initialize(out, err, status)
+            super()
+            @out = out #: String
+            @err = err #: String
+            @status = status #: Process::Status
+          end
         end
 
         #: (Input) -> Output

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -5,6 +5,8 @@ module Roast
   module DSL
     module SystemCogs
       class Call < SystemCog
+        class Config < Cog::Config; end
+
         class Params < SystemCog::Params
           #: Symbol
           attr_accessor :run

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -5,6 +5,31 @@ module Roast
   module DSL
     module SystemCogs
       class Map < SystemCog
+        class Config < Cog::Config
+          #: (Integer) -> void
+          def parallel(value)
+            raise ArgumentError, "value must be >= 0" if value < 0
+
+            # treat 0 as unlimited parallelism
+            @values[:parallel] = value > 0 ? value : nil
+          end
+
+          #: () -> void
+          def parallel!
+            @values[:parallel] = nil
+          end
+
+          #: () -> void
+          def no_parallel!
+            @values[:parallel] = 1
+          end
+
+          #: () -> Integer?
+          def max_parallel_tasks
+            @values.fetch(:parallel, 1)
+          end
+        end
+
         class Params < SystemCog::Params
           #: Symbol
           attr_accessor :run
@@ -47,31 +72,6 @@ module Roast
           def initialize(execution_managers)
             super()
             @execution_managers = execution_managers
-          end
-        end
-
-        class Config < Cog::Config
-          #: (Integer) -> void
-          def parallel(value)
-            raise ArgumentError, "value must be >= 0" if value < 0
-
-            # treat 0 as unlimited parallelism
-            @values[:parallel] = value > 0 ? value : nil
-          end
-
-          #: () -> void
-          def parallel!
-            @values[:parallel] = nil
-          end
-
-          #: () -> void
-          def no_parallel!
-            @values[:parallel] = 1
-          end
-
-          #: () -> Integer?
-          def max_parallel_tasks
-            @values.fetch(:parallel, 1)
           end
         end
 

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -9,7 +9,7 @@ module Roast
       #             System Cogs
       ########################################
 
-      #: (?Symbol?) {() [self: Roast::DSL::Cog::Config] -> void} -> void
+      #: (?Symbol?) {() [self: Roast::DSL::SystemCogs::Call::Config] -> void} -> void
       def call(name = nil, &block); end
 
       #: (?Symbol?) {() [self: Roast::DSL::SystemCogs::Map::Config] -> void} -> void


### PR DESCRIPTION
We've ended up with a convention where the inner classes defined in a cog class
are given in the order Params (for system cogs), Input, Output, then Config.

This PR moves the Config class definitions to the top of each cog class.
This keeps the layout consistent across all cogs, but also puts these inner
classes in the position corresponding to which they are evaluated when the workflow
is executed.