### PR TITLE
Pass output values to next iteration of repeat loop, and back to caller

### DIFF
--- a/dsl/repeat_loop_results.rb
+++ b/dsl/repeat_loop_results.rb
@@ -1,0 +1,34 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+end
+
+execute do
+  repeat(:loop, run: :loop_body) { 7 }
+
+  ruby do
+    # You can access the final output value of a `repeat` cog directly
+    result = repeat!(:loop)
+    puts "Final Result: #{result.value}"
+  end
+end
+
+execute(:loop_body) do
+  # on each loop iteration, the input value provided will be the output value of the previous iteration
+  # the initial value will be what was provided when `repeat` was called in the outer scope.
+  ruby(:add) do |_, num, idx|
+    new_num = num + idx
+    s = "iteration #{idx}: #{num} + #{idx} -> #{new_num}"
+    puts s
+    new_num
+  end
+
+  ruby { |_, _, idx| break! if idx >= 3 }
+
+  # The value provided to `outputs` will be the input value for the next iteration
+  # On the final iteration, it will also be the `repeat` cog's own output value
+  outputs { ruby!(:add).value }
+end

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -235,6 +235,21 @@ module DSL
         assert_empty lines
       end
 
+      test "repeat_loop_results.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :repeat_loop_results do
+          Roast::DSL::Workflow.from_file("dsl/repeat_loop_results.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          iteration 0: 7 + 0 -> 7
+          iteration 1: 7 + 1 -> 8
+          iteration 2: 8 + 2 -> 10
+          iteration 3: 10 + 3 -> 13
+          Final Result: 13
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
       test "ruby_cog.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :ruby_cog do
           Roast::DSL::Workflow.from_file("dsl/ruby_cog.rb", EMPTY_PARAMS)


### PR DESCRIPTION
We need some way to track state between iterations of a repeat loop, and to retrieve an ultimate result from the last iteration

The result of the `outputs` block in the loop executor will be passed to the next iteration of the loop as its scope value, and the result of the final iteration's `outputs` block will be passed back as the result value of the `repeat` cog itself.