### PR TITLE
Fix test flakes caused by non-ascii letters in example cog output

### DIFF
--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -53,9 +53,9 @@ module DSL
           assert_equal word.tr("a-z", "A-Z"), lines.shift
         end
         assert_equal "---", lines.shift
-        assert_match(/^[\w']+$/, lines.shift)
+        assert_match(/^[\p{L}']+$/, lines.shift)
         assert_equal "SCOPE VALUE: ROAST", lines.shift
-        assert_match(/^[\w']+$/, lines.shift)
+        assert_match(/^[\p{L}']+$/, lines.shift)
         assert_equal "SCOPE VALUE: OTHER", lines.shift
         assert_equal "--> after", lines.shift
         assert_empty lines


### PR DESCRIPTION
annoyingly, the words list contains non-ascii characters