### PR TITLE
Add configurable session resume to agent cog

### DIFF
--- a/dsl/agent_sessions.rb
+++ b/dsl/agent_sessions.rb
@@ -1,0 +1,20 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  agent do
+    provider :claude
+    model "haiku"
+    dump_raw_agent_messages_to "tmp/claude-messages.log"
+  end
+end
+
+execute do
+  agent(:one) { "The magic word is 'pomegranate'" }
+  agent(:two) do |my|
+    my.session = agent!(:one).session
+    "What is the magic word?"
+  end
+end

--- a/lib/roast/dsl/cogs/agent.rb
+++ b/lib/roast/dsl/cogs/agent.rb
@@ -379,6 +379,9 @@ module Roast
           #: String?
           attr_accessor :prompt
 
+          #: String?
+          attr_accessor :session
+
           #: () -> void
           def initialize
             super
@@ -410,6 +413,9 @@ module Roast
 
           #: String
           attr_reader :response
+
+          #: String
+          attr_reader :session
 
           private
 

--- a/lib/roast/dsl/cogs/agent/providers/claude.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude.rb
@@ -8,7 +8,7 @@ module Roast
         module Providers
           class Claude < Provider
             class Output < Agent::Output
-              delegate :response, to: :@invocation_result
+              delegate :response, :session, to: :@invocation_result
 
               #: (ClaudeInvocation::Result) -> void
               def initialize(invocation_result)

--- a/lib/roast/dsl/cogs/agent/providers/claude/claude_invocation.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/claude_invocation.rb
@@ -25,6 +25,9 @@ module Roast
                 #: bool
                 attr_accessor :success
 
+                #: String?
+                attr_accessor :session
+
                 def initialize
                   @response = ""
                   @success = false
@@ -38,6 +41,7 @@ module Roast
                 @apply_permissions = config.apply_permissions? #: bool
                 @working_directory = config.valid_working_directory #: Pathname?
                 @prompt = input.valid_prompt! #: String
+                @session = input.session #: String?
                 @result = Result.new #: Result
                 @raw_dump_file = config.valid_dump_raw_agent_messages_to_path #: Pathname?
               end
@@ -114,6 +118,8 @@ module Roast
                   @result.success = message.success
                 end
 
+                @result.session = message.session_id if message.session_id.present?
+
                 puts
                 puts "[AGENT MESSAGE] #{message.inspect}"
                 # TODO: do something better with unhandled data so we can improve the parser
@@ -125,6 +131,7 @@ module Roast
                 command = ["claude", "-p", "--verbose", "--output-format", "stream-json"]
                 command.push("--model", @model) if @model
                 command.push("--append-system-prompt", @append_system_prompt) if @append_system_prompt
+                command.push("--fork-session", "--resume", @session) if @session.present?
                 command << "--dangerously-skip-permissions" unless @apply_permissions
                 command
               end


### PR DESCRIPTION
You can resume from a previous agent session by setting `my.session` on a subsequent agent invocation to be the `session` attribute on a prior agent's output