### PR TITLE
Add a marker for slow tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rake rubocop_ci
       - run: bundle exec rake sorbet
-      - run: bundle exec rake minitest_dsl
+      - run: bundle exec rake rubocop_ci
+      - run: bundle exec rake minitest_dsl_fast
+      - run: bundle exec rake minitest_dsl_slow
       - run: bundle exec rake minitest_functional
       - run: bundle exec rake minitest_old
-

--- a/Rakefile
+++ b/Rakefile
@@ -21,16 +21,30 @@ end
 Rake::TestTask.new(:minitest_old) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"].exclude("test/functional/**/*_test.rb", "test/dsl/**/*_test.rb")
+  t.test_files = FileList["test/**/*_test.rb"].exclude(
+    "test/functional/**/*_test.rb",
+    "test/dsl/**/*_test.rb",
+    "test/roast/dsl/**/*_test.rb",
+  )
 end
 
-Rake::TestTask.new(:minitest_dsl) do |t|
+Rake::TestTask.new(:minitest_dsl_fast) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/dsl/**/*_test.rb"]
+  t.test_files = FileList["test/dsl/**/*_test.rb", "test/roast/dsl/**/*_test.rb"]
 end
 
-task test: [:minitest_dsl, :minitest_functional, :minitest_old]
+Rake::TestTask.new(:minitest_dsl_slow) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/dsl/**/*_test.rb", "test/roast/dsl/**/*_test.rb"]
+end
+task :set_slow_env do
+  ENV["ROAST_RUN_SLOW_TESTS"] = "true"
+end
+task minitest_dsl_slow: :set_slow_env
+
+task test: [:minitest_dsl_fast, :minitest_dsl_slow, :minitest_functional, :minitest_old]
 
 ### Rubocop Tasks
 
@@ -51,6 +65,6 @@ end
 
 ### Task Groups
 
-task default: [:sorbet, :rubocop, :minitest_dsl]
+task default: [:sorbet, :rubocop, :minitest_dsl_fast]
 
 task check: [:sorbet, :rubocop]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,10 @@ if ENV["CI"]
   Minitest::RG.rg!(color: true)
 end
 
+def slow_test!
+  skip "slow test" unless ["1", "true"].include?(ENV["ROAST_RUN_SLOW_TESTS"])
+end
+
 VCR.configure do |config|
   config.cassette_library_dir = "test/fixtures/vcr_cassettes"
   config.hook_into :webmock


### PR DESCRIPTION
This PR adds a `slow_test!` helper method for tests that will skip the test unless is is being run via the `:minitest_dsl_slow` rake task (or with the 'ROAST_RUN_SLOW_TESTS' environment variable set).

CI is configured to run the fast tests first, and then the slow tests, (so we'll see errors that brea
the majority of test cases quickly) and the default behaviour of `bundle exec rake` will only
run the fast tests, making it easier for quick local dev iteration.