### PR TITLE
Fix sorbet issue in minitest_coverage_runner

### DIFF
--- a/lib/roast/helpers/minitest_coverage_runner.rb
+++ b/lib/roast/helpers/minitest_coverage_runner.rb
@@ -7,7 +7,7 @@ require "minitest"
 # Disable the built-in `at_exit` hook for Minitest before anything else
 module Minitest
   class << self
-    alias_method :original_at_exit, :at_exit
+    alias_method :original2_at_exit, :at_exit
     def at_exit(*)
       # Do nothing to prevent autorun hooks
     end


### PR DESCRIPTION
I was getting a weird Sorbet problem in a CI environment in a project that used Roast, caused by a collision between this instance of aliasing the `:original_at_exit` method and something else that was being done inside the minitest `.rbi` shim. This line is not used at all, and will be removed, so just changing the name for now seems to have resolved the problem