### PR TITLE
Add next! and break! control flow statements

### DIFF
--- a/dsl/next_break.rb
+++ b/dsl/next_break.rb
@@ -1,0 +1,40 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+end
+
+execute do
+  map(:loop, run: :loop_body) { 1..3 }
+
+  ruby do
+    results = collect(map!(:loop)) do
+      [ruby?(:one), ruby?(:two), ruby?(:three)]
+    end
+    results.each_with_index do |iteration_results, index|
+      puts "Iteration #{index}: #{iteration_results.presence || "did not run at all"}"
+    end
+  end
+end
+
+execute(:loop_body) do
+  ruby(:one) do |_, _, idx|
+    skip! if idx == 0
+    s = "[#{idx}] beginning"
+    puts s
+    s
+  end
+  ruby(:two) do |_, _, idx|
+    break! if idx == 1
+    s = "[#{idx}] middle"
+    puts s
+    s
+  end
+  ruby(:three) do |_, _, idx|
+    s = "[#{idx}] end"
+    puts s
+    s
+  end
+end

--- a/dsl/next_break_parallel.rb
+++ b/dsl/next_break_parallel.rb
@@ -1,0 +1,44 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  map { parallel! }
+end
+
+execute do
+  map(:loop, run: :loop_body) { 1..3 }
+
+  ruby do
+    results = collect(map!(:loop)) do
+      [ruby?(:one), ruby?(:two), ruby?(:three)]
+    end
+    results.each_with_index do |iteration_results, index|
+      puts "Iteration #{index}: #{iteration_results.presence || "did not run at all"}"
+    end
+  end
+end
+
+execute(:loop_body) do
+  ruby(:one) do |_, _, idx|
+    sleep(0.1) if idx == 0
+    sleep(0.2) if idx == 1
+    skip! if idx == 0
+    s = "[#{idx}] beginning"
+    puts s
+    s
+  end
+  ruby(:two) do |_, _, idx|
+    break! if idx == 1
+    s = "[#{idx}] middle"
+    puts s
+    s
+  end
+  ruby(:three) do |_, _, idx|
+    sleep(0.3) if idx == 2
+    s = "[#{idx}] end"
+    puts s
+    s
+  end
+end

--- a/lib/roast/dsl/cog.rb
+++ b/lib/roast/dsl/cog.rb
@@ -79,6 +79,9 @@ module Roast
           # TODO: better / cleaner handling in the workflow execution manager for a workflow failure
           #   just re-raising this exception for now
           raise e if config.abort_on_error?
+        rescue ControlFlow::Next, ControlFlow::Break => e
+          @skipped = true
+          raise e
         rescue StandardError => e
           @failed = true
           raise e
@@ -88,6 +91,8 @@ module Roast
       #: () -> void
       def wait
         @task&.wait
+      rescue
+        # Do nothing if the cog's task raised an exception. That is handled elsewhere.
       end
 
       #: () -> bool

--- a/lib/roast/dsl/cog_input_context.rb
+++ b/lib/roast/dsl/cog_input_context.rb
@@ -9,6 +9,7 @@ module Roast
       include SystemCogs::Map::InputContext
 
       class CogInputContextError < Roast::Error; end
+
       class ContextNotFoundError < CogInputContextError; end
 
       #: (?String?) -> void
@@ -19,6 +20,16 @@ module Roast
       #: (?String?) -> void
       def fail!(message = nil)
         raise ControlFlow::FailCog, message
+      end
+
+      #: (?String?) -> void
+      def next!(message = nil)
+        raise ControlFlow::Next, message
+      end
+
+      #: (?String?) -> void
+      def break!(message = nil)
+        raise ControlFlow::Break, message
       end
 
       #: (String, ?Hash) -> String

--- a/lib/roast/dsl/control_flow.rb
+++ b/lib/roast/dsl/control_flow.rb
@@ -10,8 +10,30 @@ module Roast
       class SkipCog < StandardError; end
 
       # Raised in a cog's input block or execute method to terminate the cog and mark it as 'failed'
-      # without terminating the workflow
+      # without terminating the workflow. The workflow may abort anyway if the cog is configured to abort the
+      # workflow on failure.
       class FailCog < StandardError; end
+
+      # Raised in a cog's input block or execute method to terminate the current loop iteration
+      # and start the next iteration immediately. The current cog will be marked as 'skipped',
+      # and every subsequent cog in the current iteration will not run. Any async cogs currently running in the
+      # current scope will be stopped.
+      #
+      # If this exception is raised outside of a loop (e.g, via the `call` cog, or in the top-level executor),
+      # this exception will just terminate that executor as described above without starting a 'next' iteration.
+      class Next < StandardError; end
+
+      # Raised in a cog's input block or execute method to terminate the current loop iteration immediately
+      # and skip all subsequent loop iterations. The current cog will be marked as 'skipped',
+      # and every subsequent cog in the current iteration will not run. Any async cogs currently running in the
+      # current scope will be stopped.
+      #
+      # If this exception is raised outside of a loop (e.g, via the `call` cog, or in the top-level executor),
+      # this exception will just terminate that executor as described above without starting a 'next' iteration.
+      #
+      # If this exception is raised inside a `map`, this exception will prevent any subsequent executor invocations
+      # within that map and will stop any async invocations running in parallel.
+      class Break < StandardError; end
     end
   end
 end

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -126,6 +126,12 @@ module Roast
       #: (Async::Task) -> void
       def wait_for_task_with_exception_handling(task)
         task.wait
+      rescue ControlFlow::Next
+        # TODO: do something with the message passed to next!
+        @barrier.stop
+      rescue ControlFlow::Break => e
+        @barrier.stop
+        raise e
       rescue StandardError => e
         @barrier.stop
         raise e

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -70,8 +70,12 @@ module Roast
                 scope_index: input.index,
               )
               em.prepare!
-              em.run!
-
+              begin
+                em.run!
+              rescue ControlFlow::Break
+                # treat `break!` like `next!` in a `call` invocation
+                # TODO: maybe do something with the message passed to break!
+              end
               Output.new(em)
             end
           end

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -124,6 +124,9 @@ module Roast
               ems << em = create_execution_manager_for_map_item(run, item, index + input.initial_index)
               em.prepare!
               em.run!
+            rescue ControlFlow::Break
+              # TODO: do something with the message passed to break!
+              break
             end
             ems.fill(nil, ems.length, input.items.length - ems.length)
             Output.new(ems)
@@ -147,6 +150,9 @@ module Roast
             # noinspection RubyArgCount
             barrier.wait do |task|
               task.wait
+            rescue ControlFlow::Break
+              # TODO: do something with the message passed to break!
+              barrier.stop
             rescue StandardError => e
               barrier.stop
               raise e

--- a/lib/roast/dsl/workflow.rb
+++ b/lib/roast/dsl/workflow.rb
@@ -55,7 +55,12 @@ module Roast
         raise WorkflowAlreadyStartedError if started? || completed?
 
         @started = true
-        @execution_manager.run!
+        begin
+          @execution_manager.run!
+        rescue ControlFlow::Break
+          # treat `break!` like `next!` in the top-level executor scope
+          # TODO: maybe do something with the message passed to break!
+        end
         @completed = true
       end
 

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -161,6 +161,40 @@ module DSL
         assert_equal expected_stdout, stdout
       end
 
+      test "next_break.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :next_break do
+          Roast::DSL::Workflow.from_file("dsl/next_break.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          [0] middle
+          [0] end
+          [1] beginning
+          Iteration 0: [false, true, true]
+          Iteration 1: [true, false, false]
+          Iteration 2: did not run at all
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
+      test "next_break_parallel.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :next_break_parallel do
+          Roast::DSL::Workflow.from_file("dsl/next_break_parallel.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          [2] beginning
+          [2] middle
+          [0] middle
+          [0] end
+          [1] beginning
+          Iteration 0: [false, true, true]
+          Iteration 1: [true, false, false]
+          Iteration 2: [true, true, false]
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
       test "parallel_map.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :parallel_map do
           Roast::DSL::Workflow.from_file("dsl/parallel_map.rb", EMPTY_PARAMS)


### PR DESCRIPTION
The PRs adds two new cog flow control statements for manipulating the flow of loops.

There are specifically inspired by the needs of the `repeat` system cog I will be adding in an up-stack PR, but they're potentially beneficial for `call` and `map` as well.

Semantics of `next!` and `break!` within a cog input block are basically the same as `next` and `break` within a normal ruby block used in a normal ruby iteration like `values.each`. 'Next' will terminate the current execution (skipping all subsequent steps) and proceed immediately with the next one. 'Break' will terminate the current execution (also skipping all subsequent steps) and also skip any subsequent iterations of the loop. It will also stop any parallel invocations currently in progress.