### PR TITLE
Use `outputs` for collect and reduce

### DIFF
--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -48,8 +48,8 @@ module Roast
       #: (Roast::DSL::SystemCogs::Map::Output) -> Array[untyped]
       def collect(map_cog_output, &block); end
 
-      #: [A] (Roast::DSL::SystemCogs::Map::Output, ?NilClass) {(A?) -> A} -> A?
-      #: [A] (Roast::DSL::SystemCogs::Map::Output, ?A) {(A) -> A} -> A
+      #: [A] (Roast::DSL::SystemCogs::Map::Output, ?NilClass) {(A?, untyped) -> A} -> A?
+      #: [A] (Roast::DSL::SystemCogs::Map::Output, ?A) {(A, untyped) -> A} -> A
       def reduce(map_cog_output, initial_value = nil, &block); end
 
       #: (Symbol) -> Roast::DSL::SystemCogs::Call::Output?


### PR DESCRIPTION
When we added the `outputs` mechanism for sub executors, we hooked it up to `from` but didn't properly hook it up to `collect` or `reduce`