### PR TITLE
Standardize logging with Roast::Log class (Fixes #390)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,13 @@ Roast/UseCmdRunner:
     - 'lib/roast/dsl/command_runner.rb'
     - 'roast-ai.gemspec'
 
+Roast/UseRoastLog:
+  Enabled: true
+  Exclude:
+    - 'test/**/*.rb'
+    - 'dsl/**/*.rb'
+    - '.roast/initializers/**/*.rb'
+
 Style/MethodCallWithArgsParentheses:
   Enabled: true
   Exclude:

--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -82,7 +82,7 @@ module Roast
       workflow_path, *files = paths
 
       if options[:executor] == "dsl"
-        puts "⚠️ WARNING: This is an experimental syntax and may break at any time. Don't depend on it."
+        Roast::Log.warn("⚠️ WARNING: This is an experimental syntax and may break at any time. Don't depend on it.")
         targets, workflow_args, workflow_kwargs = parse_custom_workflow_args(files, ARGV)
         targets.unshift(options[:target]) if options[:target]
         workflow_params = Roast::DSL::WorkflowParams.new(targets, workflow_args, workflow_kwargs)
@@ -104,7 +104,7 @@ module Roast
       if options[:verbose]
         raise e
       else
-        $stderr.puts e.message
+        Roast::Log.error(e.message)
       end
     end
 
@@ -148,7 +148,7 @@ module Roast
 
     desc "version", "Display the current version of Roast"
     def version
-      puts "Roast version #{Roast::VERSION}"
+      Roast::Log.info("Roast version #{Roast::VERSION}")
     end
 
     desc "init", "Initialize a new Roast workflow from an example"
@@ -175,16 +175,16 @@ module Roast
         raise Thor::Error, "No workflow.yml files found in roast/ directory"
       end
 
-      puts "Available workflows:"
-      puts
+      Roast::Log.info("Available workflows:")
+      Roast::Log.info("")
 
       workflow_files.each do |file|
         workflow_name = File.dirname(file.sub("#{roast_dir}/", ""))
-        puts "  #{workflow_name} (from project)"
+        Roast::Log.info("  #{workflow_name} (from project)")
       end
 
-      puts
-      puts "Run a workflow with: roast execute <workflow_name>"
+      Roast::Log.info("")
+      Roast::Log.info("Run a workflow with: roast execute <workflow_name>")
     end
 
     desc "validate [WORKFLOW_CONFIGURATION_FILE]", "Validate a workflow configuration"
@@ -208,7 +208,7 @@ module Roast
 
       if options[:cleanup] && options[:older_than]
         count = repository.cleanup_old_sessions(options[:older_than])
-        puts "Cleaned up #{count} old sessions"
+        Roast::Log.info("Cleaned up #{count} old sessions")
         return
       end
 
@@ -219,23 +219,23 @@ module Roast
       )
 
       if sessions.empty?
-        puts "No sessions found"
+        Roast::Log.info("No sessions found")
         return
       end
 
-      puts "Found #{sessions.length} session(s):"
-      puts
+      Roast::Log.info("Found #{sessions.length} session(s):")
+      Roast::Log.info("")
 
       sessions.each do |session|
         id, workflow_name, _, status, current_step, created_at, updated_at = session
 
-        puts "Session: #{id}"
-        puts "  Workflow: #{workflow_name}"
-        puts "  Status: #{status}"
-        puts "  Current step: #{current_step || "N/A"}"
-        puts "  Created: #{created_at}"
-        puts "  Updated: #{updated_at}"
-        puts
+        Roast::Log.info("Session: #{id}")
+        Roast::Log.info("  Workflow: #{workflow_name}")
+        Roast::Log.info("  Status: #{status}")
+        Roast::Log.info("  Current step: #{current_step || "N/A"}")
+        Roast::Log.info("  Created: #{created_at}")
+        Roast::Log.info("  Updated: #{updated_at}")
+        Roast::Log.info("")
       end
     end
 
@@ -257,33 +257,33 @@ module Roast
       states = details[:states]
       events = details[:events]
 
-      puts "Session: #{session[0]}"
-      puts "Workflow: #{session[1]}"
-      puts "Path: #{session[2]}"
-      puts "Status: #{session[3]}"
-      puts "Created: #{session[6]}"
-      puts "Updated: #{session[7]}"
+      Roast::Log.info("Session: #{session[0]}")
+      Roast::Log.info("Workflow: #{session[1]}")
+      Roast::Log.info("Path: #{session[2]}")
+      Roast::Log.info("Status: #{session[3]}")
+      Roast::Log.info("Created: #{session[6]}")
+      Roast::Log.info("Updated: #{session[7]}")
 
       if session[5]
-        puts
-        puts "Final output:"
-        puts session[5]
+        Roast::Log.info("")
+        Roast::Log.info("Final output:")
+        Roast::Log.info(session[5])
       end
 
       if states && !states.empty?
-        puts
-        puts "Steps executed:"
+        Roast::Log.info("")
+        Roast::Log.info("Steps executed:")
         states.each do |step_index, step_name, created_at|
-          puts "  #{step_index}: #{step_name} (#{created_at})"
+          Roast::Log.info("  #{step_index}: #{step_name} (#{created_at})")
         end
       end
 
       if events && !events.empty?
-        puts
-        puts "Events:"
+        Roast::Log.info("")
+        Roast::Log.info("Events:")
         events.each do |event_name, event_data, received_at|
-          puts "  #{event_name} at #{received_at}"
-          puts "    Data: #{event_data}" if event_data
+          Roast::Log.info("  #{event_name} at #{received_at}")
+          Roast::Log.info("    Data: #{event_data}") if event_data
         end
       end
     end
@@ -299,7 +299,7 @@ module Roast
       generator = WorkflowDiagramGenerator.new(workflow, workflow_file)
       output_path = generator.generate(options[:output])
 
-      puts ::CLI::UI.fmt("{{success:✓}} Diagram generated: #{output_path}")
+      Roast::Log.info(::CLI::UI.fmt("{{success:✓}} Diagram generated: #{output_path}"))
     rescue Roast::Error => e
       raise Thor::Error, "Error generating diagram: #{e.message}"
     end
@@ -328,11 +328,11 @@ module Roast
       examples = available_examples
 
       if examples.empty?
-        puts "No examples found!"
+        Roast::Log.info("No examples found!")
         return
       end
 
-      puts "Select an option:"
+      Roast::Log.info("Select an option:")
       choices = ["Pick from examples", "New from prompt (coming soon)"]
 
       selected = run_picker(choices, "Select initialization method:")
@@ -373,34 +373,34 @@ module Roast
       target_path = File.join(roast_dir, example_name)
 
       unless File.directory?(source_path)
-        puts "Example '#{example_name}' not found!"
+        Roast::Log.info("Example '#{example_name}' not found!")
         return
       end
 
       if File.exist?(target_path)
-        puts "Directory '#{example_name}' already exists in current directory!"
+        Roast::Log.info("Directory '#{example_name}' already exists in current directory!")
         return
       end
 
       FileUtils.cp_r(source_path, target_path)
-      puts "Successfully copied example '#{example_name}' to current directory."
+      Roast::Log.info("Successfully copied example '#{example_name}' to current directory.")
     end
 
     def show_coming_soon_message
-      puts
-      puts ::CLI::UI.fmt("{{bold:Workflow Generator - Coming Soon}}")
-      puts
-      puts "The 'New from prompt' workflow generator is being rebuilt to ensure"
-      puts "generated workflows are reliable and properly validated."
-      puts
-      puts "This feature will return with:"
-      puts "  • Better AI-generated workflow quality"
-      puts "  • Validation to ensure generated workflows actually work"
-      puts "  • Integration with Roast's upcoming DSL features"
-      puts
-      puts "For now, please use 'Pick from examples' to get started."
-      puts "You can then customize the example workflow for your needs."
-      puts
+      Roast::Log.info("")
+      Roast::Log.info(::CLI::UI.fmt("{{bold:Workflow Generator - Coming Soon}}"))
+      Roast::Log.info("")
+      Roast::Log.info("The 'New from prompt' workflow generator is being rebuilt to ensure")
+      Roast::Log.info("generated workflows are reliable and properly validated.")
+      Roast::Log.info("")
+      Roast::Log.info("This feature will return with:")
+      Roast::Log.info("  • Better AI-generated workflow quality")
+      Roast::Log.info("  • Validation to ensure generated workflows actually work")
+      Roast::Log.info("  • Integration with Roast's upcoming DSL features")
+      Roast::Log.info("")
+      Roast::Log.info("For now, please use 'Pick from examples' to get started.")
+      Roast::Log.info("You can then customize the example workflow for your needs.")
+      Roast::Log.info("")
     end
 
     class << self

--- a/lib/roast/log.rb
+++ b/lib/roast/log.rb
@@ -1,0 +1,40 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  # Standardized logging interface for Roast
+  # Delegates to Roast::Helpers::Logger for actual logging
+  class Log
+    class << self
+      # Log an info message (equivalent to puts for user-facing output)
+      # @param message [String] The message to log
+      def info(message)
+        Roast::Helpers::Logger.info(message)
+      end
+
+      # Log a debug message
+      # @param message [String] The message to log
+      def debug(message)
+        Roast::Helpers::Logger.debug(message)
+      end
+
+      # Log a warning message
+      # @param message [String] The message to log
+      def warn(message)
+        Roast::Helpers::Logger.warn(message)
+      end
+
+      # Log an error message
+      # @param message [String] The message to log
+      def error(message)
+        Roast::Helpers::Logger.error(message)
+      end
+
+      # Log a fatal error message
+      # @param message [String] The message to log
+      def fatal(message)
+        Roast::Helpers::Logger.fatal(message)
+      end
+    end
+  end
+end

--- a/lib/roast/workflow/base_step.rb
+++ b/lib/roast/workflow/base_step.rb
@@ -70,8 +70,8 @@ module Roast
 
           # Debug output
           if template_response.is_a?(DotAccessHash) && template_response.recommendations&.is_a?(Array)
-            $stderr.puts "DEBUG: recommendations array has #{template_response.recommendations.size} items"
-            $stderr.puts "DEBUG: first item class: #{template_response.recommendations.first.class}" if template_response.recommendations.first
+            Roast::Log.debug("DEBUG: recommendations array has #{template_response.recommendations.size} items")
+            Roast::Log.debug("DEBUG: first item class: #{template_response.recommendations.first.class}") if template_response.recommendations.first
           end
 
           # Create a binding that includes the wrapped response

--- a/lib/roast/workflow/case_executor.rb
+++ b/lib/roast/workflow/case_executor.rb
@@ -13,7 +13,7 @@ module Roast
       end
 
       def execute_case(case_config)
-        $stderr.puts "Executing case step: #{case_config.inspect}"
+        Roast::Log.debug("Executing case step: #{case_config.inspect}")
 
         # Extract case expression
         case_expr = case_config["case"]

--- a/lib/roast/workflow/conditional_executor.rb
+++ b/lib/roast/workflow/conditional_executor.rb
@@ -13,7 +13,7 @@ module Roast
       end
 
       def execute_conditional(conditional_config)
-        $stderr.puts "Executing conditional step: #{conditional_config.inspect}"
+        Roast::Log.debug("Executing conditional step: #{conditional_config.inspect}")
 
         # Determine if this is an 'if' or 'unless' condition
         condition_expr = conditional_config["if"] || conditional_config["unless"]

--- a/lib/roast/workflow/configuration_loader.rb
+++ b/lib/roast/workflow/configuration_loader.rb
@@ -202,8 +202,8 @@ module Roast
 
           ::CLI::UI::Frame.open("Validation Warnings", color: :yellow) do
             warnings.each do |warning|
-              puts ::CLI::UI.fmt("{{yellow:#{warning[:message]}}}")
-              puts ::CLI::UI.fmt("  {{gray:→ #{warning[:suggestion]}}}") if warning[:suggestion]
+              Roast::Log.warn(::CLI::UI.fmt("{{yellow:#{warning[:message]}}}"))
+              Roast::Log.warn(::CLI::UI.fmt("  {{gray:→ #{warning[:suggestion]}}}")) if warning[:suggestion]
               puts
             end
           end

--- a/lib/roast/workflow/each_step.rb
+++ b/lib/roast/workflow/each_step.rb
@@ -18,16 +18,16 @@ module Roast
         collection = process_iteration_input(@collection_expr, workflow, coerce_to: :iterable)
 
         unless collection.respond_to?(:each)
-          $stderr.puts "Error: Collection '#{@collection_expr}' is not iterable"
+          Roast::Log.error("Error: Collection '#{@collection_expr}' is not iterable")
           raise ArgumentError, "Collection '#{@collection_expr}' is not iterable"
         end
 
         results = []
-        $stderr.puts "Starting each loop over collection with #{collection.size} items"
+        Roast::Log.info("Starting each loop over collection with #{collection.size} items")
 
         # Iterate over the collection
         collection.each_with_index do |item, index|
-          $stderr.puts "Each loop iteration #{index + 1} with #{@variable_name}=#{item.inspect}"
+          Roast::Log.debug("Each loop iteration #{index + 1} with #{@variable_name}=#{item.inspect}")
 
           # Create a context with the current item as a variable
           define_iteration_variable(item)
@@ -40,7 +40,7 @@ module Roast
           save_iteration_state(index, item) if workflow.respond_to?(:session_name) && workflow.session_name
         end
 
-        $stderr.puts "Each loop completed with #{collection.size} iterations"
+        Roast::Log.info("Each loop completed with #{collection.size} iterations")
         results
       end
 
@@ -82,7 +82,7 @@ module Roast
         state_repository.save_state(workflow, "#{name}_item_#{index}", state_data)
       rescue => e
         # Don't fail the workflow if state saving fails
-        $stderr.puts "Warning: Failed to save iteration state: #{e.message}"
+        Roast::Log.warn("Warning: Failed to save iteration state: #{e.message}")
       end
     end
   end

--- a/lib/roast/workflow/error_handler.rb
+++ b/lib/roast/workflow/error_handler.rb
@@ -120,19 +120,19 @@ module Roast
         # Print user-friendly error message based on error type
         case error
         when StepLoader::StepNotFoundError
-          $stderr.puts "\n❌ Step not found: '#{step_name}'"
-          $stderr.puts "   Please check that the step exists in your workflow's steps directory."
-          $stderr.puts "   Looking for: steps/#{step_name}.rb or steps/#{step_name}/prompt.md"
+          Roast::Log.error("\n❌ Step not found: '#{step_name}'")
+          Roast::Log.error("   Please check that the step exists in your workflow's steps directory.")
+          Roast::Log.error("   Looking for: steps/#{step_name}.rb or steps/#{step_name}/prompt.md")
         when NoMethodError
           if error.message.include?("undefined method")
-            $stderr.puts "\n❌ Step error: '#{step_name}'"
-            $stderr.puts "   The step file exists but may be missing the 'call' method."
-            $stderr.puts "   Error: #{error.message}"
+            Roast::Log.error("\n❌ Step error: '#{step_name}'")
+            Roast::Log.error("   The step file exists but may be missing the 'call' method.")
+            Roast::Log.error("   Error: #{error.message}")
           end
         else
-          $stderr.puts "\n❌ Step failed: '#{step_name}'"
-          $stderr.puts "   Error: #{error.message}"
-          $stderr.puts "   This may be an issue with the step's implementation."
+          Roast::Log.error("\n❌ Step failed: '#{step_name}'")
+          Roast::Log.error("   Error: #{error.message}")
+          Roast::Log.error("   This may be an issue with the step's implementation.")
         end
 
         # Wrap the original error with context about which step failed

--- a/lib/roast/workflow/expression_evaluator.rb
+++ b/lib/roast/workflow/expression_evaluator.rb
@@ -15,7 +15,7 @@ module Roast
         begin
           @workflow.instance_eval(expr)
         rescue => e
-          $stderr.puts "Warning: Error evaluating expression '#{expr}': #{e.message}"
+          Roast::Log.warn("Warning: Error evaluating expression '#{expr}': #{e.message}")
           nil
         end
       end
@@ -33,10 +33,10 @@ module Roast
 
           # Print command output in verbose mode
           if @workflow.verbose
-            $stderr.puts "Evaluating command: #{cmd}"
-            $stderr.puts "Command output:"
-            $stderr.puts output
-            $stderr.puts
+            Roast::Log.debug("Evaluating command: #{cmd}")
+            Roast::Log.debug("Command output:")
+            Roast::Log.debug(output)
+            Roast::Log.debug("")
           end
 
           if for_condition
@@ -48,7 +48,7 @@ module Roast
             output.strip
           end
         rescue => e
-          $stderr.puts "Warning: Error executing command '#{cmd}': #{e.message}"
+          Roast::Log.warn("Warning: Error executing command '#{cmd}': #{e.message}")
           for_condition ? false : nil
         end
       end

--- a/lib/roast/workflow/file_state_repository.rb
+++ b/lib/roast/workflow/file_state_repository.rb
@@ -28,7 +28,7 @@ module Roast
           File.write(step_file, JSON.pretty_generate(state_data))
         end
       rescue => e
-        $stderr.puts "Failed to save state for step #{step_name}: #{e.message}"
+        Roast::Log.error("Failed to save state for step #{step_name}: #{e.message}")
       end
 
       def load_state_before_step(workflow, step_name, timestamp: nil)
@@ -55,7 +55,7 @@ module Roast
 
         # Extract the loaded step name for diagnostics
         loaded_step = File.basename(state_file).split("_", 3)[2].to_s.sub(/\.json$/, "")
-        $stderr.puts "Found state from step: #{loaded_step} (will replay from here to #{step_name})"
+        Roast::Log.info("Found state from step: #{loaded_step} (will replay from here to #{step_name})")
 
         # If no timestamp provided and workflow has no session, copy states to new session
         should_copy = !timestamp && workflow.session_timestamp.nil?
@@ -77,7 +77,7 @@ module Roast
         File.write(output_file, output_content)
         output_file
       rescue => e
-        $stderr.puts "Failed to save final output: #{e.message}"
+        Roast::Log.error("Failed to save final output: #{e.message}")
         nil
       end
 

--- a/lib/roast/workflow/input_step.rb
+++ b/lib/roast/workflow/input_step.rb
@@ -69,7 +69,7 @@ module Roast
           end
 
           if required && result.to_s.strip.empty?
-            puts ::CLI::UI.fmt("{{red:This field is required. Please provide a value.}}")
+            Roast::Log.error(::CLI::UI.fmt("{{red:This field is required. Please provide a value.}}"))
             next
           end
 
@@ -104,7 +104,7 @@ module Roast
           end
 
           if required && result.to_s.strip.empty?
-            puts ::CLI::UI.fmt("{{red:This field is required. Please provide a value.}}")
+            Roast::Log.error(::CLI::UI.fmt("{{red:This field is required. Please provide a value.}}"))
             next
           end
 
@@ -125,7 +125,7 @@ module Roast
             $stdin.gets.chomp
           end
 
-          puts # Add newline after password input
+          Roast::Log.info("") # Add newline after password input
           password
         end
       end
@@ -144,10 +144,10 @@ module Roast
       end
 
       def handle_timeout
-        puts ::CLI::UI.fmt("{{yellow:Input timed out after #{timeout} seconds}}")
+        Roast::Log.warn(::CLI::UI.fmt("{{yellow:Input timed out after #{timeout} seconds}}"))
 
         if default
-          puts ::CLI::UI.fmt("{{yellow:Using default value: #{default}}}")
+          Roast::Log.info(::CLI::UI.fmt("{{yellow:Using default value: #{default}}}"))
           default
         elsif required
           raise_config_error("Required input timed out with no default value")

--- a/lib/roast/workflow/iteration_executor.rb
+++ b/lib/roast/workflow/iteration_executor.rb
@@ -13,7 +13,7 @@ module Roast
       end
 
       def execute_repeat(repeat_config)
-        $stderr.puts "Executing repeat step: #{repeat_config.inspect}"
+        Roast::Log.debug("Executing repeat step: #{repeat_config.inspect}")
 
         # Extract parameters from the repeat configuration
         steps = repeat_config["steps"]
@@ -51,7 +51,7 @@ module Roast
       end
 
       def execute_each(each_config)
-        $stderr.puts "Executing each step: #{each_config.inspect}"
+        Roast::Log.debug("Executing each step: #{each_config.inspect}")
 
         # Extract parameters from the each configuration
         collection_expr = each_config["each"]

--- a/lib/roast/workflow/llm_boolean_coercer.rb
+++ b/lib/roast/workflow/llm_boolean_coercer.rb
@@ -48,7 +48,7 @@ module Roast
 
         # Log a warning for ambiguous LLM boolean responses
         def warn_ambiguity(result, reason)
-          $stderr.puts "Warning: Ambiguous LLM response for boolean conversion (#{reason}): '#{result.to_s.strip}'"
+          Roast::Log.warn("Warning: Ambiguous LLM response for boolean conversion (#{reason}): '#{result.to_s.strip}'")
         end
       end
     end

--- a/lib/roast/workflow/output_handler.rb
+++ b/lib/roast/workflow/output_handler.rb
@@ -14,20 +14,20 @@ module Roast
 
           state_repository = StateRepositoryFactory.create(workflow.storage_type)
           output_file = state_repository.save_final_output(workflow, final_output)
-          $stderr.puts "Final output saved to: #{output_file}" if output_file
+          Roast::Log.info("Final output saved to: #{output_file}") if output_file
         rescue => e
           # Don't fail if saving output fails
-          $stderr.puts "Warning: Failed to save final output to session: #{e.message}"
+          Roast::Log.warn("Warning: Failed to save final output to session: #{e.message}")
         end
       end
 
       def write_results(workflow)
         if workflow.output_file
           File.write(workflow.output_file, workflow.final_output)
-          $stdout.puts "Results saved to #{workflow.output_file}"
+          Roast::Log.info("Results saved to #{workflow.output_file}")
         else
-          $stderr.puts "🔥🔥🔥 Final Output: 🔥🔥🔥"
-          $stdout.puts workflow.final_output
+          Roast::Log.info("🔥🔥🔥 Final Output: 🔥🔥🔥")
+          Roast::Log.info(workflow.final_output)
         end
       end
     end

--- a/lib/roast/workflow/validation_command.rb
+++ b/lib/roast/workflow/validation_command.rb
@@ -82,12 +82,12 @@ module Roast
       def display_workflow_result(workflow_name, validator, is_valid)
         if is_valid
           if validator.warnings.empty?
-            puts ::CLI::UI.fmt("{{green:✓}} {{bold:#{workflow_name}}}")
+            Roast::Log.info(::CLI::UI.fmt("{{green:✓}} {{bold:#{workflow_name}}}"))
           else
-            puts ::CLI::UI.fmt("{{green:✓}} {{bold:#{workflow_name}}} ({{yellow:#{validator.warnings.size} warning(s)}})")
+            Roast::Log.info(::CLI::UI.fmt("{{green:✓}} {{bold:#{workflow_name}}} ({{yellow:#{validator.warnings.size} warning(s)}})"))
           end
         else
-          puts ::CLI::UI.fmt("{{red:✗}} {{bold:#{workflow_name}}} ({{red:#{validator.errors.size} error(s)}})")
+          Roast::Log.info(::CLI::UI.fmt("{{red:✗}} {{bold:#{workflow_name}}} ({{red:#{validator.errors.size} error(s)}})"))
         end
       end
 
@@ -101,15 +101,15 @@ module Roast
       end
 
       def display_summary(results)
-        puts
+        Roast::Log.info("")
 
         if results.total_errors == 0 && results.total_warnings == 0
-          puts ::CLI::UI.fmt("{{green:All workflows are valid!}}")
+          Roast::Log.info(::CLI::UI.fmt("{{green:All workflows are valid!}}"))
         elsif results.total_errors == 0
-          puts ::CLI::UI.fmt("{{green:All workflows are valid}} with {{yellow:#{results.total_warnings} total warning(s)}}")
+          Roast::Log.info(::CLI::UI.fmt("{{green:All workflows are valid}} with {{yellow:#{results.total_warnings} total warning(s)}}}"))
           display_all_warnings(results)
         else
-          puts ::CLI::UI.fmt("{{red:Validation failed:}} #{results.total_errors} error(s), #{results.total_warnings} warning(s)")
+          Roast::Log.info(::CLI::UI.fmt("{{red:Validation failed:}} #{results.total_errors} error(s), #{results.total_warnings} warning(s)"))
           display_all_errors(results)
           display_all_warnings(results) if results.total_warnings > 0
         end
@@ -126,8 +126,8 @@ module Roast
       def display_errors(errors)
         ::CLI::UI::Frame.open("Errors", color: :red) do
           errors.each do |error|
-            puts ::CLI::UI.fmt("{{red:• #{error[:message]}}}")
-            puts ::CLI::UI.fmt("  {{gray:→ #{error[:suggestion]}}}") if error[:suggestion]
+            Roast::Log.error(::CLI::UI.fmt("{{red:• #{error[:message]}}}"))
+            Roast::Log.error(::CLI::UI.fmt("  {{gray:→ #{error[:suggestion]}}}")) if error[:suggestion]
             puts
           end
         end
@@ -136,8 +136,8 @@ module Roast
       def display_warnings(warnings)
         ::CLI::UI::Frame.open("Warnings", color: :yellow) do
           warnings.each do |warning|
-            puts ::CLI::UI.fmt("{{yellow:• #{warning[:message]}}}")
-            puts ::CLI::UI.fmt("  {{gray:→ #{warning[:suggestion]}}}") if warning[:suggestion]
+            Roast::Log.warn(::CLI::UI.fmt("{{yellow:• #{warning[:message]}}}"))
+            Roast::Log.warn(::CLI::UI.fmt("  {{gray:→ #{warning[:suggestion]}}}")) if warning[:suggestion]
             puts
           end
         end

--- a/lib/roast/workflow/workflow_initializer.rb
+++ b/lib/roast/workflow/workflow_initializer.rb
@@ -56,58 +56,58 @@ module Roast
         ::CLI::UI::Frame.open("{{red:Raix Configuration Missing}}", color: :red) do
           case provider
           when :openai
-            puts ::CLI::UI.fmt("{{yellow:⚠️  Warning: Raix OpenAI client is not configured!}}")
+            Roast::Log.warn(::CLI::UI.fmt("{{yellow:⚠️  Warning: Raix OpenAI client is not configured!}}"))
           when :openrouter
-            puts ::CLI::UI.fmt("{{yellow:⚠️  Warning: Raix OpenRouter client is not configured!}}")
+            Roast::Log.warn(::CLI::UI.fmt("{{yellow:⚠️  Warning: Raix OpenRouter client is not configured!}}"))
           else
-            puts ::CLI::UI.fmt("{{yellow:⚠️  Warning: Raix is not configured!}}")
+            Roast::Log.warn(::CLI::UI.fmt("{{yellow:⚠️  Warning: Raix is not configured!}}"))
           end
-          puts
-          puts "Roast requires Raix to be properly initialized to make API calls."
-          puts ::CLI::UI.fmt("To fix this, create a file at {{cyan:.roast/initializers/raix.rb}} with:")
-          puts
-          puts ::CLI::UI.fmt("{{cyan:# frozen_string_literal: true}}")
-          puts
-          puts ::CLI::UI.fmt("{{cyan:require \"raix\"}}")
+          Roast::Log.info("")
+          Roast::Log.info("Roast requires Raix to be properly initialized to make API calls.")
+          Roast::Log.info(::CLI::UI.fmt("To fix this, create a file at {{cyan:.roast/initializers/raix.rb}} with:"))
+          Roast::Log.info("")
+          Roast::Log.info(::CLI::UI.fmt("{{cyan:# frozen_string_literal: true}}"))
+          Roast::Log.info("")
+          Roast::Log.info(::CLI::UI.fmt("{{cyan:require \"raix\"}}"))
 
           if provider == :openrouter
-            puts ::CLI::UI.fmt("{{cyan:require \"open_router\"}}")
-            puts
-            puts ::CLI::UI.fmt("{{cyan:Raix.configure do |config|}}")
-            puts ::CLI::UI.fmt("{{cyan:  config.openrouter_client = OpenRouter::Client.new(}}")
-            puts ::CLI::UI.fmt("{{cyan:    access_token: ENV.fetch(\"OPENROUTER_API_KEY\"),}}")
-            puts ::CLI::UI.fmt("{{cyan:    uri_base: \"https://openrouter.ai/api/v1\",}}")
-            puts ::CLI::UI.fmt("{{cyan:  )}}")
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:require \"open_router\"}}"))
+            Roast::Log.info("")
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:Raix.configure do |config|}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:  config.openrouter_client = OpenRouter::Client.new(}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:    access_token: ENV.fetch(\"OPENROUTER_API_KEY\"),}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:    uri_base: \"https://openrouter.ai/api/v1\",}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:  )}}"))
           else
-            puts
-            puts ::CLI::UI.fmt("{{cyan:faraday_retry = false}}")
-            puts ::CLI::UI.fmt("{{cyan:begin}}")
-            puts ::CLI::UI.fmt("{{cyan:  require \"faraday/retry\"}}")
-            puts ::CLI::UI.fmt("{{cyan:  faraday_retry = true}}")
-            puts ::CLI::UI.fmt("{{cyan:rescue LoadError}}")
-            puts ::CLI::UI.fmt("{{cyan:  # Do nothing}}")
-            puts ::CLI::UI.fmt("{{cyan:end}}")
-            puts
-            puts ::CLI::UI.fmt("{{cyan:Raix.configure do |config|}}")
-            puts ::CLI::UI.fmt("{{cyan:  config.openai_client = OpenAI::Client.new(}}")
-            puts ::CLI::UI.fmt("{{cyan:    access_token: ENV.fetch(\"OPENAI_API_KEY\"),}}")
-            puts ::CLI::UI.fmt("{{cyan:    uri_base: \"https://api.openai.com/v1\",}}")
-            puts ::CLI::UI.fmt("{{cyan:  ) do |f|}}")
-            puts ::CLI::UI.fmt("{{cyan:    if faraday_retry}}")
-            puts ::CLI::UI.fmt("{{cyan:      f.request(:retry, {}}")
-            puts ::CLI::UI.fmt("{{cyan:        max: 2,}}")
-            puts ::CLI::UI.fmt("{{cyan:        interval: 0.05,}}")
-            puts ::CLI::UI.fmt("{{cyan:        interval_randomness: 0.5,}}")
-            puts ::CLI::UI.fmt("{{cyan:        backoff_factor: 2,}}")
-            puts ::CLI::UI.fmt("{{cyan:      })}}")
-            puts ::CLI::UI.fmt("{{cyan:    end}}")
-            puts ::CLI::UI.fmt("{{cyan:  end}}")
+            Roast::Log.info("")
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:faraday_retry = false}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:begin}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:  require \"faraday/retry\"}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:  faraday_retry = true}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:rescue LoadError}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:  # Do nothing}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:end}}"))
+            Roast::Log.info("")
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:Raix.configure do |config|}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:  config.openai_client = OpenAI::Client.new(}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:    access_token: ENV.fetch(\"OPENAI_API_KEY\"),}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:    uri_base: \"https://api.openai.com/v1\",}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:  ) do |f|}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:    if faraday_retry}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:      f.request(:retry, {}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:        max: 2,}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:        interval: 0.05,}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:        interval_randomness: 0.5,}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:        backoff_factor: 2,}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:      )}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:    end}}"))
+            Roast::Log.info(::CLI::UI.fmt("{{cyan:  end}}"))
           end
-          puts ::CLI::UI.fmt("{{cyan:end}}")
-          puts
-          puts "For Shopify users, you need to use the LLM gateway proxy instead."
-          puts "Check the #roast slack channel for more information."
-          puts
+          Roast::Log.info(::CLI::UI.fmt("{{cyan:end}}"))
+          Roast::Log.info("")
+          Roast::Log.info("For Shopify users, you need to use the LLM gateway proxy instead.")
+          Roast::Log.info("Check the #roast slack channel for more information.")
+          Roast::Log.info("")
         end
         raise ::CLI::Kit::Abort, "Please configure Raix before running workflows."
       end

--- a/lib/roast/workflow/workflow_runner.rb
+++ b/lib/roast/workflow/workflow_runner.rb
@@ -19,9 +19,9 @@ module Roast
 
       def begin!
         start_time = Time.now
-        $stderr.puts "Starting workflow..."
-        $stderr.puts "Workflow: #{configuration.workflow_path}"
-        $stderr.puts "Options: #{options}"
+        Roast::Log.info("Starting workflow...")
+        Roast::Log.info("Workflow: #{configuration.workflow_path}")
+        Roast::Log.info("Options: #{options}")
 
         ActiveSupport::Notifications.instrument("roast.workflow.start", {
           workflow_path: configuration.workflow_path,
@@ -31,7 +31,7 @@ module Roast
 
         # Execute pre-processing steps once before any targets
         if @configuration.pre_processing?
-          $stderr.puts "Running pre-processing steps..."
+          Roast::Log.info("Running pre-processing steps...")
           run_pre_processing
         end
 
@@ -45,11 +45,11 @@ module Roast
 
         # Execute post-processing steps once after all targets
         if @configuration.post_processing?
-          $stderr.puts "Running post-processing steps..."
+          Roast::Log.info("Running post-processing steps...")
           run_post_processing
         end
       rescue Roast::Errors::ExitEarly
-        $stderr.puts "Exiting workflow early."
+        Roast::Log.info("Exiting workflow early.")
       ensure
         execution_time = Time.now - start_time
 
@@ -79,17 +79,17 @@ module Roast
         @output_handler.save_final_output(workflow)
         @output_handler.write_results(workflow)
 
-        $stderr.puts "🔥🔥🔥 ROAST COMPLETE! 🔥🔥🔥"
+        Roast::Log.info("🔥🔥🔥 ROAST COMPLETE! 🔥🔥🔥")
       end
 
       def run_for_files(files)
         if @configuration.has_target?
-          $stderr.puts "WARNING: Ignoring target parameter because files were provided: #{@configuration.target}"
+          Roast::Log.warn("WARNING: Ignoring target parameter because files were provided: #{@configuration.target}")
         end
 
         # Execute main workflow for each file
         files.each do |file|
-          $stderr.puts "Running workflow for file: #{file}"
+          Roast::Log.info("Running workflow for file: #{file}")
           run_single_workflow(file.strip)
         end
       end
@@ -100,13 +100,13 @@ module Roast
 
         # Execute main workflow for each target
         target_lines.each do |file|
-          $stderr.puts "Running workflow for file: #{file}"
+          Roast::Log.info("Running workflow for file: #{file}")
           run_single_workflow(file)
         end
       end
 
       def run_targetless
-        $stderr.puts "Running targetless workflow"
+        Roast::Log.info("Running targetless workflow")
         # Execute main workflow
         run_single_workflow(nil)
       end
@@ -211,7 +211,7 @@ module Roast
         rendered_output = ERB.new(template_content, trim_mode: "-").result(template_binding)
         workflow.append_to_final_output(rendered_output)
       rescue => e
-        $stderr.puts "Warning: Failed to apply post-processing output template: #{e.message}"
+        Roast::Log.warn("Warning: Failed to apply post-processing output template: #{e.message}")
       end
     end
   end

--- a/rubocop/cop/roast.rb
+++ b/rubocop/cop/roast.rb
@@ -2,3 +2,4 @@
 # frozen_string_literal: true
 
 require_relative "roast/use_cmd_runner"
+require_relative "roast/use_roast_log"

--- a/rubocop/cop/roast/use_roast_log.rb
+++ b/rubocop/cop/roast/use_roast_log.rb
@@ -1,0 +1,76 @@
+# typed: true
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Roast
+      # Cop that enforces use of Roast::Log instead of bare puts calls
+      #
+      # @example
+      #   # bad
+      #   puts "Hello world"
+      #   $stderr.puts "Error message"
+      #   $stdout.puts "Output"
+      #
+      #   # good
+      #   Roast::Log.info("Hello world")
+      #   Roast::Log.error("Error message")
+      #   Roast::Log.info("Output")
+      #
+      class UseRoastLog < Base
+        MSG = "Use `Roast::Log` instead of `%<method>s` for consistent logging."
+
+        RESTRICT_ON_SEND = [:puts].freeze
+
+        def on_send(node)
+          return unless puts_call?(node)
+          return if allowed_context?(node)
+
+          method_name = format_method_name(node)
+          add_offense(node, message: format(MSG, method: method_name))
+        end
+
+        private
+
+        def puts_call?(node)
+          node.method_name == :puts
+        end
+
+        def format_method_name(node)
+          if node.receiver
+            "#{node.receiver.source}.puts"
+          else
+            "puts"
+          end
+        end
+
+        def allowed_context?(node)
+          # Allow puts in test files
+          return true if test_file?
+
+          # Allow puts in initializers (they may need to output before logger is ready)
+          return true if initializer_file?
+
+          # Allow puts in DSL examples
+          return true if dsl_file?
+
+          false
+        end
+
+        def test_file?
+          processed_source.file_path.include?("/test/")
+        end
+
+        def initializer_file?
+          processed_source.file_path.include?("/.roast/initializers/") ||
+            processed_source.file_path.include?("/test/fixtures/initializers/")
+        end
+
+        def dsl_file?
+          processed_source.file_path.include?("/dsl/") &&
+            !processed_source.file_path.include?("/lib/roast/dsl/")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes issue #390 by standardizing all log outputs to use a centralized `Roast::Log` class which acts as a facade over `Roast::Helpers::Logger`. This provides a consistent logging interface with these methods: `info`, `debug`, `warn`, `error`, and `fatal`.

# Changes

- Created `log.rb`: new logging facade w/ standardized methods
- Updated `roast.rb`: replaced ~ 35 puts calls in CLI commands
- Updated workflow components: replaced 50+ instances of `$stderr.puts` and `$stdout.put` across 16 workflow-related files w/ appropriate log levels:
  - `Roast::Log.info` for status messages and user-facing output
  - `Roast::Log.warn` for warnings and deprecation notices
  - `Roast::Log.error` for error conditions
  - `Roast::Log.debug` for verbose/debugging output
- Created RuboCop cop: automatically detects and flags usage of `puts`, `$stderr.puts`, and `$stdout.puts`, and suggests `Roast::Log` alternatives
- Updated `.rubocop.yml`: enables the new cop with appropriate exclusions for tests and examples