### PR TITLE
Access a specific iteration of a `repeat` loop using `from`

### DIFF
--- a/dsl/repeat_loop_results.rb
+++ b/dsl/repeat_loop_results.rb
@@ -12,7 +12,18 @@ execute do
   ruby do
     # You can access the final output value of a `repeat` cog directly
     result = repeat!(:loop)
-    puts "Final Result: #{result.value}"
+    puts "Ultimate Loop Result: #{result.value}"
+  end
+
+  ruby do
+    puts "---"
+    # You can also access the final result, or individual cog results, of any specific iteration
+    # In the same manner as you would use `from` to access the results of a single `call` invocation.
+    puts "First Iteration Result: #{from(repeat!(:loop).first)}"
+    puts "Final Iteration Result: #{from(repeat!(:loop).last)}"
+    puts "Second-to-last Iteration Result: #{from(repeat!(:loop).iteration(-2))}"
+    # NOTE: accessing a specific iteration will raise an IndexException if the requested index is out of bounds
+    # for the number of iterations that ran.
   end
 end
 

--- a/lib/roast/dsl/system_cogs/repeat.rb
+++ b/lib/roast/dsl/system_cogs/repeat.rb
@@ -53,6 +53,21 @@ module Roast
           def value
             @execution_managers.last&.final_output
           end
+
+          #: (Integer) -> Call::Output
+          def iteration(index)
+            Call::Output.new(@execution_managers.fetch(index))
+          end
+
+          #: () -> Call::Output
+          def first
+            iteration(0)
+          end
+
+          #: () -> Call::Output
+          def last
+            iteration(-1)
+          end
         end
 
         # @requires_ancestor: Roast::DSL::ExecutionManager

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -245,7 +245,11 @@ module DSL
           iteration 1: 7 + 1 -> 8
           iteration 2: 8 + 2 -> 10
           iteration 3: 10 + 3 -> 13
-          Final Result: 13
+          Ultimate Loop Result: 13
+          ---
+          First Iteration Result: 7
+          Final Iteration Result: 13
+          Second-to-last Iteration Result: 10
         EOF
         assert_equal expected_stdout, stdout
       end


### PR DESCRIPTION
For more advanced output access, you can use `from` to access the cog outputs from a specific iteration of the loop