### PR TITLE
Parse Claude tool use messages

### DIFF
--- a/lib/roast/dsl/cogs/agent/providers/claude/claude_invocation.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/claude_invocation.rb
@@ -120,8 +120,10 @@ module Roast
 
                 @result.session = message.session_id if message.session_id.present?
 
-                puts
-                puts "[AGENT MESSAGE] #{message.inspect}"
+                formatted_message = message.format
+                puts formatted_message unless formatted_message.blank?
+
+                puts "[AGENT MESSAGE] #{message.inspect}" unless message.unparsed.blank?
                 # TODO: do something better with unhandled data so we can improve the parser
                 puts "[WARNING] Unhandled data in Claude #{message.type} message: #{message.unparsed}\n" unless message.unparsed.blank?
               end

--- a/lib/roast/dsl/cogs/agent/providers/claude/message.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/message.rb
@@ -32,6 +32,8 @@ module Roast
                     Messages::SystemMessage.new(type:, hash:)
                   when :text
                     Messages::TextMessage.new(type:, hash:)
+                  when :tool_use
+                    Messages::ToolUseMessage.new(type:, hash:)
                   else
                     Messages::UnknownMessage.new(type:, hash:)
                   end

--- a/lib/roast/dsl/cogs/agent/providers/claude/messages/tool_use_message.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/messages/tool_use_message.rb
@@ -1,0 +1,44 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Agent < Cog
+        module Providers
+          class Claude < Provider
+            module Messages
+              class ToolUseMessage < Message
+                IGNORED_FIELDS = [
+                  :id,
+                  :role,
+                ].freeze
+
+                #: Symbol
+                attr_reader :name
+
+                #: Hash[Symbol, untyped]
+                attr_reader :input
+
+                #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+                def initialize(type:, hash:)
+                  @id = hash.delete(:id) || ""
+                  @name = hash.delete(:name)&.to_sym || :unknown
+                  @input = hash.delete(:input) || {}
+                  hash.except!(*IGNORED_FIELDS)
+                  super(type:, hash:)
+                end
+
+                #: () -> String
+                def format
+                  tool_use = ToolUse.new(name:, input:)
+                  tool_use.format
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/dsl/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/tool_use.rb
@@ -1,0 +1,48 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Agent < Cog
+        module Providers
+          class Claude < Provider
+            class ToolUse
+              #: Symbol
+              attr_reader :name
+
+              #: Hash[Symbol, untyped]
+              attr_reader :input
+
+              #: (name: Symbol, input: Hash[Symbol, untyped]) -> void
+              def initialize(name:, input:)
+                @name = name
+                @input = input
+              end
+
+              #: () -> String
+              def format
+                format_method_name = "format_#{@name.downcase}".to_sym
+                return send(format_method_name) if respond_to?(format_method_name, true)
+
+                format_unknown
+              end
+
+              private
+
+              #: () -> String
+              def format_bash
+                "BASH #{@input.inspect}"
+              end
+
+              #: () -> String
+              def format_unknown
+                "UNKNOWN #{@input.inspect}"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds rudimentary parsing for tool use messages. The formatting is very basic and I haven't really started adding support for all the different tool types yet. I'm going to try to do it as generically as possible, but some tools do require special handling