### PR TITLE
Provide the output, input value and loop index to the blocks given to `call`, `collect`, and `from`

### DIFF
--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -85,9 +85,10 @@ module Roast
             em = call_cog_output.instance_variable_get(:@execution_manager)
             raise CogInputContext::ContextNotFoundError if em.nil?
 
-            return em.cog_input_context.instance_exec(&block) if block_given?
+            final_output = em.send(:final_output)
+            return em.cog_input_context.instance_exec(final_output, &block) if block_given?
 
-            em.send(:final_output)
+            final_output
           end
         end
       end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -40,16 +40,16 @@ module Roast
       #             System Cogs
       ########################################
 
-      #: [T] (Roast::DSL::SystemCogs::Call::Output) {() -> T} -> T
+      #: [T] (Roast::DSL::SystemCogs::Call::Output) {(untyped) -> T} -> T
       #: (Roast::DSL::SystemCogs::Call::Output) -> untyped
       def from(call_cog_output, &block); end
 
-      #: [T] (Roast::DSL::SystemCogs::Map::Output) {() -> T} -> Array[T]
+      #: [T] (Roast::DSL::SystemCogs::Map::Output) {(untyped, untyped, Integer) -> T} -> Array[T]
       #: (Roast::DSL::SystemCogs::Map::Output) -> Array[untyped]
       def collect(map_cog_output, &block); end
 
-      #: [A] (Roast::DSL::SystemCogs::Map::Output, ?NilClass) {(A?, untyped) -> A} -> A?
-      #: [A] (Roast::DSL::SystemCogs::Map::Output, ?A) {(A, untyped) -> A} -> A
+      #: [A] (Roast::DSL::SystemCogs::Map::Output, ?NilClass) {(A?, untyped, untyped, Integer) -> A} -> A?
+      #: [A] (Roast::DSL::SystemCogs::Map::Output, ?A) {(A, untyped, untyped, Integer) -> A} -> A
       def reduce(map_cog_output, initial_value = nil, &block); end
 
       #: (Symbol) -> Roast::DSL::SystemCogs::Call::Output?


### PR DESCRIPTION
If a sub-executor defines a default output with an `outputs` declaration, it can be useful to have access to that even when accessing custom output from it using `from`, `collect`, or `reduce`.

Additionally, especially when accessing the results of a running a map, it can be helpful to have the input value and input index provided for convenience.