### PR TITLE
Access individual `map` iteration results using `from`

### DIFF
--- a/dsl/map.rb
+++ b/dsl/map.rb
@@ -46,4 +46,10 @@ execute do
   # - name of the map cog itself can be omitted (anonymous cog)
   # - items over which to map coerced from return value of input proc
   map(run: :capitalize_a_word) { words.reverse }
+
+  # ACCESSING THE OUTPUT OF A SPECIFIC MAP ITERATION
+  ruby do
+    puts ""
+    puts "#{words[2]} -> #{from(map!(:some_name).iteration(2)) { cmd!(:capitalize).text }}"
+  end
 end

--- a/lib/roast/dsl/system_cogs/map.rb
+++ b/lib/roast/dsl/system_cogs/map.rb
@@ -5,6 +5,10 @@ module Roast
   module DSL
     module SystemCogs
       class Map < SystemCog
+        class MapOutputAccessError < Roast::Error; end
+
+        class MapIterationDidNotRunError < MapOutputAccessError; end
+
         class Config < Cog::Config
           #: (Integer) -> void
           def parallel(value)
@@ -81,6 +85,29 @@ module Roast
           def initialize(execution_managers)
             super()
             @execution_managers = execution_managers
+          end
+
+          #: (Integer) -> bool
+          def iteration?(index)
+            @execution_managers.fetch(index).present?
+          end
+
+          #: (Integer) -> Call::Output
+          def iteration(index)
+            em = @execution_managers.fetch(index)
+            raise MapIterationDidNotRunError, index unless em.present?
+
+            Call::Output.new(em)
+          end
+
+          #: () -> Call::Output
+          def first
+            iteration(0)
+          end
+
+          #: () -> Call::Output
+          def last
+            iteration(-1)
           end
         end
 

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -133,6 +133,8 @@ module DSL
           GOODNIGHT
           WORLD
           HELLO
+
+          goodnight -> GOODNIGHT
         EOF
         assert_equal expected_stdout, stdout
       end


### PR DESCRIPTION
Building on the architectural pattern established down-stack for accessing output from a specific, individual iteration of a `repeat` loop, you can now access a specific iteration of a `map` invocation as well.

Note that the semantics here are slightly different. `map` is run on an iterable of some known size, N, and it will always produce the results of N iterations. However, because `break!` can be issued inside the map executor, some of those iterations that had not started yet will be `nil` in the map result. Attempting to access those iterations directly will raise an `IndexError`.

To help make this uncertainty easier to handle, `Map::Output` get an `iteration?` method that will check if the requested iteration has output, if you know you're working with a map that might not always complete (i.e. contains a conditional `break!`). I expect this usage will be quite uncommon for `map`, so I don't think additional shorthand is required at this time.