### PR TITLE
Clean up gemfile requirements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,17 +9,19 @@ gemspec
 
 # TODO: remove this version pin when the next cli-ui version is released with this circular dependency fix
 #   https://github.com/Shopify/cli-ui/pull/606
-gem "benchmark"
 gem "cli-ui", github: "Shopify/cli-ui", ref: "0185746bac2e34e7609e02a4d585c5f19703200e"
-gem "guard-minitest"
-gem "guard"
-gem "minitest-rg"
-gem "mocha"
-gem "rake", require: false
-gem "rubocop-shopify", require: false
-gem "rubocop-sorbet", require: false
-gem "simplecov", require: false
-gem "sorbet", require: false
-gem "tapioca", require: false
-gem "vcr", require: false
-gem "webmock", require: false
+
+group :development, :test do
+  gem "guard-minitest"
+  gem "guard"
+  gem "minitest-rg"
+  gem "mocha"
+  gem "rake", require: false
+  gem "rubocop-shopify", require: false
+  gem "rubocop-sorbet", require: false
+  gem "simplecov", require: false
+  gem "sorbet", require: false
+  gem "tapioca", require: false
+  gem "vcr", require: false
+  gem "webmock", require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
     roast-ai (0.4.11)
       activesupport (>= 7.0)
       async (~> 2.34)
+      benchmark (~> 0.4.1)
       cli-kit (~> 5.2)
       cli-ui (~> 2.6)
       diff-lcs (~> 1.5)
@@ -258,7 +259,6 @@ PLATFORMS
   arm64-darwin
 
 DEPENDENCIES
-  benchmark
   cli-ui!
   guard
   guard-minitest

--- a/roast-ai.gemspec
+++ b/roast-ai.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("activesupport", ">= 7.0")
   spec.add_dependency("async", "~> 2.34")
+  spec.add_dependency("benchmark", "~> 0.4.1")
   spec.add_dependency("cli-kit", "~> 5.2")
   spec.add_dependency("cli-ui", "~> 2.6")
   spec.add_dependency("diff-lcs", "~> 1.5")


### PR DESCRIPTION
Benchmark needs to be an explicit require, because it's being removed from core ruby libs in ruby 3.5 and we're getting spammed with deprecation warnings (and rightly so)