### PR TITLE
Parse JSON output from cogs that support it

### DIFF
--- a/dsl/json_output.rb
+++ b/dsl/json_output.rb
@@ -1,0 +1,28 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  cmd { print_all! }
+end
+
+execute do
+  cmd(:json) do |my|
+    my.command = "echo"
+    my.args << <<~JSON
+      {
+        "hello": "world",
+        "letters": [
+          "aaa",
+          "bbb"
+        ]
+      }
+    JSON
+  end
+
+  ruby do
+    puts "RAW OUTPUT: #{cmd!(:json).out}"
+    puts "SOME VALUE FROM PARSED OUTPUT: #{cmd!(:json).json![:letters].first}"
+  end
+end

--- a/lib/roast/dsl/cog/output.rb
+++ b/lib/roast/dsl/cog/output.rb
@@ -6,7 +6,39 @@ module Roast
     class Cog
       # Generic output from running a cog.
       # Cogs should extend this class with their own output types.
-      class Output; end
+      class Output
+        # @requires_ancestor: Output
+        module WithJson
+          #: () -> Hash[Symbol, untyped]
+          def json!
+            input = json_text
+            return {} unless input
+
+            # Look for JSON code blocks anywhere in the text
+            # Matches ```json or ``` followed by content, then closing ```
+            json_block_pattern = /```(?:json)?\s*\n(.*?)\n```/m
+            match = input.match(json_block_pattern)
+            text = match ? match[1] || input : input
+            @json ||= JSON.parse(text.strip, symbolize_names: true)
+          end
+
+          #: () -> Hash[Symbol, untyped]?
+          def json
+            json!
+          rescue JSON::ParserError
+            nil
+          end
+
+          private
+
+          # Cogs should implement this method to provide the text value that should be parsed to provide the 'json' attribute
+          #
+          #: () -> String?
+          def json_text
+            raise NotImplementedError
+          end
+        end
+      end
     end
   end
 end

--- a/lib/roast/dsl/cogs/agent.rb
+++ b/lib/roast/dsl/cogs/agent.rb
@@ -6,8 +6,11 @@ module Roast
     module Cogs
       class Agent < Cog
         class AgentCogError < Roast::Error; end
+
         class UnknownProviderError < AgentCogError; end
+
         class MissingProviderError < AgentCogError; end
+
         class MissingPromptError < AgentCogError; end
 
         class Config < Cog::Config
@@ -403,8 +406,16 @@ module Roast
         end
 
         class Output < Cog::Output
+          include Cog::Output::WithJson
+
           #: String
           attr_reader :response
+
+          private
+
+          def json_text
+            response
+          end
         end
 
         #: Agent::Config

--- a/lib/roast/dsl/cogs/chat.rb
+++ b/lib/roast/dsl/cogs/chat.rb
@@ -31,6 +31,8 @@ module Roast
         end
 
         class Output < Cog::Output
+          include Cog::Output::WithJson
+
           #: String
           attr_reader :response
 
@@ -38,6 +40,12 @@ module Roast
           def initialize(response)
             super()
             @response = response
+          end
+
+          private
+
+          def json_text
+            response
           end
         end
 

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -139,6 +139,8 @@ module Roast
         end
 
         class Output < Cog::Output
+          include Cog::Output::WithJson
+
           #: String
           attr_reader :out
 
@@ -154,6 +156,12 @@ module Roast
             @out = out #: String
             @err = err #: String
             @status = status #: Process::Status
+          end
+
+          private
+
+          def json_text
+            out
           end
         end
 

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -75,6 +75,32 @@ module DSL
         assert_equal expected_stdout, stdout
       end
 
+      test "json_output.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :json_output do
+          Roast::DSL::Workflow.from_file("dsl/json_output.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          {
+            "hello": "world",
+            "letters": [
+              "aaa",
+              "bbb"
+            ]
+          }
+
+          RAW OUTPUT: {
+            "hello": "world",
+            "letters": [
+              "aaa",
+              "bbb"
+            ]
+          }
+          SOME VALUE FROM PARSED OUTPUT: aaa
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
       test "outputs.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :outputs do
           Roast::DSL::Workflow.from_file("dsl/outputs.rb", EMPTY_PARAMS)


### PR DESCRIPTION
Adds a mix-in for Cog::Output that adds two generic output accessor methods

- `json!` will return a hash parsed from JSON-formatted text output of the cog, or raise a `JSON::ParserError`.
- `json` will return a hash or `nil` if the text could not be parsed

Applies this to the `cmd`, `chat`, and `agent` cogs