### PR TITLE
Deep-Dupe config defaults before setting

### DIFF
--- a/lib/roast/dsl/cog/config.rb
+++ b/lib/roast/dsl/cog/config.rb
@@ -45,10 +45,12 @@ module Roast
         class << self
           #: [T] (Symbol, T) ?{(T) -> T} -> void
           def field(key, default, &validator)
+            default = default #: as untyped
+
             define_method(key) do |*args|
               if args.empty?
                 # with no args, return the configured value, or the default
-                @values[key] || default
+                @values[key] || default.deep_dup
               else
                 # with an argument, set the configured value
                 new_value = args.first
@@ -58,7 +60,7 @@ module Roast
 
             define_method("use_default_#{key}!".to_sym) do
               # explicitly set the configured value to the default
-              @values[key] = default
+              @values[key] = default.deep_dup
             end
           end
         end

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -50,7 +50,7 @@ module DSL
         assert_equal "--> before", lines.shift
         3.times do
           word = lines.shift
-          assert_equal word.upcase, lines.shift
+          assert_equal word.tr("a-z", "A-Z"), lines.shift
         end
         assert_equal "---", lines.shift
         assert_match(/^[\w']+$/, lines.shift)


### PR DESCRIPTION
For scalar types used as config parameter default values, the existing logic is fine. But if a config default value is something like an array or hash, or any mutable object, we should not return the same instance every time the default value is set for that attribute on a config