### PR TITLE
Run cogs in custom working directory

### DIFF
--- a/dsl/working_directory.rb
+++ b/dsl/working_directory.rb
@@ -1,0 +1,16 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd { print_all! }
+  cmd(:alt) { working_directory "/tmp" }
+  cmd(:orig) { use_current_working_directory! }
+end
+
+execute do
+  cmd(:cwd) { "echo Current working directory: `pwd`" }
+  cmd(:alt) { "echo Alternate working directory: `pwd`" }
+  cmd(:orig) { "echo Back to originl working directory: `pwd`" }
+end

--- a/lib/roast/dsl/cog/config.rb
+++ b/lib/roast/dsl/cog/config.rb
@@ -225,6 +225,71 @@ module Roast
           @values[:exit_on_error] ||= true
         end
 
+        # Configure the cog to run external commands in the specified working directory
+        #
+        # The directory given can be relative or absolute.
+        # If relative, it will be understood in relation to the directory from which Roast is invoked.
+        #
+        # ---
+        #
+        # __Important Note__: this configuration option only applies to external commands invoked by a cog
+        # It does not affect the working directory in which Roast is running.
+        #
+        # ---
+        #
+        # #### See Also
+        # - `use_current_working_directory!`
+        # - `valid_working_directory`
+        #
+        #: (String) -> void
+        def working_directory(directory)
+          @values[:working_directory] = directory
+        end
+
+        # Configure the cog to run in the directory from which Roast is invoked
+        #
+        # ---
+        #
+        # __Important Note__: this configuration option only applies to external commands invoked by a cog
+        # It does not affect the working directory in which Roast is running.
+        #
+        # ---
+        #
+        # #### See Also
+        # - `working_directory`
+        # - `valid_working_directory`
+        #
+        #: () -> void
+        def use_current_working_directory!
+          @values[:working_directory] = nil
+        end
+
+        # Get the validated, configured value for the working directory path in which the cog should run
+        #
+        # A value of `nil` means to use the current working directory.
+        # This method will raise an `InvalidConfigError` if the path does not exist or is not a directory.
+        #
+        # ---
+        #
+        # __Important Note__: this configuration option only applies to external commands invoked by a cog
+        # It does not affect the working directory in which Roast is running.
+        #
+        # ---
+        #
+        # #### See Also
+        # - `working_directory`
+        # - `use_current_working_directory!`
+        #
+        #: () -> Pathname?
+        def valid_working_directory
+          path = Pathname.new(@values[:working_directory]).expand_path if @values[:working_directory]
+          return unless path
+          raise InvalidConfigError, "working directory '#{path}' does not exist'" unless path.exist?
+          raise InvalidConfigError, "working directory '#{path}' is not a directory'" unless path.directory?
+
+          path
+        end
+
         alias_method(:exit_on_error!, :abort_on_error!)
         alias_method(:no_exit_on_error!, :no_abort_on_error!)
         alias_method(:continue_on_error!, :no_abort_on_error!)

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -167,6 +167,7 @@ module Roast
           stdout, stderr, status = CommandRunner #: as untyped
             .execute(
               [input.command] + input.args,
+              working_directory: config.valid_working_directory,
               stdout_handler: stdout_handler,
               stderr_handler: stderr_handler,
             )

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -231,6 +231,19 @@ module DSL
         EOF
         assert_equal expected_stdout, stdout
       end
+
+      test "working_directory.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :working_directory do
+          Roast::DSL::Workflow.from_file("dsl/working_directory.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          Current working directory: #{Dir.pwd}
+          Alternate working directory: /tmp
+          Back to originl working directory: #{Dir.pwd}
+        EOF
+        assert_equal expected_stdout, stdout
+      end
     end
   end
 end


### PR DESCRIPTION
Cogs that run external commands, like `cmd` and `agent`, or that access files on disk (like `chat`, when we give it the ability to do thing like handle image input/output) may benefit from being configured with an alternate working directory.

---

Note: This PR does not make Roast automatically change into the configured working directory when running a cog for which it is specified, because doing so causes issues for parallelization. (If two cogs are running in parallel and each attempts to change the working directory of
the main ruby process, then it gets changed for all parallel cogs, leading to unexpected behaviour. There's no way to effectively coördinate this.)

Instead cogs that need to interact with the filesystem, or care about their working directory for any reason, should use the `working_directory` config value internally to intentionally do whatever they want to do within that folder *without* changing the working directory of the ruby process.

(We'll maybe want to put some guardrails in place, at least a warning, to prevent the user from inadvertently changing the working directory in, say, a cog's input block. Though that's only an issue if they do use async cogs and don't realize/anticipate the side effects. Probably a niche issue.)