### PR TITLE
Always evaluate an executor's `outputs` and cache the result so it isn't run more than once

### DIFF
--- a/dsl/outputs.rb
+++ b/dsl/outputs.rb
@@ -17,11 +17,15 @@ execute(:capitalize_a_word) do
     my.args << "echo \"#{word}\" | tr '[:lower:]' '[:upper:]'"
   end
   cmd(:to_lower) do |my, word|
+    break! # the `outputs` will always be evaluated even if a cog breaks out of the execution scope
     my.command = "sh"
     my.args << "-c"
     my.args << "echo \"#{word}\" | tr '[:upper:]' '[:lower:]'"
   end
-  outputs { |word| "Upper: #{cmd!(:to_upper).text}\nOriginal: #{word}" } # `outputs` can return any kind of value
+  outputs do |word|
+    "Upper: #{cmd!(:to_upper).text} - Original: #{word}"
+    # `outputs` can return any kind of value
+  end
 end
 
 execute do
@@ -29,7 +33,8 @@ execute do
   call(:hello, run: :capitalize_a_word) { "Hello" }
 
   cmd do
-    upper = from(call!(:hello))
-    "echo \"#{upper}\""
+    from_outputs = from(call!(:hello))
+    explicit_value_access = from(call!(:hello)) { cmd!(:to_upper).text }
+    "echo From Outputs: '\"#{from_outputs}\"\nExplicit Value Access: \"#{explicit_value_access}\"'"
   end
 end

--- a/lib/roast/dsl/control_flow.rb
+++ b/lib/roast/dsl/control_flow.rb
@@ -5,14 +5,16 @@ module Roast
   module DSL
     # Errors that can be raised to control workflow execution
     module ControlFlow
+      class Base < StandardError; end
+
       # Raised in a cog's input block or execute method to terminate the cog and mark it as 'skipped'
       # without triggering any failure handling
-      class SkipCog < StandardError; end
+      class SkipCog < Base; end
 
       # Raised in a cog's input block or execute method to terminate the cog and mark it as 'failed'
       # without terminating the workflow. The workflow may abort anyway if the cog is configured to abort the
       # workflow on failure.
-      class FailCog < StandardError; end
+      class FailCog < Base; end
 
       # Raised in a cog's input block or execute method to terminate the current loop iteration
       # and start the next iteration immediately. The current cog will be marked as 'skipped',
@@ -21,7 +23,7 @@ module Roast
       #
       # If this exception is raised outside of a loop (e.g, via the `call` cog, or in the top-level executor),
       # this exception will just terminate that executor as described above without starting a 'next' iteration.
-      class Next < StandardError; end
+      class Next < Base; end
 
       # Raised in a cog's input block or execute method to terminate the current loop iteration immediately
       # and skip all subsequent loop iterations. The current cog will be marked as 'skipped',
@@ -33,7 +35,7 @@ module Roast
       #
       # If this exception is raised inside a `map`, this exception will prevent any subsequent executor invocations
       # within that map and will stop any async invocations running in parallel.
-      class Break < StandardError; end
+      class Break < Base; end
     end
   end
 end

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -106,7 +106,11 @@ module DSL
           Roast::DSL::Workflow.from_file("dsl/outputs.rb", EMPTY_PARAMS)
         end
         assert_empty stderr
-        assert_equal "Upper: HELLO\nOriginal: Hello\n", stdout
+        expected_stdout = <<~EOF
+          From Outputs: "Upper: HELLO - Original: Hello"
+          Explicit Value Access: "HELLO"
+        EOF
+        assert_equal expected_stdout, stdout
       end
 
       test "map.rb workflow runs successfully" do


### PR DESCRIPTION
The PR make two useful changes:

- caching the result of the `outputs` block in an executor makes it so the output block only runs once, even if it is access multiple times from the output scope. This is consistent the way that cogs run -- they run once and their outputs are stored and can be accessed repeatedly without reëvaluating anything. This conforms better to likely user expectations, and prevents any side effects triggered in the outputs blocks from happening multiple times. 

- eagerly evaluating the `outputs` block before completing the executor allows control flow statements like `break!` to be called in the outputs block, which is a natural place to decide "this is the last iteration of this loop that needs to be run".

As well, these two changes together allows the outputs block to be used as a sort of finalization for an executor scope