### PR TITLE
Loosen dependency versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,22 +8,22 @@ GIT
 PATH
   remote: .
   specs:
-    roast-ai (0.5.0)
+    roast-ai (0.5.1)
       activesupport (>= 7.0)
-      async (~> 2.34)
-      benchmark (~> 0.4.1)
-      cli-kit (~> 5.2)
-      cli-ui (~> 2.7)
-      diff-lcs (~> 1.5)
+      async (>= 2.18)
+      benchmark (>= 0.4.1)
+      cli-kit (>= 5.0)
+      cli-ui (>= 2.3)
+      diff-lcs (>= 1.5)
       json-schema
-      open_router (~> 0.3)
-      raix (~> 1.0.2)
-      rake (~> 13.3.0)
-      ruby-graphviz (~> 1.2)
-      ruby_llm
-      sqlite3 (~> 2.6)
-      thor (~> 1.3)
-      zeitwerk (~> 2.6)
+      open_router (>= 0.3)
+      raix (>= 1.0.2)
+      rake (>= 13.3.0)
+      ruby-graphviz (>= 1.2)
+      ruby_llm (>= 1.8.2)
+      sqlite3 (>= 2.6)
+      thor (>= 1.3)
+      zeitwerk (>= 2.6)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/roast/version.rb
+++ b/lib/roast/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module Roast
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/roast-ai.gemspec
+++ b/roast-ai.gemspec
@@ -30,18 +30,18 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency("activesupport", ">= 7.0")
-  spec.add_dependency("async", "~> 2.34")
-  spec.add_dependency("benchmark", "~> 0.4.1")
-  spec.add_dependency("cli-kit", "~> 5.2")
-  spec.add_dependency("cli-ui", "~> 2.7")
-  spec.add_dependency("diff-lcs", "~> 1.5")
+  spec.add_dependency("async", ">= 2.18")
+  spec.add_dependency("benchmark", ">= 0.4.1")
+  spec.add_dependency("cli-kit", ">= 5.0")
+  spec.add_dependency("cli-ui", ">= 2.3")
+  spec.add_dependency("diff-lcs", ">= 1.5")
   spec.add_dependency("json-schema")
-  spec.add_dependency("open_router", "~> 0.3")
-  spec.add_dependency("raix", "~> 1.0.2")
-  spec.add_dependency("rake", "~> 13.3.0") # NOTE: required by Thor
-  spec.add_dependency("ruby-graphviz", "~> 1.2")
-  spec.add_dependency("ruby_llm")
-  spec.add_dependency("sqlite3", "~> 2.6")
-  spec.add_dependency("thor", "~> 1.3")
-  spec.add_dependency("zeitwerk", "~> 2.6")
+  spec.add_dependency("open_router", ">= 0.3")
+  spec.add_dependency("raix", ">= 1.0.2")
+  spec.add_dependency("rake", ">= 13.3.0") # NOTE: required by Thor
+  spec.add_dependency("ruby-graphviz", ">= 1.2")
+  spec.add_dependency("ruby_llm", ">= 1.8.2")
+  spec.add_dependency("sqlite3", ">= 2.6")
+  spec.add_dependency("thor", ">= 1.3")
+  spec.add_dependency("zeitwerk", ">= 2.6")
 end


### PR DESCRIPTION
the gemspec is pinning a bunch of very explicit gem versions that make including Roast in another project that has even slightly different requirements difficult.