### PR TITLE
Pin Sorbet version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@ group :development, :test do
   gem "rubocop-shopify", require: false
   gem "rubocop-sorbet", require: false
   gem "simplecov", require: false
-  gem "sorbet", require: false
-  gem "tapioca", require: false
+  gem "sorbet", "~> 0.5.12414", require: false
+  gem "tapioca", "~> 0.16.11", require: false
   gem "vcr", require: false
   gem "webmock", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,8 +270,8 @@ DEPENDENCIES
   rubocop-shopify
   rubocop-sorbet
   simplecov
-  sorbet
-  tapioca
+  sorbet (~> 0.5.12414)
+  tapioca (~> 0.16.11)
   vcr
   webmock
 


### PR DESCRIPTION
CI has started installing a later version of Sorbet than is specified in the Gemfile.lock,
and typechecks are failing. Pinning the specific Sorbet version we currently have in Gemfile.lock
resolves the problem.

Updating Sorbet and Tapioca to the latest version should be a TODO item for the project.