### PR TITLE
Add `repeat` cog

### DIFF
--- a/dsl/simple_repeat.rb
+++ b/dsl/simple_repeat.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+end
+
+execute do
+  repeat(:loop, run: :loop_body) {}
+end
+
+execute(:loop_body) do
+  ruby(:one) do |_, _, idx|
+    s = "iteration #{idx}"
+    puts s
+    s
+  end
+
+  ruby { |_, _, idx| break! if idx >= 3 }
+
+  outputs { |_, idx| "output of iteration #{idx}" }
+end

--- a/lib/roast/dsl/cog/registry.rb
+++ b/lib/roast/dsl/cog/registry.rb
@@ -12,6 +12,7 @@ module Roast
           @cogs = {}
           use(SystemCogs::Call)
           use(SystemCogs::Map)
+          use(SystemCogs::Repeat)
           use(Cogs::Cmd)
           use(Cogs::Chat)
           use(Cogs::Agent)

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -7,6 +7,7 @@ module Roast
     class ExecutionManager
       include SystemCogs::Call::Manager
       include SystemCogs::Map::Manager
+      include SystemCogs::Repeat::Manager
 
       class ExecutionManagerError < Roast::Error; end
 
@@ -189,6 +190,8 @@ module Roast
             create_call_system_cog(cog_params, cog_input_proc)
           elsif cog_class == SystemCogs::Map
             create_map_system_cog(cog_params, cog_input_proc)
+          elsif cog_class == SystemCogs::Repeat
+            create_repeat_system_cog(cog_params, cog_input_proc)
           else
             raise NotImplementedError, "No system cog manager defined for #{cog_class}"
           end

--- a/lib/roast/dsl/system_cogs/repeat.rb
+++ b/lib/roast/dsl/system_cogs/repeat.rb
@@ -1,0 +1,87 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module DSL
+    module SystemCogs
+      class Repeat < SystemCog
+        class Config < Cog::Config; end
+
+        class Params < SystemCog::Params
+          #: Symbol
+          attr_accessor :run
+
+          #: (?Symbol?, run: Symbol) -> void
+          def initialize(name = nil, run:)
+            super(name)
+            @run = run
+          end
+        end
+
+        class Input < Cog::Input
+          #: untyped
+          attr_accessor :value
+
+          # Integer
+          attr_accessor :index
+
+          #: () -> void
+          def initialize
+            super
+            @index = 0
+          end
+
+          #: () -> void
+          def validate!
+            raise Cog::Input::InvalidInputError, "'value' is required" if value.nil? && !coerce_ran?
+          end
+
+          def coerce(input_return_value)
+            super
+            @value = input_return_value unless @value.present?
+          end
+        end
+
+        class Output < Cog::Output
+          #: (Array[ExecutionManager]) -> void
+          def initialize(execution_managers)
+            super()
+            @execution_managers = execution_managers
+          end
+        end
+
+        # @requires_ancestor: Roast::DSL::ExecutionManager
+        module Manager
+          private
+
+          #: (Params, ^(Cog::Input) -> untyped) -> SystemCogs::Repeat
+          def create_repeat_system_cog(params, input_proc)
+            SystemCogs::Repeat.new(params.name, input_proc) do |input|
+              input = input #: as Input
+              raise ExecutionManager::ExecutionScopeNotSpecifiedError unless params.run.present?
+
+              ems = [] #: Array[ExecutionManager]
+              loop do
+                ems << em = ExecutionManager.new(
+                  @cog_registry,
+                  @config_manager,
+                  @all_execution_procs,
+                  @workflow_context,
+                  scope: params.run,
+                  scope_value: input.value.deep_dup,
+                  scope_index: ems.length,
+                )
+                em.prepare!
+                em.run!
+              rescue ControlFlow::Break
+                # TODO: do something with the message passed to break!
+                break
+              end
+              Output.new(ems)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/cog_input_context.rbi
@@ -70,6 +70,15 @@ module Roast
       #: (Symbol) -> bool
       def map?(name); end
 
+      #: (Symbol) -> Roast::DSL::SystemCogs::Repeat::Output?
+      def repeat(name); end
+
+      #: (Symbol) -> Roast::DSL::SystemCogs::Repeat::Output
+      def repeat!(name); end
+
+      #: (Symbol) -> bool
+      def repeat?(name); end
+
       ########################################
       #            Standard Cogs
       ########################################

--- a/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/config_context.rbi
@@ -18,6 +18,9 @@ module Roast
       #: (?(Symbol | Regexp)?) {() [self: Roast::DSL::SystemCogs::Map::Config] -> void} -> void
       def map(name = nil, &block); end
 
+      #: (?(Symbol | Regexp)?) {() [self: Roast::DSL::SystemCogs::Repeat::Config] -> void} -> void
+      def repeat(name = nil, &block); end
+
       ########################################
       #            Standard Cogs
       ########################################

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -22,6 +22,9 @@ module Roast
       #: (?Symbol?, run: Symbol) {(Roast::DSL::SystemCogs::Map::Input, untyped, Integer) [self: Roast::DSL::CogInputContext] -> untyped} -> void
       def map(name = nil, run:, &block); end
 
+      #: (?Symbol?, run: Symbol) {(Roast::DSL::SystemCogs::Repeat::Input, untyped, Integer) [self: Roast::DSL::CogInputContext] -> untyped} -> void
+      def repeat(name = nil, run:, &block); end
+
       ########################################
       #            Standard Cogs
       ########################################

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -295,6 +295,20 @@ module DSL
         assert_empty stderr
       end
 
+      test "simple_repeat.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :simple_repeat do
+          Roast::DSL::Workflow.from_file("dsl/simple_repeat.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          iteration 0
+          iteration 1
+          iteration 2
+          iteration 3
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
       test "targets_and_params.rb workflow runs successfully" do
         params = Roast::DSL::WorkflowParams.new(
           ["one", "two", "three"],


### PR DESCRIPTION
The `repeat` cog lets you run a loop for however many iterations it takes until a condition is true.


A super simplistic toy example:
```
execute do
  repeat(run: :my_loop)
end

execute(:my_loop) do
  ruby { |_, _, idx| puts "iteration: ${idx}" }
  ruby { break! if idx >= 4 }
end
```

`repeat` does not take an inherent termination condition. It runs until `break!` is called somewhere within it.

