### PR TITLE
Add an ERB prompt templater

### DIFF
--- a/dsl/prompts/simple_prompt.md.erb
+++ b/dsl/prompts/simple_prompt.md.erb
@@ -1,0 +1,3 @@
+You just told me the following about a lake. Make some stuff up about why that's nonsense.
+
+<%= lake_answer %>

--- a/dsl/simple_chat.rb
+++ b/dsl/simple_chat.rb
@@ -11,5 +11,12 @@ config do
 end
 
 execute do
+  # Ask a question
   chat(:lake) { "What is the deepest lake?" }
+
+  # Ask a question with a template prompt. You can pass variables to it as you would an ERB template
+  # chat { template("dsl/prompts/simple_prompt.md.erb", { lake_answer: chat!(:lake).response }) }
+
+  # Shorthand to look up a template prompt
+  chat { template("simple_prompt", { lake_answer: chat!(:lake).response }) }
 end

--- a/lib/roast/dsl/cog_input_context.rb
+++ b/lib/roast/dsl/cog_input_context.rb
@@ -20,6 +20,14 @@ module Roast
       def fail!(message = nil)
         raise ControlFlow::FailCog, message
       end
+
+      #: (String, ?Hash) -> String
+      def template(path, args = {})
+        path = "prompts/#{path}.md.erb" unless File.exist?(path)
+        fail!("The prompt #{path} could not be found") unless File.exist?(path)
+
+        ERB.new(File.read(path)).result_with_hash(args)
+      end
     end
   end
 end


### PR DESCRIPTION
Prompts can be defined in a file, which is especially nice when they are lengthy so you don't have a ton of text in your workflow definition. I've also added templating with ERB, similar to the Roast prototype, to allow adding runtime information to prompts.
