### PR TITLE
Explicitly define 'provider' config methods for `chat` cog

### DIFF
--- a/lib/roast/dsl/cogs/chat.rb
+++ b/lib/roast/dsl/cogs/chat.rb
@@ -12,7 +12,7 @@ module Roast
         def execute(input)
           chat = ruby_llm_context.chat(
             model: config.model,
-            provider: config.provider,
+            provider: config.valid_provider!,
             assume_model_exists: config.assume_model_exists,
           )
 

--- a/sorbet/rbi/shims/lib/roast/dsl/cogs/chat.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cogs/chat.rbi
@@ -12,8 +12,6 @@ module Roast
           def api_key(value = nil); end
           #: (?String?) -> String?
           def base_url(value = nil); end
-          #: (?Symbol?) -> Symbol?
-          def provider(value = nil); end
           #: (?bool?) -> bool?
           def assume_model_exists(value = nil); end
         end


### PR DESCRIPTION
Tapioca (in a project that includes roast) is having difficulty with the `field` macro when generating an .rbi file for the roast gem that sorbet will be happy with.

We need to migrate to explicit method definitions for these config settings so we can add method doc comments anyway. I'm doing that in a stack of PRs, one per field, to make them easier to review.