### PR TITLE
Duplicate scope values and cog output objects to prevent users inadvertently mutating them

### DIFF
--- a/lib/roast/dsl/cog_input_manager.rb
+++ b/lib/roast/dsl/cog_input_manager.rb
@@ -76,7 +76,7 @@ module Roast
           raise CogFailedError, cog_name if cog.failed?
           raise CogStoppedError, cog_name if cog.stopped?
           raise CogNotYetRunError, cog_name unless cog.succeeded?
-        end.output
+        end.output.deep_dup
       end
 
       #: () -> void

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -75,7 +75,7 @@ module Roast
           cog_tasks = @cog_stack.map do |cog|
             cog_config = @config_manager.config_for(cog.class, cog.name)
             cog_task = cog.run!(
-              cog_config,
+              cog_config.deep_dup,
               cog_input_context,
               @scope_value.deep_dup, # Pass a copy to each cog to guard against mutated values being passed between cogs
               @scope_index,

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -22,6 +22,7 @@ module Roast
             @values[:parallel] = 1
           end
 
+          #: () -> void
           def validate!
             valid_parallel!
           end


### PR DESCRIPTION
I'm not trying to be overly proscriptive about users passing state between cogs. It's discouraged, because it will make resuming a workflow partway through (when we implement that) probably break. But, if a user *wants* to pass global state between cogs they can always just create a global variable, or do any number of other things.

The intent here is to prevent *accidental* mutation of state that the user doesn't intend, or doesn't think about. For instance, before this change:

```
execute do
  ruby(:one) { [1,2,3] } # outputs an array of some values
  
  ruby(:two) do
    array = ruby!(:one).value
    array << 4 # mutates the array that ruby(:one) outputs, and outputs the mutated array
  end

  ruby(three) do
    value_from_one = ruby!(:one).value # this will be [1, 2, 3, 4], not [1, 2, 3]
    value_from_two = ruby!(:two).value # this will be the *same instance* as the output from :one
  end
end
```

In this toy example, the user probably won't actually be confused. But when the output objects are more complex, perhaps containing nested hashes, and the cog input logic involves extracting some piece of a cog's output or providing a default and subsequently using it somehow where it's not immediately apparent that it is a cog's output. The difference between, say, `h[:new_key] = "new_value"` and `h.merge({ new_key: "new value" })` is subtle and easy to miss.