### PR TITLE
Add a `global` config scope to set basic things that apply to all cogs of all types

### DIFF
--- a/dsl/outputs.rb
+++ b/dsl/outputs.rb
@@ -4,6 +4,7 @@
 #: self as Roast::DSL::Workflow
 
 config do
+  global { exit_on_error! }
   cmd { display! }
   cmd(/to_/) { no_display! }
 end

--- a/dsl/targets_and_params.rb
+++ b/dsl/targets_and_params.rb
@@ -19,6 +19,9 @@ execute do
     # Simple word tokens are collected as `args`. Tokens in the form `key=value` are parsed into the `kwargs` hash.
     # e.g., `roast execute --executor=dsl dsl/targets_and_params.rb Gemfile* -- foo=bar abc=pqr hello world`
     puts "workflow args: #{params.args}" # [:hello, :world] (args are parsed as symbols)
-    puts "workflow kwargs: #{params.kwargs}" # {abc: "pqr", foo: "bar"} (keys are parsed as symbols, values as strings)
+
+    # {abc: "pqr", foo: "bar"} (keys are parsed as symbols, values as strings)
+    # (Note: using explicit formatting for compatibility with Ruby versions < 3.4)
+    puts "workflow kwargs: {#{params.kwargs.map { |k, v| "#{k}: #{v.inspect}" }.join(", ")}}"
   end
 end

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -5,24 +5,27 @@ module Roast
   module DSL
     class ConfigContext
 
+      #: () {() [self: Roast::DSL::Cog::Config] -> void} -> void
+      def global(&block); end
+
       ########################################
       #             System Cogs
       ########################################
 
-      #: (?Symbol?) {() [self: Roast::DSL::SystemCogs::Call::Config] -> void} -> void
+      #: (?(Symbol | Regexp)?) {() [self: Roast::DSL::SystemCogs::Call::Config] -> void} -> void
       def call(name = nil, &block); end
 
-      #: (?Symbol?) {() [self: Roast::DSL::SystemCogs::Map::Config] -> void} -> void
+      #: (?(Symbol | Regexp)?) {() [self: Roast::DSL::SystemCogs::Map::Config] -> void} -> void
       def map(name = nil, &block); end
 
       ########################################
       #            Standard Cogs
       ########################################
 
-      #: (?Symbol?) {() [self: Roast::DSL::Cogs::Agent::Config] -> void} -> void
+      #: (?(Symbol | Regexp)?) {() [self: Roast::DSL::Cogs::Agent::Config] -> void} -> void
       def agent(name = nil, &block); end
 
-      #: (?Symbol?) {() [self: Roast::DSL::Cogs::Chat::Config] -> void} -> void
+      #: (?(Symbol | Regexp)?) {() [self: Roast::DSL::Cogs::Chat::Config] -> void} -> void
       def chat(name = nil, &block); end
 
       # Configure the `cmd` cog
@@ -55,7 +58,7 @@ module Roast
       #: (?(Symbol | Regexp)?) {() [self: Roast::DSL::Cogs::Cmd::Config] -> void} -> void
       def cmd(name_or_pattern = nil, &block); end
 
-      #: (?Symbol?) {() [self: Roast::DSL::Cogs::Ruby::Config] -> void} -> void
+      #: (?(Symbol | Regexp)?) {() [self: Roast::DSL::Cogs::Ruby::Config] -> void} -> void
       def ruby(name_or_pattern = nil, &block); end
     end
   end


### PR DESCRIPTION
Some config parameters, like 'exit on error', 'async' and 'working directory', are generally applicable to all/most cogs.
It makes sense to have a consistent definition for their setter/getter methods.

Many of these definitions exist on the Cog::Config base class, but user still need to specify them multiple times for each cog type.

Now you can set some options globally using a single block

```
config do
  global do
    # every cog of every time will run with this attribute set, unless overridden by a more specific config specification
    exit_on_error!
  end

  cmd do
    # overrides for all `cmd` cogs
    no_exit_on_error!
  end

  chat(:foo) do
    # overrides for a specifically named `chat` cog
    no_exit_on_error!
  end
end
```