### PR TITLE
Add workflow targets and params

### DIFF
--- a/dsl/targets_and_params.rb
+++ b/dsl/targets_and_params.rb
@@ -1,0 +1,24 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+end
+
+execute do
+  ruby do |_, params|
+    # Any files listed after the standard roast command-line args are collected as your workflows targets
+    # (shell globs are expanded as you would expect)
+    # e.g., `roast execute --executor=dsl dsl/targets_and_params.rb Gemfile Gemfile.lock`
+    # or, `roast execute --executor=dsl dsl/targets_and_params.rb Gemfile*`
+    puts "workflow targets: #{params.targets}"
+
+    # You can specify custom arguments for your workflow. Anything coming after `--` on the roast command
+    # line will be parsed as custom arguments.
+    # Simple word tokens are collected as `args`. Tokens in the form `key=value` are parsed into the `kwargs` hash.
+    # e.g., `roast execute --executor=dsl dsl/targets_and_params.rb Gemfile* -- foo=bar abc=pqr hello world`
+    puts "workflow args: #{params.args}" # [:hello, :world] (args are parsed as symbols)
+    puts "workflow kwargs: #{params.kwargs}" # {abc: "pqr", foo: "bar"} (keys are parsed as symbols, values as strings)
+  end
+end

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -24,16 +24,21 @@ module Roast
 
       class OutputsAlreadyDefinedError < ExecutionManagerError; end
 
-      #: (Cog::Registry, ConfigManager, Hash[Symbol?, Array[^() -> void]], ?Symbol?, ?untyped?, ?Integer) -> void
-      # TODO: we should refactor this class to reduce its number of instance variables and number of arguments here
-      # rubocop:disable Metrics/ParameterLists
+      #: (
+      #|  Cog::Registry,
+      #|  ConfigManager,
+      #|  Hash[Symbol?, Array[^() -> void]],
+      #|  ?scope: Symbol?,
+      #|  ?scope_value: untyped?,
+      #|  ?scope_index: Integer
+      #| ) -> void
       def initialize(
         cog_registry,
         config_manager,
         all_execution_procs,
-        scope = nil,
-        scope_value = nil,
-        scope_index = 0
+        scope: nil,
+        scope_value: nil,
+        scope_index: 0
       )
         @cog_registry = cog_registry
         @config_manager = config_manager
@@ -46,8 +51,6 @@ module Roast
         @execution_context = ExecutionContext.new #: ExecutionContext
         @cog_input_manager = CogInputManager.new(@cog_registry, @cogs) #: CogInputManager
       end
-
-      # rubocop:enable Metrics/ParameterLists
 
       #: () -> void
       def prepare!

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -60,7 +60,14 @@ module Roast
               input = input #: as Input
               raise ExecutionManager::ExecutionScopeNotSpecifiedError unless params.run.present?
 
-              em = ExecutionManager.new(@cog_registry, @config_manager, @all_execution_procs, params.run, input.value, input.index)
+              em = ExecutionManager.new(
+                @cog_registry,
+                @config_manager,
+                @all_execution_procs,
+                scope: params.run,
+                scope_value: input.value,
+                scope_index: input.index,
+              )
               em.prepare!
               em.run!
 

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -94,9 +94,9 @@ module Roast
                   @cog_registry,
                   @config_manager,
                   @all_execution_procs,
-                  params.run,
-                  item,
-                  index + input.initial_index,
+                  scope: params.run,
+                  scope_value: item,
+                  scope_index: index + input.initial_index,
                 )
                 em.prepare!
                 em.run!

--- a/lib/roast/dsl/workflow.rb
+++ b/lib/roast/dsl/workflow.rb
@@ -11,18 +11,19 @@ module Roast
       class InvalidCogReference < WorkflowError; end
 
       class << self
-        #: (String) -> void
-        def from_file(workflow_path)
-          workflow = new(workflow_path)
+        #: (String, WorkflowParams) -> void
+        def from_file(workflow_path, params)
+          workflow = new(workflow_path, params)
           workflow.prepare!
           workflow.start!
         end
       end
 
-      #: (String) -> void
-      def initialize(workflow_path)
-        @workflow_path = Pathname.new(workflow_path)
-        @workflow_definition = File.read(workflow_path)
+      #: (String, WorkflowParams) -> void
+      def initialize(workflow_path, workflow_params)
+        @workflow_path = Pathname.new(workflow_path) #: Pathname
+        @workflow_params = workflow_params
+        @workflow_definition = File.read(workflow_path) #: String
         @cog_registry = Cog::Registry.new #: Cog::Registry
         @config_procs = [] #: Array[^() -> void]
         @execution_procs = { nil: [] } #: Hash[Symbol?, Array[^() -> void]]
@@ -38,7 +39,7 @@ module Roast
         extract_dsl_procs!
         @config_manager = ConfigManager.new(@cog_registry, @config_procs)
         @config_manager.prepare!
-        @execution_manager = ExecutionManager.new(@cog_registry, @config_manager, @execution_procs)
+        @execution_manager = ExecutionManager.new(@cog_registry, @config_manager, @execution_procs, scope_value: @workflow_params)
         @execution_manager.prepare!
 
         @prepared = true

--- a/lib/roast/dsl/workflow_params.rb
+++ b/lib/roast/dsl/workflow_params.rb
@@ -1,0 +1,24 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    class WorkflowParams
+      #: Array[String]
+      attr_reader :targets
+
+      #: Array[Symbol]
+      attr_reader :args
+
+      #: Hash[Symbol, String]
+      attr_reader :kwargs
+
+      #: (Array[String], Array[Symbol], Hash[Symbol, String]) -> void
+      def initialize(targets, args, kwargs)
+        @targets = targets
+        @args = args
+        @kwargs = kwargs
+      end
+    end
+  end
+end

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -5,10 +5,12 @@ require "test_helper"
 # This test suite validates the incubating example workflows in `dsl/`.
 module DSL
   module Functional
+    EMPTY_PARAMS = Roast::DSL::WorkflowParams.new([], [], {})
+
     class RoastDSLExamplesTest < FunctionalTest
       test "async_cogs.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :async_cogs do
-          Roast::DSL::Workflow.from_file("dsl/async_cogs.rb")
+          Roast::DSL::Workflow.from_file("dsl/async_cogs.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         expected_stdout = <<~EOF
@@ -25,7 +27,7 @@ module DSL
 
       test "async_cogs_complex.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :async_cogs_complex do
-          Roast::DSL::Workflow.from_file("dsl/async_cogs_complex.rb")
+          Roast::DSL::Workflow.from_file("dsl/async_cogs_complex.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         expected_stdout = <<~EOF
@@ -41,7 +43,7 @@ module DSL
 
       test "call.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :call do
-          Roast::DSL::Workflow.from_file("dsl/call.rb")
+          Roast::DSL::Workflow.from_file("dsl/call.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         lines = stdout.lines.map(&:strip)
@@ -61,7 +63,7 @@ module DSL
 
       test "collect_from.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :collect_from do
-          Roast::DSL::Workflow.from_file("dsl/collect_from.rb")
+          Roast::DSL::Workflow.from_file("dsl/collect_from.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         expected_stdout = <<~EOF
@@ -75,7 +77,7 @@ module DSL
 
       test "outputs.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :outputs do
-          Roast::DSL::Workflow.from_file("dsl/outputs.rb")
+          Roast::DSL::Workflow.from_file("dsl/outputs.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         assert_equal "Upper: HELLO", stdout.strip
@@ -83,7 +85,7 @@ module DSL
 
       test "map.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :prototype do
-          Roast::DSL::Workflow.from_file("dsl/map.rb")
+          Roast::DSL::Workflow.from_file("dsl/map.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         expected_stdout = <<~EOF
@@ -107,7 +109,7 @@ module DSL
 
       test "map_reduce.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :map_reduce do
-          Roast::DSL::Workflow.from_file("dsl/map_reduce.rb")
+          Roast::DSL::Workflow.from_file("dsl/map_reduce.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         assert_equal "lower case words: hello world", stdout.strip
@@ -115,7 +117,7 @@ module DSL
 
       test "map_with_index.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :map_with_index do
-          Roast::DSL::Workflow.from_file("dsl/map_with_index.rb")
+          Roast::DSL::Workflow.from_file("dsl/map_with_index.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         expected_stdout = <<~EOF
@@ -135,7 +137,7 @@ module DSL
 
       test "parallel_map.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :parallel_map do
-          Roast::DSL::Workflow.from_file("dsl/parallel_map.rb")
+          Roast::DSL::Workflow.from_file("dsl/parallel_map.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         # first four lines may appear in a non-deterministic order
@@ -157,7 +159,7 @@ module DSL
 
       test "prototype.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :prototype do
-          Roast::DSL::Workflow.from_file("dsl/prototype.rb")
+          Roast::DSL::Workflow.from_file("dsl/prototype.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         lines = stdout.lines.map(&:strip)
@@ -171,7 +173,7 @@ module DSL
 
       test "step_communication.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :step_communication do
-          Roast::DSL::Workflow.from_file("dsl/step_communication.rb")
+          Roast::DSL::Workflow.from_file("dsl/step_communication.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         lines = stdout.lines.map(&:strip)
@@ -191,16 +193,34 @@ module DSL
           .returns(["Hi! How can I help you today?", "", mock_status])
 
         stdout, stderr = in_sandbox :simple_agent do
-          Roast::DSL::Workflow.from_file("dsl/simple_agent.rb")
+          Roast::DSL::Workflow.from_file("dsl/simple_agent.rb", EMPTY_PARAMS)
         end
 
         assert_includes stdout, "Hi! How can I help you today?"
         assert_empty stderr
       end
 
+      test "targets_and_params.rb workflow runs successfully" do
+        params = Roast::DSL::WorkflowParams.new(
+          ["one", "two", "three"],
+          [:a, :b, :c],
+          { hello: "world", goodnight: "moon" },
+        )
+        stdout, stderr = in_sandbox :targets_and_params do
+          Roast::DSL::Workflow.from_file("dsl/targets_and_params.rb", params)
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          workflow targets: ["one", "two", "three"]
+          workflow args: [:a, :b, :c]
+          workflow kwargs: {hello: "world", goodnight: "moon"}
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
       test "ruby_cog.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :ruby_cog do
-          Roast::DSL::Workflow.from_file("dsl/ruby_cog.rb")
+          Roast::DSL::Workflow.from_file("dsl/ruby_cog.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
         expected_stdout = <<~EOF

--- a/test/roast/dsl/workflow_test.rb
+++ b/test/roast/dsl/workflow_test.rb
@@ -7,7 +7,7 @@ module Roast
     class WorkflowTest < ActiveSupport::TestCase
       test "from_file raises error when file does not exist" do
         assert_raises(Errno::ENOENT) do
-          Workflow.from_file("/non/existent/file.rb")
+          Workflow.from_file("/non/existent/file.rb", WorkflowParams.new([], [], {}))
         end
       end
     end


### PR DESCRIPTION
Provides support for targets and custom parameters for DSL workflows

e.g.

```
roast execute --executor=dsl dsl/targets_and_params.rb Gemfile* -- foo=bar abc=pqr hello world
```

will parse as:
```
targets = ["Gemfile", "Gemfile.lock"]
args = [:hello, :world]
kwargs = { abc: "def", foo: "bar" }
```

These parameters are available to cogs as the scope input parameter of the outermost scope (similar to how an input parameter can be passed to a subroutine executor by `call` or `map`)