### PR TITLE
Explicitly define 'api_key' config methods for `chat` cog

### DIFF
--- a/lib/roast/dsl/cogs/chat.rb
+++ b/lib/roast/dsl/cogs/chat.rb
@@ -43,7 +43,7 @@ module Roast
         #: () -> RubyLLM::Context
         def ruby_llm_context
           @ruby_llm_context ||= RubyLLM.context do |context|
-            context.openai_api_key = config.api_key unless config.api_key.nil?
+            context.openai_api_key = config.valid_api_key!
             context.openai_api_base = config.base_url unless config.base_url.nil?
           end
         end

--- a/sorbet/rbi/shims/lib/roast/dsl/cogs/chat.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cogs/chat.rbi
@@ -9,8 +9,6 @@ module Roast
           #: (?String?) -> String?
           def model(value = nil); end
           #: (?String?) -> String?
-          def api_key(value = nil); end
-          #: (?String?) -> String?
           def base_url(value = nil); end
           #: (?bool?) -> bool?
           def assume_model_exists(value = nil); end


### PR DESCRIPTION
See downstack PR: https://app.graphite.com/github/pr/Shopify/roast/551