### PR TITLE
Add explicit rake dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ PATH
       json-schema
       open_router (~> 0.3)
       raix (~> 1.0.2)
+      rake (~> 13.3.0)
       ruby-graphviz (~> 1.2)
       ruby_llm
       sqlite3 (~> 2.6)

--- a/roast-ai.gemspec
+++ b/roast-ai.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("json-schema")
   spec.add_dependency("open_router", "~> 0.3")
   spec.add_dependency("raix", "~> 1.0.2")
+  spec.add_dependency("rake", "~> 13.3.0") # NOTE: required by Thor
   spec.add_dependency("ruby-graphviz", "~> 1.2")
   spec.add_dependency("ruby_llm")
   spec.add_dependency("sqlite3", "~> 2.6")


### PR DESCRIPTION
The `thor` gem depends on `rake` but does no properly declare this dependency.
The lack of `rake` causes tapioca+sorbet to fail in projects the require roast.