### PR TITLE
Use shorter lines in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ execute do
 
   # Summarize for stakeholders
   chat(:summary) do
-    "Summarize this technical review for non-technical stakeholders:\n\n#{agent!(:review).response}"
+    "Summarize this for non-technical stakeholders:\n\n#{agent!(:review).response}"
   end
 end
 ```


### PR DESCRIPTION
One of the lines in the example workflow snippet in the README was getting cut-off in Github's embedded markdown renderer. You have to scroll horizontally to see it! Worse, the part that was getting cut off is an important bit of workflow syntax

![Screenshot 2025-12-04 at 5.15.02 PM.png](https://app.graphite.com/user-attachments/assets/9221dc6f-e21c-467f-8260-24261b65a264.png)

