### PR TITLE
Adds an `outputs!` block as an alternative to `outputs`.

### DIFF
--- a/dsl/outputs_bang.rb
+++ b/dsl/outputs_bang.rb
@@ -1,0 +1,37 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::DSL::Workflow
+
+config do
+  global { exit_on_error! }
+  cmd { display! }
+  cmd(/to_/) { no_display! }
+end
+
+execute(:subroutine1) do
+  ruby(:one) { "one" }
+  ruby(:two) { skip! }
+  # Attempting to access the output of a cog that did not run will not raise an exception inside the `outputs` block
+  # Instead, it will just return `nil`
+  outputs { ruby!(:two).value }
+end
+
+execute(:subroutine2) do
+  ruby(:one) { "one" }
+  ruby(:two) { skip! }
+  # Attempting to access the output of a cog that did not run *will* raise an exception inside the `outputs!` block
+  outputs! do
+    puts "❗️ This block is expected to raise an exception ❗️"
+    ruby!(:two).value
+  end
+end
+
+execute do
+  call(:one, run: :subroutine1) {}
+
+  ruby { puts "Using the `outputs` block should return `nil`: #{from(call!(:one)) || "nil"}" }
+
+  # The `outputs!` block in subroutine2 will raise an exception as soon as it is evaluated
+  call(:two, run: :subroutine2) {}
+end

--- a/lib/roast/dsl/execution_manager.rb
+++ b/lib/roast/dsl/execution_manager.rb
@@ -59,6 +59,7 @@ module Roast
         @cog_input_manager = CogInputManager.new(@cog_registry, @cogs, @workflow_context) #: CogInputManager
         @barrier = Async::Barrier.new #: Async::Barrier
         @final_output = nil #: untyped
+        @final_output_computed = false #: bool
       end
 
       #: () -> void
@@ -207,25 +208,38 @@ module Roast
 
       def bind_outputs
         on_outputs_method = method(:on_outputs)
-        method_to_bind = proc do |&outputs_proc|
-          on_outputs_method.call(outputs_proc)
-        end
+        on_outputs_bang_method = method(:on_outputs!)
+        method_to_bind = proc { |&outputs_proc| on_outputs_method.call(outputs_proc) }
+        bang_method_to_bind = proc { |&outputs_proc| on_outputs_bang_method.call(outputs_proc) }
         @execution_context.instance_eval do
           define_singleton_method(:outputs, method_to_bind)
+          define_singleton_method(:outputs!, bang_method_to_bind)
         end
       end
 
       #: (^(untyped, Integer) -> untyped) -> void
       def on_outputs(outputs)
-        raise OutputsAlreadyDefinedError if @outputs
+        raise OutputsAlreadyDefinedError if @outputs || @outputs_bang
 
         @outputs = outputs
       end
 
+      #: (^(untyped, Integer) -> untyped) -> void
+      def on_outputs!(outputs)
+        raise OutputsAlreadyDefinedError if @outputs || @outputs_bang
+
+        @outputs_bang = outputs
+      end
+
       #: () -> untyped
       def compute_final_output
-        @final_output = if @outputs
-          @cog_input_manager.context.instance_exec(@scope_value, @scope_index, &@outputs)
+        return if @final_output_computed
+
+        @final_output_computed = true
+        outputs_proc = @outputs_bang || @outputs
+
+        @final_output = if outputs_proc
+          @cog_input_manager.context.instance_exec(@scope_value, @scope_index, &outputs_proc)
         else
           last_cog_name = @cog_stack.last&.name
           raise CogInputManager::CogDoesNotExistError, "no cogs defined in scope" unless last_cog_name
@@ -235,6 +249,18 @@ module Roast
       rescue ControlFlow::SkipCog, ControlFlow::Next
         # TODO: do something with the message passed to the control flow statement
         # Swallow skip! and next! control flow statements in the outputs block
+        # Calling these will just make the final output `nil`.
+        # (As will calling `break!`, but it gets handled elsewhere.)
+        # Calling `fail!` inside `outputs` should actually raise an exception.
+      rescue CogInputManager::CogNotYetRunError, CogInputManager::CogSkippedError, CogInputManager::CogStoppedError => e
+        # Attempting to accessing a cog that was skipped, stopped, or did not run from inside an `outputs` block
+        # is more likely to happen when the user `break!`s from a loop. Allowing this access not to result in an
+        # exception getting raised immediately will reduce boilerplate code needed to check if the loop was broken
+        # and return nil or some fallback value if it was, and the normal outputs value otherwise.
+        #
+        # Using `outputs` to define the scope's outputs will swallow these exceptions.
+        # Using `outputs!` instead will cause the exceptions to be raised.
+        raise e if @outputs_bang.present?
       end
     end
   end

--- a/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi
@@ -12,6 +12,9 @@ module Roast
       #: () {(untyped, Integer) [self: Roast::DSL::CogInputContext] -> untyped} -> void
       def outputs(&block); end
 
+      #: () {(untyped, Integer) [self: Roast::DSL::CogInputContext] -> untyped} -> void
+      def outputs!(&block); end
+
       ########################################
       #             System Cogs
       ########################################

--- a/test/dsl/functional/roast_dsl_examples_test.rb
+++ b/test/dsl/functional/roast_dsl_examples_test.rb
@@ -113,6 +113,20 @@ module DSL
         assert_equal expected_stdout, stdout
       end
 
+      test "outputs_bang.rb workflow runs successfully" do
+        stdout, stderr = in_sandbox :outputs_bang do
+          assert_raises Roast::DSL::CogInputManager::CogSkippedError do
+            Roast::DSL::Workflow.from_file("dsl/outputs_bang.rb", EMPTY_PARAMS)
+          end
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          Using the `outputs` block should return `nil`: nil
+          ❗️ This block is expected to raise an exception ❗️
+        EOF
+        assert_equal expected_stdout, stdout
+      end
+
       test "map.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :prototype do
           Roast::DSL::Workflow.from_file("dsl/map.rb", EMPTY_PARAMS)


### PR DESCRIPTION
`outputs` will now swallow some `CogOutputAccessError`s, simplifying the logic needed
when potentially `break!`ing from an executor. (Users would otherwise have to check if a cog ran,
return nil if it did not, then proceed with their output-calculating logic).

`outputs!` implements the previous behaviour, where any attempt to access the output of a cog
that did not complete will raise an exception.