### PR TITLE
Fix `self:` sigs on .rbi shims

### DIFF
--- a/lib/roast/dsl/workflow.rb
+++ b/lib/roast/dsl/workflow.rb
@@ -75,12 +75,12 @@ module Roast
         @completed ||= false
       end
 
-      #: { () [self: ConfigContext] -> void } -> void
+      #: { () [self: Roast::DSL::ConfigContext] -> void } -> void
       def config(&block)
         @config_procs << block
       end
 
-      #: (?Symbol?) { () [self: ExecutionContext] -> void } -> void
+      #: (?Symbol?) { () [self: Roast::DSL::ExecutionContext] -> void } -> void
       def execute(scope = nil, &block)
         (@execution_procs[scope] ||= []) << block
       end


### PR DESCRIPTION
When roast is imported in a project, sorbet doesn't seem able to resolve these relative names correctly