### PR TITLE
Require nil-assertions explicitly

### DIFF
--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -50,6 +50,9 @@ unless defined?(T)
   require("roast/sorbet_runtime_stub")
 end
 
+# Require project components that will not get automatically loaded
+require "roast/dsl/nil_assertions"
+
 # Autoloading setup
 require "zeitwerk"
 


### PR DESCRIPTION
`nil-assertions` does not get automatically loaded by zeitwerk since it is just a patch on Kernel,
so there's no explicit usage to trigger its loading