### PR TITLE
Pass scope_value and scope_index to `outputs`

### DIFF
--- a/dsl/outputs.rb
+++ b/dsl/outputs.rb
@@ -21,7 +21,7 @@ execute(:capitalize_a_word) do
     my.args << "-c"
     my.args << "echo \"#{word}\" | tr '[:upper:]' '[:lower:]'"
   end
-  outputs { "Upper: #{cmd!(:to_upper).out}" } # `outputs` can return any kind of value
+  outputs { |word| "Upper: #{cmd!(:to_upper).out}\nOriginal: #{word}" } # `outputs` can return any kind of value
 end
 
 execute do

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -180,7 +180,7 @@ module Roast
         end
       end
 
-      #: (^() -> untyped) -> void
+      #: (^(untyped, Integer) -> untyped) -> void
       def on_outputs(outputs)
         raise OutputsAlreadyDefinedError if @outputs
 
@@ -189,7 +189,7 @@ module Roast
 
       #: () -> untyped
       def final_output
-        return @cog_input_manager.context.instance_exec(&@outputs) if @outputs
+        return @cog_input_manager.context.instance_exec(@scope_value, @scope_index, &@outputs) if @outputs
 
         last_cog = @cog_stack.last
         raise CogInputManager::CogDoesNotExistError, "no cogs defined in scope" unless last_cog

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -9,7 +9,7 @@ module Roast
       #       Special Context Methods
       ########################################
 
-      #: () {() [self: Roast::DSL::CogInputContext] -> untyped} -> void
+      #: () {(untyped, Integer) [self: Roast::DSL::CogInputContext] -> untyped} -> void
       def outputs(&block); end
 
       ########################################

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -106,7 +106,7 @@ module DSL
           Roast::DSL::Workflow.from_file("dsl/outputs.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
-        assert_equal "Upper: HELLO", stdout.strip
+        assert_equal "Upper: HELLO\nOriginal: Hello\n", stdout
       end
 
       test "map.rb workflow runs successfully" do


### PR DESCRIPTION
The `outputs` block should have access to the scope_value and scope_index just like a normal cog input block

```
execute(:name) do
  ...
  outputs do |value, index|
     # can use the value and index as well as any cog output to set the final output
  end
end
```