### PR TITLE
Add .text and .lines methods to cog outputs that have textual content

### DIFF
--- a/dsl/async_cogs.rb
+++ b/dsl/async_cogs.rb
@@ -33,7 +33,7 @@ execute do
   # It will block until 'slow_background_task_1' completes.
   # 'fourth' is synchronous, so cogs that follow it will also be forced to wait (whether they are async or not)
   cmd(:fourth) do
-    "echo \"fourth <-- '#{cmd!(:slow_background_task_1).out}'\""
+    "echo \"fourth <-- '#{cmd!(:slow_background_task_1).text}'\""
   end
 
   cmd(:fifth) { "echo fifth" }

--- a/dsl/async_cogs_complex.rb
+++ b/dsl/async_cogs_complex.rb
@@ -47,7 +47,7 @@ execute do
     # until the named async cog is complete IF AND ONLY IF it has already started.
     # If the named cog is defined later in the workflow and thus not already started,
     # these methods will return immediately.
-    "echo \"fifth (second said: '#{cmd!(:second).out}')\""
+    "echo \"fifth (second said: '#{cmd!(:second).text}')\""
   end
 
   # 'sixth' is async as well, and it will complete before the slow-running 'second' cog AND before the 'fifth' cog

--- a/dsl/call.rb
+++ b/dsl/call.rb
@@ -14,7 +14,7 @@ execute(:capitalize_a_random_word) do
   cmd(:capitalize) do |my, value_from_call|
     # Optional second block argument lets you use a value passed to the sub-executor by `call`
     # from withing any cog in the sub-executor
-    word = value_from_call || cmd!(:word).out
+    word = value_from_call || cmd!(:word).text
     my.command = "/bin/sh"
     my.args << "-c"
     my.args << "/bin/echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"

--- a/dsl/collect_from.rb
+++ b/dsl/collect_from.rb
@@ -39,21 +39,21 @@ execute do
 
     # Using `from`, you can access cogs from the executor scope that was run by a specific named `call`.
     # The block you pass to `from` runs in the input context of the specified scope, rather than the current scope.
-    original = from(call!(:hello)) { cmd!(:to_original).out }
+    original = from(call!(:hello)) { cmd!(:to_original).text }
     # The type of the return value of `from` is the same type as the return value of the block.
-    upper = from(call!(:hello)) { cmd!(:to_upper) }.out
+    upper = from(call!(:hello)) { cmd!(:to_upper) }.text
     # You can also use this shorthand `from` syntax to get the output of the last cog in the call's executor scope.
     # In this syntax, the return value of `from` is untyped
-    lower = from(call!(:hello)).out
+    lower = from(call!(:hello)).text
     "echo \"#{original} --> #{upper} --> #{lower}\""
   end
 
   cmd do
     # You can also grab the `call`'s output once and pass it to multiple `from` invocations.
     my_scope = call!(:world)
-    original = from(my_scope) { cmd!(:to_original).out }
-    upper = from(my_scope) { cmd!(:to_upper).out }
-    lower = from(my_scope) { cmd!(:to_lower).out }
+    original = from(my_scope) { cmd!(:to_original).text }
+    upper = from(my_scope) { cmd!(:to_upper).text }
+    lower = from(my_scope) { cmd!(:to_lower).text }
     "echo \"#{original} --> #{upper} --> #{lower}\""
   end
 
@@ -61,12 +61,12 @@ execute do
     # Using `collect`, you can access cogs from the executor scopes that were run by a specific named `map`.
     # The block you pass to `collect` runs in the input context of each specified scope.
     # `collect` returns an array containing the output of each invocation of that block.
-    originals = collect(map!(:other_words)) { cmd!(:to_original).out }
+    originals = collect(map!(:other_words)) { cmd!(:to_original).text }
     # The type of the return value of `call` is an Array of the same type as the return value of the block.
-    uppers = collect(map!(:other_words)) { cmd!(:to_upper) }.map(&:out)
+    uppers = collect(map!(:other_words)) { cmd!(:to_upper) }.map(&:text)
     # You can also use this shorthand `collect` syntax to get the output of the last cog in each of the map's executor scopes.
     # In this syntax, the return value of `collect` is Array[untyped]
-    lowers = collect(map!(:other_words)).map(&:out)
+    lowers = collect(map!(:other_words)).map(&:text)
     "echo \"#{originals.join(",")} --> #{uppers.join(",")} --> #{lowers.join(",")}\""
   end
 end

--- a/dsl/json_output.rb
+++ b/dsl/json_output.rb
@@ -22,7 +22,7 @@ execute do
   end
 
   ruby do
-    puts "RAW OUTPUT: #{cmd!(:json).out}"
+    puts "RAW OUTPUT: #{cmd!(:json).text}"
     puts "SOME VALUE FROM PARSED OUTPUT: #{cmd!(:json).json![:letters].first}"
   end
 end

--- a/dsl/map_reduce.rb
+++ b/dsl/map_reduce.rb
@@ -31,7 +31,7 @@ execute do
     # The return value of each invocation of the block will be passed as the 'accumulator' to the next invocation.
     # You can provide an optional initial value for the accumulator as the second argument to `reduce`.
     # If an initial value is present, the return type is non-nilable. If absent, the return type is nilable.
-    words = reduce(map!(:words), "lower case words:") { |acc| acc + " " + cmd!(:to_lower).out }
+    words = reduce(map!(:words), "lower case words:") { |acc| acc + " " + cmd!(:to_lower).text }
     "echo \"#{words}\""
   end
 end

--- a/dsl/outputs.rb
+++ b/dsl/outputs.rb
@@ -21,7 +21,7 @@ execute(:capitalize_a_word) do
     my.args << "-c"
     my.args << "echo \"#{word}\" | tr '[:upper:]' '[:lower:]'"
   end
-  outputs { |word| "Upper: #{cmd!(:to_upper).out}\nOriginal: #{word}" } # `outputs` can return any kind of value
+  outputs { |word| "Upper: #{cmd!(:to_upper).text}\nOriginal: #{word}" } # `outputs` can return any kind of value
 end
 
 execute do

--- a/dsl/parallel_map.rb
+++ b/dsl/parallel_map.rb
@@ -32,6 +32,6 @@ execute do
     my.command = "echo"
     # Regardless of the order in which the items were processed by a parallel map,
     # their results will always be provided to `collect` and `reduce` in the order in which they were given.
-    my.args << collect(map!(:words)) { cmd!(:to_upper).out }.join(", ")
+    my.args << collect(map!(:words)) { cmd!(:to_upper).text }.join(", ")
   end
 end

--- a/dsl/ruby_cog.rb
+++ b/dsl/ruby_cog.rb
@@ -22,7 +22,7 @@ execute do
   # Letting you write whatever ruby code you want to generate that output
   ruby(:whatever) do
     # Do whatever you want in this block
-    value = cmd!(:roast).out
+    value = cmd!(:roast).text
     puts "Hello, #{value.upcase}"
     puts "Calling a method: #{MyClass.add_stuff(3, 4)}"
     # The value you return will be exposed as the .value attribute on the cog's output

--- a/dsl/step_communication.rb
+++ b/dsl/step_communication.rb
@@ -14,9 +14,8 @@ execute do
   cmd(:ls) { "ls -al" }
   cmd(:echo) do |my|
     my.command = "echo"
-    # TODO: this is a bespoke output object for cmd, is there a generic one we can offer
-    first_line = cmd!(:ls).out.split("\n").second
-    last_line = cmd!(:ls).out.split("\n").last
+    first_line = cmd!(:ls).lines.second
+    last_line = cmd!(:ls).lines.last
     my.args << first_line unless first_line.blank?
     my.args << "\n---\n"
     my.args << last_line if last_line != first_line && last_line.present?

--- a/lib/roast/dsl/cog/output.rb
+++ b/lib/roast/dsl/cog/output.rb
@@ -38,6 +38,28 @@ module Roast
             raise NotImplementedError
           end
         end
+
+        # @requires_ancestor: Roast::DSL::Cog::Output
+        module WithText
+          #: () -> String
+          def text
+            raw_text.strip
+          end
+
+          #: () -> Array[String]
+          def lines
+            raw_text.lines.map(&:strip)
+          end
+
+          private
+
+          # Cogs should implement this method to provide the text value of their output
+          #
+          #: () -> String
+          def raw_text
+            raise NotImplementedError
+          end
+        end
       end
     end
   end

--- a/lib/roast/dsl/cogs/agent/output.rb
+++ b/lib/roast/dsl/cogs/agent/output.rb
@@ -7,6 +7,7 @@ module Roast
       class Agent < Cog
         class Output < Cog::Output
           include Cog::Output::WithJson
+          include Cog::Output::WithText
 
           #: String
           attr_reader :response
@@ -20,6 +21,10 @@ module Roast
           private
 
           def json_text
+            response
+          end
+
+          def raw_text
             response
           end
         end

--- a/lib/roast/dsl/cogs/chat/output.rb
+++ b/lib/roast/dsl/cogs/chat/output.rb
@@ -7,6 +7,7 @@ module Roast
       class Chat < Cog
         class Output < Cog::Output
           include Cog::Output::WithJson
+          include Cog::Output::WithText
 
           #: String
           attr_reader :response
@@ -20,6 +21,10 @@ module Roast
           private
 
           def json_text
+            response
+          end
+
+          def raw_text
             response
           end
         end

--- a/lib/roast/dsl/cogs/cmd.rb
+++ b/lib/roast/dsl/cogs/cmd.rb
@@ -64,24 +64,6 @@ module Roast
             @values[:print_stderr] = false
           end
 
-          # Configure the cog to strip surrounding whitespace from the values in its output object
-          #
-          # Default: `true`
-          #
-          #: () -> void
-          def clean_output!
-            @values[:raw_output] = false
-          end
-
-          # Configure the cog __not__ to strip surrounding whitespace from the values in its output object
-          #
-          # Default: `false`
-          #
-          #: () -> void
-          def raw_output!
-            @values[:raw_output] = true
-          end
-
           # Check if the cog is configured to write STDOUT to the console
           #
           #: () -> bool
@@ -94,13 +76,6 @@ module Roast
           #: () -> bool
           def print_stderr?
             !!@values[:print_stderr]
-          end
-
-          # Check if the cog is configured to write its output to the console in raw form
-          #
-          #: () -> bool
-          def raw_output?
-            !!@values[:raw_output]
           end
 
           alias_method(:display!, :print_all!)
@@ -140,6 +115,7 @@ module Roast
 
         class Output < Cog::Output
           include Cog::Output::WithJson
+          include Cog::Output::WithText
 
           #: String
           attr_reader :out
@@ -163,6 +139,10 @@ module Roast
           def json_text
             out
           end
+
+          def raw_text
+            out
+          end
         end
 
         #: (Input) -> Output
@@ -179,11 +159,6 @@ module Roast
               stdout_handler: stdout_handler,
               stderr_handler: stderr_handler,
             )
-
-          unless config.raw_output?
-            stdout = stdout.strip
-            stderr = stderr.strip
-          end
 
           Output.new(stdout, stderr, status)
         end


### PR DESCRIPTION
These are basically just convenience methods that made it easy to get
the textual response of a cog with surrounding whitespace and newlines stripped,
and to get an array of lines with each line similarly stripped.

When a cog's output contains elements you want to process one at a time
(which happens often when a `cmd` cog produces a list of something, files, etc.),
it's common to have to split the text into lines and strip off the trailing newlines.
This makes it easier.