### PR TITLE
Add validation to cog configs

### DIFF
--- a/lib/roast/dsl/cog/config.rb
+++ b/lib/roast/dsl/cog/config.rb
@@ -5,6 +5,17 @@ module Roast
   module DSL
     class Cog
       class Config
+        class ConfigError < Roast::Error; end
+
+        class InvalidConfigError < ConfigError; end
+
+        # Validate that the config instance has all required parameters set in an acceptable manner
+        #
+        # Inheriting cog should implement this for its config class if validation is desired.
+        #
+        #: () -> void
+        def validate!; end
+
         #: Hash[Symbol, untyped]
         attr_reader :values
 

--- a/lib/roast/dsl/config_manager.rb
+++ b/lib/roast/dsl/config_manager.rb
@@ -53,6 +53,7 @@ module Roast
         end.values.each { |cfg| config = config.merge(cfg) }
         name_scoped_config = fetch_name_scoped_config(cog_class, name) unless name.nil?
         config = config.merge(name_scoped_config) if name_scoped_config
+        config.validate!
         config
       end
 


### PR DESCRIPTION
Adds an abstract a `validate!` method to `Cog::Config` that will get called once a cog instance's configs are merged. A config that fails validation will raise an exception before the workflow begins running.

This also allows config validation logic to take the full state of the config into account, if necessary (vs the previous pattern of validating individual args when they were set on the config object)

---

Introduces a `valid_<param>` and `valid_<param>!` accessor pattern for config class attributes. The convention I'm imagining is this:

* boolean config setters are bang methods (`exit_on_error!` and `no_exit_on_error!`)
* boolean config getters are equivalently named question methods (`exit_on_error?`)
  * boolean values are never in an invalid state and there's never a name collision here
* most other value setters are single-argument methods that take a value (`parallel 3`)
* getters for other values are methods with the `valid_` prefix (`valid_parallel!`)
  * method uses the `!` suffix if it performs validation and might throw
  * method uses no bang suffix if it does not perform validation and will always return a valid or default value
  * this prevents name collision between the setters and getters, makes it clear that a validated value is being used, and allows us to narrow the type annotation on getters that, e.g., will not produce `nil`s.
