### PR TITLE
Split out `chat` cog's Config, Input, Output into separate files

### DIFF
--- a/lib/roast/dsl/cogs/chat.rb
+++ b/lib/roast/dsl/cogs/chat.rb
@@ -5,50 +5,6 @@ module Roast
   module DSL
     module Cogs
       class Chat < Cog
-        class Config < Cog::Config
-          field :model, "gpt-4o-mini"
-          field :api_key, ENV["OPENAI_API_KEY"]
-          field :base_url, ENV.fetch("OPENAI_API_BASE_URL", "https://api.openai.com/v1")
-          field :provider, :openai
-          field :assume_model_exists, false
-        end
-
-        class Input < Cog::Input
-          #: String?
-          attr_accessor :prompt
-
-          #: () -> void
-          def validate!
-            raise Cog::Input::InvalidInputError, "'prompt' is required" unless prompt.present?
-          end
-
-          #: (untyped) -> void
-          def coerce(input_return_value)
-            if input_return_value.is_a?(String)
-              self.prompt = input_return_value
-            end
-          end
-        end
-
-        class Output < Cog::Output
-          include Cog::Output::WithJson
-
-          #: String
-          attr_reader :response
-
-          #: (String response) -> void
-          def initialize(response)
-            super()
-            @response = response
-          end
-
-          private
-
-          def json_text
-            response
-          end
-        end
-
         #: Roast::DSL::Cogs::Chat::Config
         attr_reader :config
 

--- a/lib/roast/dsl/cogs/chat/config.rb
+++ b/lib/roast/dsl/cogs/chat/config.rb
@@ -1,0 +1,18 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Chat < Cog
+        class Config < Cog::Config
+          field :model, "gpt-4o-mini"
+          field :api_key, ENV["OPENAI_API_KEY"]
+          field :base_url, ENV.fetch("OPENAI_API_BASE_URL", "https://api.openai.com/v1")
+          field :provider, :openai
+          field :assume_model_exists, false
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/dsl/cogs/chat/input.rb
+++ b/lib/roast/dsl/cogs/chat/input.rb
@@ -1,0 +1,27 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Chat < Cog
+        class Input < Cog::Input
+          #: String?
+          attr_accessor :prompt
+
+          #: () -> void
+          def validate!
+            raise Cog::Input::InvalidInputError, "'prompt' is required" unless prompt.present?
+          end
+
+          #: (untyped) -> void
+          def coerce(input_return_value)
+            if input_return_value.is_a?(String)
+              self.prompt = input_return_value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/dsl/cogs/chat/output.rb
+++ b/lib/roast/dsl/cogs/chat/output.rb
@@ -1,0 +1,29 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module Cogs
+      class Chat < Cog
+        class Output < Cog::Output
+          include Cog::Output::WithJson
+
+          #: String
+          attr_reader :response
+
+          #: (String response) -> void
+          def initialize(response)
+            super()
+            @response = response
+          end
+
+          private
+
+          def json_text
+            response
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As the cog's config, input, and output specs get more complex (especially with more documentation) they're a lot easier to read in separate files