### PR TITLE
Access the results of all `repeat` loop iterations using `collect` and `reduce`

### DIFF
--- a/dsl/repeat_loop_results.rb
+++ b/dsl/repeat_loop_results.rb
@@ -25,6 +25,14 @@ execute do
     # NOTE: accessing a specific iteration will raise an IndexException if the requested index is out of bounds
     # for the number of iterations that ran.
   end
+
+  ruby do
+    puts "---"
+    # You can access the results of all iterations in the same manner as you would use `collect` or `reduce`
+    # to access the complete results of a `map` invocation.
+    puts "All :add cog outputs: #{collect(repeat!(:loop).results) { ruby!(:add).value }}"
+    puts "Sum of :add cog output: #{reduce(repeat!(:loop).results, 0) { |acc| acc + ruby!(:add).value }}"
+  end
 end
 
 execute(:loop_body) do

--- a/lib/roast/dsl/system_cogs/repeat.rb
+++ b/lib/roast/dsl/system_cogs/repeat.rb
@@ -68,6 +68,11 @@ module Roast
           def last
             iteration(-1)
           end
+
+          #: () -> Map::Output
+          def results
+            Map::Output.new(@execution_managers)
+          end
         end
 
         # @requires_ancestor: Roast::DSL::ExecutionManager

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -250,6 +250,9 @@ module DSL
           First Iteration Result: 7
           Final Iteration Result: 13
           Second-to-last Iteration Result: 10
+          ---
+          All :add cog outputs: [7, 8, 10, 13]
+          Sum of :add cog output: 38
         EOF
         assert_equal expected_stdout, stdout
       end


### PR DESCRIPTION
Now you can also use `collect` and `reduce` to work with the results of every iteration of the repeat loop