### PR TITLE
Replace Async {}.wait with Sync

### DIFF
--- a/lib/roast/dsl/command_runner.rb
+++ b/lib/roast/dsl/command_runner.rb
@@ -81,7 +81,7 @@ module Roast
           end
 
           # Read stdout and stderr concurrently
-          stdout_content, stderr_content = Async do
+          stdout_content, stderr_content = Sync do
             stdout_task = Async do
               buffer = "" #: String
               stdout.each_line do |line|
@@ -113,7 +113,7 @@ module Roast
             end
 
             [stdout_task.wait, stderr_task.wait]
-          end.wait
+          end
 
           # Wait for the process to complete
           status = wait_thread.value

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -71,7 +71,7 @@ module Roast
         raise ExecutionManagerCurrentlyRunningError if running?
 
         @running = true
-        Async do
+        Sync do
           cog_tasks = @cog_stack.map do |cog|
             cog_config = @config_manager.config_for(cog.class, cog.name)
             cog_task = cog.run!(
@@ -84,7 +84,7 @@ module Roast
             cog_task
           end
           cog_tasks.map(&:wait)
-        end.wait
+        end
         @running = false
       end
 


### PR DESCRIPTION
TIL `Sync` is a small optimization for a situation in which you want to run a block in an async context (so it has access to the event loop, can wait on other tasks, etc.), but the block itself is not going to be left in the background of the current context.

For example:
```
Async do
  ...
end.wait
```

is functionally identical to
```
Sync do
  ...
end
```

The main difference is that the `Sync` version will not create a new task if it is already inside a task, it will just execute it's block synchronously inside that asynchronous context.