### PR TITLE
Fix requires_ancestor sigs

### DIFF
--- a/lib/roast/dsl/cog/output.rb
+++ b/lib/roast/dsl/cog/output.rb
@@ -7,7 +7,7 @@ module Roast
       # Generic output from running a cog.
       # Cogs should extend this class with their own output types.
       class Output
-        # @requires_ancestor: Output
+        # @requires_ancestor: Roast::DSL::Cog::Output
         module WithJson
           #: () -> Hash[Symbol, untyped]
           def json!

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -50,7 +50,7 @@ module Roast
           end
         end
 
-        # @requires_ancestor: ExecutionManager
+        # @requires_ancestor: Roast::DSL::ExecutionManager
         module Manager
           private
 
@@ -76,7 +76,7 @@ module Roast
           end
         end
 
-        # @requires_ancestor: CogInputContext
+        # @requires_ancestor: Roast::DSL::CogInputContext
         module InputContext
           # @rbs [T] (Roast::DSL::SystemCogs::Call::Output) {() -> T} -> T
           #    | (Roast::DSL::SystemCogs::Call::Output) -> untyped

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -84,7 +84,7 @@ module Roast
         #: Config
         attr_accessor :config
 
-        # @requires_ancestor: ExecutionManager
+        # @requires_ancestor: Roast::DSL::ExecutionManager
         module Manager
           private
 
@@ -125,7 +125,7 @@ module Roast
           end
         end
 
-        # @requires_ancestor: CogInputContext
+        # @requires_ancestor: Roast::DSL::CogInputContext
         module InputContext
           # @rbs [T] (Roast::DSL::SystemCogs::Map::Output) {() -> T} -> Array[T]
           #    | (Roast::DSL::SystemCogs::Map::Output) -> Array[untyped]


### PR DESCRIPTION
When tapioca builds an .rbi file for a gem, something does not resolve correctly when requires_ancestor annotations use relative class names