### PR TITLE
Configure chat cog display

### DIFF
--- a/dsl/simple_chat.rb
+++ b/dsl/simple_chat.rb
@@ -15,8 +15,8 @@ execute do
   chat(:lake) { "What is the deepest lake?" }
 
   # Ask a question with a template prompt. You can pass variables to it as you would an ERB template
-  # chat { template("dsl/prompts/simple_prompt.md.erb", { lake_answer: chat!(:lake).response }) }
+  chat { template("dsl/prompts/simple_prompt.md.erb", { lake_answer: chat!(:lake).response }) }
 
   # Shorthand to look up a template prompt
-  chat { template("simple_prompt", { lake_answer: chat!(:lake).response }) }
+  # chat { template("simple_prompt", { lake_answer: chat!(:lake).response }) }
 end

--- a/lib/roast/dsl/cogs/agent/config.rb
+++ b/lib/roast/dsl/cogs/agent/config.rb
@@ -339,7 +339,7 @@ module Roast
 
           # Configure the cog to display all agent output
           #
-          # This enables `show_prompt!`, `show_progress!`, and `show_response!`.
+          # This enables `show_prompt!`, `show_progress!`, `show_response!`, and `show_stats!`.
           #
           # #### See Also
           # - `no_display!`
@@ -359,7 +359,7 @@ module Roast
 
           # Configure the cog to __hide__ all agent output
           #
-          # This enables `no_show_prompt!`, `no_show_progress!`, and `no_show_response!`.
+          # This enables `no_show_prompt!`, `no_show_progress!`, `no_show_response!`, `no_show_stats!`.
           #
           # #### Alias Methods
           # - `no_display!`

--- a/lib/roast/dsl/cogs/chat.rb
+++ b/lib/roast/dsl/cogs/chat.rb
@@ -17,13 +17,24 @@ module Roast
           )
 
           resp = chat.ask(input.prompt)
-          puts "Model: #{resp.model_id}"
-          puts "Role: #{resp.role}"
-          puts "Input Tokens: #{resp.input_tokens}"
-          puts "Output Tokens: #{resp.output_tokens}"
-
           chat.messages.each do |message|
-            puts "[#{message.role.to_s.upcase}] #{message.content}"
+            case message.role
+            when :user
+              puts "[USER PROMPT] #{message.content}" if config.show_prompt?
+            when :assistant
+              puts "[LLM RESPONSE] #{message.content}" if config.show_response?
+            else
+              # No other message types are expected, but let's show them if they do appear
+              # but only the user has requested some form of output
+              puts "[UNKNOWN] #{message.content}" if config.show_prompt? || config.show_response?
+            end
+          end
+          if config.show_stats?
+            puts "[LLM STATS]"
+            puts "\tModel: #{resp.model_id}"
+            puts "\tRole: #{resp.role}"
+            puts "\tInput Tokens: #{resp.input_tokens}"
+            puts "\tOutput Tokens: #{resp.output_tokens}"
           end
 
           Output.new(resp.content)

--- a/lib/roast/dsl/cogs/chat/config.rb
+++ b/lib/roast/dsl/cogs/chat/config.rb
@@ -11,6 +11,176 @@ module Roast
           field :base_url, ENV.fetch("OPENAI_API_BASE_URL", "https://api.openai.com/v1")
           field :provider, :openai
           field :assume_model_exists, false
+
+          # Configure the cog to display the prompt when running the agent
+          #
+          # Disabled by default.
+          #
+          # #### See Also
+          # - `no_show_prompt!`
+          # - `show_prompt?`
+          # - `display!`
+          #
+          #: () -> void
+          def show_prompt!
+            @values[:show_prompt] = true
+          end
+
+          # Configure the cog __not__ to display the prompt when running the agent
+          #
+          # This is the default behaviour.
+          #
+          # #### See Also
+          # - `show_prompt!`
+          # - `show_prompt?`
+          # - `no_display!`
+          # - `quiet!`
+          #
+          #: () -> void
+          def no_show_prompt!
+            @values[:show_prompt] = false
+          end
+
+          # Check if the cog is configured to display the prompt when running the agent
+          #
+          # #### See Also
+          # - `show_prompt!`
+          # - `no_show_prompt!`
+          #
+          #: () -> bool
+          def show_prompt?
+            @values.fetch(:show_prompt, false)
+          end
+
+          # Configure the cog to display the agent's final response
+          #
+          # Enabled by default.
+          #
+          # #### See Also
+          # - `no_show_response!`
+          # - `show_response?`
+          # - `display!`
+          #
+          #: () -> void
+          def show_response!
+            @values[:show_response] = true
+          end
+
+          # Configure the cog __not__ to display the agent's final response
+          #
+          # #### See Also
+          # - `show_response!`
+          # - `show_response?`
+          # - `no_display!`
+          # - `quiet!`
+          #
+          #: () -> void
+          def no_show_response!
+            @values[:show_response] = false
+          end
+
+          # Check if the cog is configured to display the agent's final response
+          #
+          # #### See Also
+          # - `show_response!`
+          # - `no_show_response!`
+          #
+          #: () -> bool
+          def show_response?
+            @values.fetch(:show_response, true)
+          end
+
+          # Configure the cog to display statistics about the agent's operation
+          #
+          # Enabled by default.
+          #
+          # #### See Also
+          # - `no_show_stats!`
+          # - `show_stats?`
+          # - `display!`
+          #
+          #: () -> void
+          def show_stats!
+            @values[:show_stats] = true
+          end
+
+          # Configure the cog __not__ to display statistics about the agent's operation
+          #
+          # #### See Also
+          # - `show_stats!`
+          # - `show_stats?`
+          # - `no_display!`
+          # - `quiet!`
+          #
+          #: () -> void
+          def no_show_stats!
+            @values[:show_stats] = false
+          end
+
+          # Check if the cog is configured to display statistics about the agent's operation
+          #
+          # #### See Also
+          # - `show_stats!`
+          # - `no_show_stats!`
+          #
+          #: () -> bool
+          def show_stats?
+            @values.fetch(:show_stats, true)
+          end
+
+          # Configure the cog to display all agent output
+          #
+          # This enables `show_prompt!`, `show_response!`, and `show_stats!`.
+          #
+          # #### See Also
+          # - `no_display!`
+          # - `quiet!`
+          # - `show_prompt!`
+          # - `show_response!`
+          # - `show_stats!`
+          #
+          #: () -> void
+          def display!
+            show_prompt!
+            show_response!
+            show_stats!
+          end
+
+          # Configure the cog to __hide__ all agent output
+          #
+          # This enables `no_show_prompt!`, `no_show_response!`, and `no_show_stats!`.
+          #
+          # #### Alias Methods
+          # - `no_display!`
+          # - `quiet!`
+          #
+          # #### See Also
+          # - `display!`
+          # - `quiet!`
+          # - `no_show_prompt!`
+          # - `no_show_response!`
+          # - `no_show_stats!`
+          #
+          #: () -> void
+          def no_display!
+            no_show_prompt!
+            no_show_response!
+            no_show_stats!
+          end
+
+          # Check if the cog is configured to display any output while running
+          #
+          # #### See Also
+          # - `show_prompt?`
+          # - `show_response?`
+          # - `show_stats?`
+          #
+          #: () -> bool
+          def display?
+            show_prompt? || show_response? || show_stats?
+          end
+
+          alias_method(:quiet!, :no_display!)
         end
       end
     end


### PR DESCRIPTION
Adding configuration options to `chat` that mirror `agent`s `show_prompt!`, `show_response!`, and `show_stats!`