### PR TITLE
Add file and line number information to workflow eval to improve stack trace readability

### DIFF
--- a/lib/roast/dsl/workflow.rb
+++ b/lib/roast/dsl/workflow.rb
@@ -111,7 +111,7 @@ module Roast
       # but does not evaluate any of them individually yet.
       #: () -> void
       def extract_dsl_procs!
-        instance_eval(@workflow_definition)
+        instance_eval(@workflow_definition, @workflow_path.realpath.to_s, 1)
       end
     end
   end


### PR DESCRIPTION
With this change, when an exception is raised inside the workflow script itself, the stacktrace emitted will actually show the filename and line number of where it was raised in the workflow script.

The rest of the stack trace is still incomprehensible, so we still have work to do there.