### PR TITLE
Add convenience methods for workflow params

### DIFF
--- a/dsl/targets_and_params.rb
+++ b/dsl/targets_and_params.rb
@@ -24,4 +24,34 @@ execute do
     # (Note: using explicit formatting for compatibility with Ruby versions < 3.4)
     puts "workflow kwargs: {#{params.kwargs.map { |k, v| "#{k}: #{v.inspect}" }.join(", ")}}"
   end
+
+  # There are convenience methods to access the workflow params from any cog input context in any scope
+  ruby do
+    puts
+    # `target!` will raise an exception unless exactly one target is provided
+    # puts "Explicit target = #{target!}"
+
+    # `targets` will return the (possibly empty) array of targets
+    puts "All targets = #{targets}"
+
+    # `arg?` will return a boolean indicating whether a specific value / flag argument is present
+    puts "Argument 'foo' provided? #{arg?(:foo) ? "yes" : "no"}"
+
+    # `args` will return the (possibly empty) array of simple value / flag arguments
+    puts "All args = #{args}"
+
+    # `kwarg` will return the value associated with a specific keyword argument,
+    # or nil if that keyword argument was not provided
+    puts "Keyword argument 'name': '#{kwarg(:name)}'"
+
+    # `kwarg!` will return the value associated with a specific keyword argument,
+    # or raise an exception if that keyword argument was not provided
+    # puts "Keyword argument 'name': #{kwarg!(:name)}"
+
+    # `kwarg?` will return a boolean indicating whether a specific keyword argument was provided
+    puts "Keyword argument 'name' provided: #{kwarg?(:name) ? "yes" : "no"}"
+
+    # `kwargs` will return the (possibly empty) hash of all keyword arguments
+    # puts "All kwargs = #{kwargs}"
+  end
 end

--- a/dsl/working_directory.rb
+++ b/dsl/working_directory.rb
@@ -12,5 +12,5 @@ end
 execute do
   cmd(:cwd) { "echo Current working directory: `pwd`" }
   cmd(:alt) { "echo Alternate working directory: `pwd`" }
-  cmd(:orig) { "echo Back to originl working directory: `pwd`" }
+  cmd(:orig) { "echo Back to original working directory: `pwd`" }
 end

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -28,6 +28,7 @@ module Roast
       #|  Cog::Registry,
       #|  ConfigManager,
       #|  Hash[Symbol?, Array[^() -> void]],
+      #|  WorkflowParams,
       #|  ?scope: Symbol?,
       #|  ?scope_value: untyped?,
       #|  ?scope_index: Integer
@@ -36,6 +37,7 @@ module Roast
         cog_registry,
         config_manager,
         all_execution_procs,
+        workflow_params,
         scope: nil,
         scope_value: nil,
         scope_index: 0
@@ -43,13 +45,14 @@ module Roast
         @cog_registry = cog_registry
         @config_manager = config_manager
         @all_execution_procs = all_execution_procs
+        @workflow_params = workflow_params
         @scope = scope
         @scope_value = scope_value
         @scope_index = scope_index
         @cogs = Cog::Store.new #: Cog::Store
         @cog_stack = Cog::Stack.new #: Cog::Stack
         @execution_context = ExecutionContext.new #: ExecutionContext
-        @cog_input_manager = CogInputManager.new(@cog_registry, @cogs) #: CogInputManager
+        @cog_input_manager = CogInputManager.new(@cog_registry, @cogs, @workflow_params) #: CogInputManager
       end
 
       #: () -> void

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -64,6 +64,7 @@ module Roast
                 @cog_registry,
                 @config_manager,
                 @all_execution_procs,
+                @workflow_params,
                 scope: params.run,
                 scope_value: input.value,
                 scope_index: input.index,

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -100,6 +100,7 @@ module Roast
                   @cog_registry,
                   @config_manager,
                   @all_execution_procs,
+                  @workflow_params,
                   scope: params.run,
                   scope_value: item,
                   scope_index: index + input.initial_index,

--- a/lib/roast/dsl/workflow.rb
+++ b/lib/roast/dsl/workflow.rb
@@ -22,7 +22,7 @@ module Roast
       #: (String, WorkflowParams) -> void
       def initialize(workflow_path, workflow_params)
         @workflow_path = Pathname.new(workflow_path) #: Pathname
-        @workflow_params = workflow_params
+        @workflow_params = workflow_params #: WorkflowParams
         @workflow_definition = File.read(workflow_path) #: String
         @cog_registry = Cog::Registry.new #: Cog::Registry
         @config_procs = [] #: Array[^() -> void]
@@ -39,7 +39,7 @@ module Roast
         extract_dsl_procs!
         @config_manager = ConfigManager.new(@cog_registry, @config_procs)
         @config_manager.prepare!
-        @execution_manager = ExecutionManager.new(@cog_registry, @config_manager, @execution_procs, scope_value: @workflow_params)
+        @execution_manager = ExecutionManager.new(@cog_registry, @config_manager, @execution_procs, @workflow_params, scope_value: @workflow_params)
         @execution_manager.prepare!
 
         @prepared = true

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -6,6 +6,34 @@ module Roast
     class CogInputContext
 
       ########################################
+      #             Workflow Methods
+      ########################################
+
+      #: () -> String
+      def target!; end
+
+      #: () -> Array[String]
+      def targets; end
+
+      #: (Symbol) -> bool
+      def arg?(value); end
+
+      #: () -> Array[Symbol]
+      def args; end
+
+      #: (Symbol) -> String?
+      def kwarg(key); end
+
+      #: (Symbol) -> String
+      def kwarg!(key); end
+
+      #: (Symbol) -> bool
+      def kwarg?(key); end
+
+      #: () -> Hash[Symbol, String]
+      def kwargs; end
+
+      ########################################
       #             System Cogs
       ########################################
 

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -271,6 +271,12 @@ module DSL
           workflow targets: ["one", "two", "three"]
           workflow args: [:a, :b, :c]
           workflow kwargs: {hello: "world", goodnight: "moon"}
+
+          All targets = ["one", "two", "three"]
+          Argument 'foo' provided? no
+          All args = [:a, :b, :c]
+          Keyword argument 'name': ''
+          Keyword argument 'name' provided: no
         EOF
         assert_equal expected_stdout, stdout
       end
@@ -283,7 +289,7 @@ module DSL
         expected_stdout = <<~EOF
           Current working directory: #{Dir.pwd}
           Alternate working directory: /tmp
-          Back to originl working directory: #{Dir.pwd}
+          Back to original working directory: #{Dir.pwd}
         EOF
         assert_equal expected_stdout, stdout
       end


### PR DESCRIPTION
This PR addresses friction/annoyance in accessing the overall workflow params.

I've added methods accessible in *all* cog input contexts (in any executor scope) to access the `targets`, `args`, and `kwargs` values of the workflow params, so workflow authors do not have to worry about passing workflow params into sub-executor scopes when needed. (This is especially useful when an arg or kwargs is used to configure some specific sub-scope behaviour of the workflow but is not used by the top-level scope).

I've also added methods to access individual args and kwargs, with `?` and `!` versions for convenience, as well as a `target!` method that requires exactly one target to be present (which I think is a common use case for Roast workflows)