### PR TITLE
Add an automatic temporary directory for the workflow

### DIFF
--- a/dsl/temporary_directory.rb
+++ b/dsl/temporary_directory.rb
@@ -1,0 +1,22 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+end
+
+execute do
+  ruby do
+    # The workflow automatically gets a temporary directory created for it
+    # unique to a single execution of the workflow, but shared across all executor scopes.
+    # This working directory will be cleaned up automatically when the workflow completes or fails.
+    puts tmpdir
+
+    # The value of `tmpdir` will always be a directory that exists
+    raise StandardError, "temporary directory does not exist" unless tmpdir.exist?
+
+    # The value of `tmpdir` will always be an absolute path
+    raise StandardError, "temporary directory is not an absolute path" unless tmpdir.absolute?
+  end
+end

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -28,7 +28,7 @@ module Roast
       #|  Cog::Registry,
       #|  ConfigManager,
       #|  Hash[Symbol?, Array[^() -> void]],
-      #|  WorkflowParams,
+      #|  WorkflowContext,
       #|  ?scope: Symbol?,
       #|  ?scope_value: untyped?,
       #|  ?scope_index: Integer
@@ -37,7 +37,7 @@ module Roast
         cog_registry,
         config_manager,
         all_execution_procs,
-        workflow_params,
+        workflow_context,
         scope: nil,
         scope_value: nil,
         scope_index: 0
@@ -45,14 +45,14 @@ module Roast
         @cog_registry = cog_registry
         @config_manager = config_manager
         @all_execution_procs = all_execution_procs
-        @workflow_params = workflow_params
+        @workflow_context = workflow_context
         @scope = scope
         @scope_value = scope_value
         @scope_index = scope_index
         @cogs = Cog::Store.new #: Cog::Store
         @cog_stack = Cog::Stack.new #: Cog::Stack
         @execution_context = ExecutionContext.new #: ExecutionContext
-        @cog_input_manager = CogInputManager.new(@cog_registry, @cogs, @workflow_params) #: CogInputManager
+        @cog_input_manager = CogInputManager.new(@cog_registry, @cogs, @workflow_context) #: CogInputManager
       end
 
       #: () -> void

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -64,7 +64,7 @@ module Roast
                 @cog_registry,
                 @config_manager,
                 @all_execution_procs,
-                @workflow_params,
+                @workflow_context,
                 scope: params.run,
                 scope_value: input.value,
                 scope_index: input.index,

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -100,7 +100,7 @@ module Roast
                   @cog_registry,
                   @config_manager,
                   @all_execution_procs,
-                  @workflow_params,
+                  @workflow_context,
                   scope: params.run,
                   scope_value: item,
                   scope_index: index + input.initial_index,

--- a/lib/roast/dsl/workflow_context.rb
+++ b/lib/roast/dsl/workflow_context.rb
@@ -1,0 +1,20 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    class WorkflowContext
+      #: WorkflowParams
+      attr_reader :params
+
+      #: String
+      attr_reader :tmpdir
+
+      #: (params: WorkflowParams, tmpdir: String) -> void
+      def initialize(params:, tmpdir:)
+        @params = params
+        @tmpdir = tmpdir
+      end
+    end
+  end
+end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -33,6 +33,9 @@ module Roast
       #: () -> Hash[Symbol, String]
       def kwargs; end
 
+      #: () -> Pathname
+      def tmpdir; end
+
       ########################################
       #             System Cogs
       ########################################

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -281,6 +281,17 @@ module DSL
         assert_equal expected_stdout, stdout
       end
 
+      test "temporary_directory.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :temporary_directory do
+          Roast::DSL::Workflow.from_file("dsl/temporary_directory.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        assert_predicate stdout.length, :>, 0
+        path = Pathname.new(stdout.strip)
+        assert_predicate path, :absolute?
+        refute_predicate path, :exist?
+      end
+
       test "working_directory.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :working_directory do
           Roast::DSL::Workflow.from_file("dsl/working_directory.rb", EMPTY_PARAMS)


### PR DESCRIPTION
This PR wraps the entire workflow execution in a `Dir.mktmpdir` block, and makes the path to the temporary directory accessible via a global convenience method similar to how the workflow params are exposed.

The workflow does not `cd` into the temporary directory. It merely creates it and cleans it up after the workflows terminates or fails.

The purpose to providing this temporary directory is to make it possible for cogs to write data to files that can be referenced by the execution of that cog (or by subsequent cogs).

There is a risk that passing state between cogs via files in the temporary directory will make the workflow harder to debug, but this functionality is something that workflow authors will implement manually if they want it, and this mechanism is much cleaner than forcing them to do that. (In particular, it's hard to manually implement a temporary directory that will be for sure cleaned up even if the workflow crashes.

As a real-world example, I'm currently writing a workflow where I need to invoke a shell command with the `cmd` cog and provide the filename of a file contained a JSON object to it as a command-line argument.

```
execute do
  cmd do
    filename = "#{tmpdir}/data.json"
    text = template("data.json.erb", { ... })
    File.write(filename, text)
    "my_command.sh -f '#{filename}'"
  end
end
```