### PR TITLE
Show stats for agent invocation

### DIFF
--- a/lib/roast/dsl/cogs/agent.rb
+++ b/lib/roast/dsl/cogs/agent.rb
@@ -21,7 +21,10 @@ module Roast
           puts "[USER PROMPT] #{input.valid_prompt!}" if config.show_prompt?
           output = provider.invoke(input)
           puts
-          puts "[AGENT RESPONSE] #{output.response}" if config.show_response?
+          # NOTE: If progress is displayed, the agent's response will always be the last progress message,
+          # so showing it again is duplicative.
+          puts "[AGENT RESPONSE] #{output.response}" if config.show_response? && !config.show_progress?
+          puts "[AGENT STATS] #{output.stats}" if config.show_stats?
           output
         end
 

--- a/lib/roast/dsl/cogs/agent/config.rb
+++ b/lib/roast/dsl/cogs/agent/config.rb
@@ -202,6 +202,7 @@ module Roast
           # - `show_prompt!`
           # - `show_prompt?`
           # - `no_display!`
+          # - `quiet!`
           #
           #: () -> void
           def no_show_prompt!
@@ -242,6 +243,7 @@ module Roast
           # - `show_progress!`
           # - `show_progress?`
           # - `no_display!`
+          # - `quiet!`
           #
           #: () -> void
           def no_show_progress!
@@ -279,6 +281,7 @@ module Roast
           # - `show_response!`
           # - `show_response?`
           # - `no_display!`
+          # - `quiet!`
           #
           #: () -> void
           def no_show_response!
@@ -296,21 +299,62 @@ module Roast
             @values.fetch(:show_response, true)
           end
 
+          # Configure the cog to display statistics about the agent's operation
+          #
+          # Enabled by default.
+          #
+          # #### See Also
+          # - `no_show_stats!`
+          # - `show_stats?`
+          # - `display!`
+          #
+          #: () -> void
+          def show_stats!
+            @values[:show_stats] = true
+          end
+
+          # Configure the cog __not__ to display statistics about the agent's operation
+          #
+          # #### See Also
+          # - `show_stats!`
+          # - `show_stats?`
+          # - `no_display!`
+          # - `quiet!`
+          #
+          #: () -> void
+          def no_show_stats!
+            @values[:show_stats] = false
+          end
+
+          # Check if the cog is configured to display statistics about the agent's operation
+          #
+          # #### See Also
+          # - `show_stats!`
+          # - `no_show_stats!`
+          #
+          #: () -> bool
+          def show_stats?
+            @values.fetch(:show_stats, true)
+          end
+
           # Configure the cog to display all agent output
           #
           # This enables `show_prompt!`, `show_progress!`, and `show_response!`.
           #
           # #### See Also
           # - `no_display!`
+          # - `quiet!`
           # - `show_prompt!`
           # - `show_progress!`
           # - `show_response!`
+          # - `show_stats!`
           #
           #: () -> void
           def display!
             show_prompt!
             show_progress!
             show_response!
+            show_stats!
           end
 
           # Configure the cog to __hide__ all agent output
@@ -323,15 +367,18 @@ module Roast
           #
           # #### See Also
           # - `display!`
+          # - `quiet!`
           # - `no_show_prompt!`
           # - `no_show_progress!`
           # - `no_show_response!`
+          # - `no_show_stats!`
           #
           #: () -> void
           def no_display!
             no_show_prompt!
             no_show_progress!
             no_show_response!
+            no_show_stats!
           end
 
           # Check if the cog is configured to display any output while running
@@ -340,10 +387,11 @@ module Roast
           # - `show_prompt?`
           # - `show_progress?`
           # - `show_response?`
+          # - `show_stats?`
           #
           #: () -> bool
           def display?
-            show_prompt? || show_progress? || show_response?
+            show_prompt? || show_progress? || show_response? || show_stats?
           end
 
           # Dump raw messages received from the agent process to a file

--- a/lib/roast/dsl/cogs/agent/output.rb
+++ b/lib/roast/dsl/cogs/agent/output.rb
@@ -14,6 +14,9 @@ module Roast
           #: String
           attr_reader :session
 
+          #: Stats
+          attr_reader :stats
+
           private
 
           def json_text

--- a/lib/roast/dsl/cogs/agent/providers/claude.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude.rb
@@ -8,7 +8,7 @@ module Roast
         module Providers
           class Claude < Provider
             class Output < Agent::Output
-              delegate :response, :session, to: :@invocation_result
+              delegate :response, :session, :stats, to: :@invocation_result
 
               #: (ClaudeInvocation::Result) -> void
               def initialize(invocation_result)

--- a/lib/roast/dsl/cogs/agent/providers/claude/claude_invocation.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/claude_invocation.rb
@@ -45,6 +45,9 @@ module Roast
                 #: String?
                 attr_accessor :session
 
+                #: Stats?
+                attr_accessor :stats
+
                 def initialize
                   @response = ""
                   @success = false
@@ -134,6 +137,7 @@ module Roast
                 when Messages::ResultMessage
                   @result.response = message.content
                   @result.success = message.success
+                  @result.stats = message.stats
                 when Messages::ToolUseMessage
                   @context.add_tool_use(message)
                 when Messages::UserMessage

--- a/lib/roast/dsl/cogs/agent/providers/claude/messages/result_message.rb
+++ b/lib/roast/dsl/cogs/agent/providers/claude/messages/result_message.rb
@@ -9,11 +9,21 @@ module Roast
           class Claude < Provider
             module Messages
               class ResultMessage < Message
+                IGNORED_FIELDS = [
+                  :duration_api_ms,
+                  :permission_denials,
+                  :usage,
+                  :uuid,
+                ].freeze
+
                 #: String
                 attr_reader :content
 
                 #: bool
                 attr_reader :success
+
+                #: Stats
+                attr_reader :stats
 
                 #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
                 def initialize(type:, hash:)
@@ -24,6 +34,21 @@ module Roast
                     @content = @content || hash.dig(:error, :message) || "Unknown error"
                     hash.delete(:error)
                   end
+
+                  @stats = Stats.new
+                  @stats.duration_ms = hash.delete(:duration_ms)
+                  @stats.num_turns = hash.delete(:num_turns)
+                  hash.delete(:modelUsage)&.each do |model, h|
+                    usage = Usage.new
+                    usage.input_tokens = h[:inputTokens]
+                    usage.output_tokens = h[:outputTokens]
+                    usage.cost_usd = h[:costUSD]
+                    @stats.model_usage[model] = usage
+                    @stats.usage.input_tokens = (@stats.usage.input_tokens || 0) + (usage.input_tokens || 0)
+                    @stats.usage.output_tokens = (@stats.usage.output_tokens || 0) + (usage.output_tokens || 0)
+                  end
+                  @stats.usage.cost_usd = hash.delete(:total_cost_usd)
+                  hash.except!(*IGNORED_FIELDS)
                   super(type:, hash:)
                 end
               end

--- a/lib/roast/dsl/cogs/agent/stats.rb
+++ b/lib/roast/dsl/cogs/agent/stats.rb
@@ -1,0 +1,47 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Agent < Cog
+        class Stats
+          include ActiveSupport::NumberHelper
+
+          NO_VALUE = "---"
+
+          #: Integer?
+          attr_accessor :duration_ms
+
+          #: Integer?
+          attr_accessor :num_turns
+
+          #: Usage
+          attr_accessor :usage
+
+          #: Hash[String, Usage]
+          attr_accessor :model_usage
+
+          def initialize
+            @usage = Usage.new
+            @model_usage = {}
+          end
+
+          #: () -> String
+          def to_s
+            lines = []
+            lines << "Turns: #{num_turns.nil? ? NO_VALUE : number_to_human(num_turns)}"
+            lines << "Duration: #{duration_ms.nil? ? NO_VALUE : ActiveSupport::Duration.build((duration_ms || 0) / 1000).inspect}"
+            lines << "Cost (USD): $#{usage.cost_usd.nil? ? NO_VALUE : number_to_human(usage.cost_usd, precision: 6, significant: false)}"
+            model_usage.each do |m, u|
+              input_tokens = u.input_tokens.nil? ? NO_VALUE : number_to_human(u.input_tokens)
+              output_tokens = u.output_tokens.nil? ? NO_VALUE : number_to_human(u.output_tokens)
+              lines << "Tokens (#{m}): #{input_tokens} in, #{output_tokens} out"
+            end
+            lines.join("\n")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/dsl/cogs/agent/usage.rb
+++ b/lib/roast/dsl/cogs/agent/usage.rb
@@ -1,0 +1,21 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Agent < Cog
+        class Usage
+          #: Integer?
+          attr_accessor :input_tokens
+
+          #: Integer?
+          attr_accessor :output_tokens
+
+          #: Float?
+          attr_accessor :cost_usd
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Optionally prints out a stats block at the end of the agent cog invocation that looks like:

```
[AGENT STATS] Turns: 4
Duration: 11 seconds
Cost (USD): $0.09822
Tokens (claude-haiku-4-5-20251001): 36 in, 841 out
Tokens (claude-sonnet-4-5-20250929): 3 in, 53 out
```