### PR TITLE
Make `final_output` public on ExecutionManager

### DIFF
--- a/dsl/simple_repeat.rb
+++ b/dsl/simple_repeat.rb
@@ -7,6 +7,8 @@ config do
 end
 
 execute do
+  # You can use `repeat` to repeat an executor multiple times
+  # The executor will run forever until it breaks according to its internal logic
   repeat(:loop, run: :loop_body) {}
 end
 
@@ -17,7 +19,11 @@ execute(:loop_body) do
     s
   end
 
+  # Use `break!` to terminate the repeat loop
+  # Cogs that occur after `break!` is called will not run on the final iteration
   ruby { |_, _, idx| break! if idx >= 3 }
 
+  # The `outputs` block will *always* run, including on the iteration in which the `break!` was issued
+  # NOTE: Be careful not to depend on the output of cogs that only run after the break point
   outputs { |_, idx| "output of iteration #{idx}" }
 end

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -25,6 +25,9 @@ module Roast
 
       class OutputsAlreadyDefinedError < ExecutionManagerError; end
 
+      #: untyped
+      attr_reader :final_output
+
       #: (
       #|  Cog::Registry,
       #|  ConfigManager,
@@ -218,9 +221,6 @@ module Roast
 
         @outputs = outputs
       end
-
-      #: untyped
-      attr_reader :final_output
 
       #: () -> untyped
       def compute_final_output

--- a/lib/roast/dsl/system_cogs/call.rb
+++ b/lib/roast/dsl/system_cogs/call.rb
@@ -89,7 +89,7 @@ module Roast
             em = call_cog_output.instance_variable_get(:@execution_manager)
             raise CogInputContext::ContextNotFoundError if em.nil?
 
-            final_output = em.send(:final_output)
+            final_output = em.final_output
             return em.cog_input_context.instance_exec(final_output, &block) if block_given?
 
             final_output

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -178,11 +178,11 @@ module Roast
 
               scope_value = em.instance_variable_get(:@scope_value)
               scope_index = em.instance_variable_get(:@scope_index)
-              final_output = em.send(:final_output)
+              final_output = em.final_output
               em.cog_input_context.instance_exec(final_output, scope_value, scope_index, &block)
             end if block_given?
 
-            ems.map { |em| em&.send(:final_output) }
+            ems.map { |em| em&.final_output }
           end
 
           #: [A] (Roast::DSL::SystemCogs::Map::Output, ?A?) {(A?, untyped) -> A} -> A?
@@ -196,7 +196,7 @@ module Roast
 
               scope_value = em.instance_variable_get(:@scope_value)
               scope_index = em.instance_variable_get(:@scope_index)
-              final_output = em.send(:final_output)
+              final_output = em.final_output
               new_accumulator = em.cog_input_context.instance_exec(accumulator, final_output, scope_value, scope_index, &block)
               case new_accumulator
               when nil


### PR DESCRIPTION
The `ExecutionManager#final_output` private method is being used via `send` by a number of places now. Clearly it should just be a public method.