### PR TITLE
Add parsing and formatting for text messages in claude output

### DIFF
--- a/lib/roast/dsl/cogs/agent/providers/claude/claude_invocation.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/claude_invocation.rb
@@ -100,7 +100,14 @@ module Roast
                 message = Message.from_json(line) unless line.empty?
                 return unless message
 
+                handle_message(message)
+              end
+
+              #: (Message) -> void
+              def handle_message(message)
                 case message
+                when Messages::AssistantMessage
+                  message.messages.each { |msg| handle_message(msg) }
                 when Messages::ResultMessage
                   @result.response = message.content
                   @result.success = message.success

--- a/lib/roast/dsl/cogs/agent/providers/claude/message.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/message.rb
@@ -22,10 +22,14 @@ module Roast
                 def from_hash(hash)
                   type = hash.delete(:type)&.to_sym
                   case type
+                  when :assistant
+                    Messages::AssistantMessage.new(type:, hash:)
                   when :result
                     Messages::ResultMessage.new(type:, hash:)
                   when :system
                     Messages::SystemMessage.new(type:, hash:)
+                  when :text
+                    Messages::TextMessage.new(type:, hash:)
                   else
                     Messages::UnknownMessage.new(type:, hash:)
                   end
@@ -47,6 +51,10 @@ module Roast
                 @type = type
                 hash.except!(*IGNORED_FIELDS)
                 @unparsed = hash
+              end
+
+              #: () -> String?
+              def format
               end
             end
           end

--- a/lib/roast/dsl/cogs/agent/providers/claude/messages/assistant_message.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/messages/assistant_message.rb
@@ -1,0 +1,36 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Agent < Cog
+        module Providers
+          class Claude < Provider
+            module Messages
+              class AssistantMessage < Message
+                IGNORED_FIELDS = [
+                  :parent_tool_use_id,
+                ].freeze
+
+                #: Array[Message]
+                attr_reader :messages
+
+                #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+                def initialize(type:, hash:)
+                  @messages = hash.dig(:message, :content).map do |content|
+                    content[:role] = :assistant
+                    Message.from_hash(content)
+                  end.compact
+                  hash.delete(:message)
+                  hash.except!(*IGNORED_FIELDS)
+                  super(type:, hash:)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/dsl/cogs/agent/providers/claude/messages/text_message.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/messages/text_message.rb
@@ -1,0 +1,36 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Agent < Cog
+        module Providers
+          class Claude < Provider
+            module Messages
+              class TextMessage < Message
+                #: Symbol?
+                attr_reader :role
+
+                #: String
+                attr_reader :text
+
+                #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+                def initialize(type:, hash:)
+                  @role = hash.delete(:role)
+                  @text = hash.delete(:text) || ""
+                  super(type:, hash:)
+                end
+
+                #: () -> String
+                def format
+                  @text
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is the first in a stack of parsing and formatting functionality for various kinds of streaming claude messages.

My intent is to implement basic formatters for all the message types I can identify first, and then to iterate on the style of the messages once a reasonably full set is collected