### PR TITLE
Allow CommandRunner to accept standard input and pass it to the running command

### DIFF
--- a/lib/roast/dsl/command_runner.rb
+++ b/lib/roast/dsl/command_runner.rb
@@ -40,18 +40,21 @@ module Roast
         #
         # @example With explicit timeout
         #   CommandRunner.execute(["sleep", "5"], timeout: 2)  # Will timeout after 2 seconds
-        #: (Array[String], ?timeout: (Integer | Float)?, ?stdout_handler: untyped, ?stderr_handler: untyped) -> [String, String, Process::Status]
-        def execute(args, timeout: nil, stdout_handler: nil, stderr_handler: nil)
-          # rubocop:disable Lint/UselessAssignment
-          stdout_content = "" #: String
-          stderr_content = "" #: String
-          # rubocop:enable Lint/UselessAssignment
+        #: (
+        #|  Array[String],
+        #|  ?timeout: (Integer | Float)?,
+        #|  ?stdin_content: String?,
+        #|  ?stdout_handler: untyped,
+        #|  ?stderr_handler: untyped
+        #| ) -> [String, String, Process::Status]
+        def execute(args, timeout: nil, stdin_content: nil, stdout_handler: nil, stderr_handler: nil)
           pid = nil #: Integer?
           wait_thread = nil #: Thread?
 
           begin
             stdin, stdout, stderr, wait_thread = Open3 #: as untyped
               .popen3(*args)
+            stdin.puts stdin_content if stdin_content.present?
             stdin.close
             pid = wait_thread.pid
 

--- a/test/roast/dsl/command_runner_test.rb
+++ b/test/roast/dsl/command_runner_test.rb
@@ -5,6 +5,17 @@ require "test_helper"
 module Roast
   module DSL
     class CommandRunnerTest < ActiveSupport::TestCase
+      test "provides stdin_content to running command" do
+        stdout, stderr, status = CommandRunner.execute(
+          ["tr", "[:lower:]", "[:upper:]"],
+          stdin_content: "Hello, world!",
+        )
+
+        assert_equal "HELLO, WORLD!\n", stdout
+        assert_equal "", stderr
+        assert_equal 0, status.exitstatus
+      end
+
       test "basic execution captures stdout" do
         stdout, stderr, status = CommandRunner.execute(["echo", "hello"])
 


### PR DESCRIPTION
This way we can send a prompt to the agent without writing it to file like legacy roast did