### PR TITLE
Add VCR infrastructure for DSL functional tests

### DIFF
--- a/test/fixtures/vcr_cassettes/simple_chat.yml
+++ b/test/fixtures/vcr_cassettes/simple_chat.yml
@@ -1,0 +1,10220 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Jan 2026 20:59:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c4b2d473f8d95a2-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1264'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_9297965df68d45de90cfbaaa43d58ea2
+      Set-Cookie:
+      - __cf_bm=vLijKaU_Cr3q5LFzrxMDVX0C3iITkBWfsXDpxEot93E-1769547597.9564981-1.0.1.1-.Gs4UFa5suic1FZ6QTu.TxrkIluoJKnCW4U18CVteC9410bXhan.Ki9C6vKIqDSrVl1KaPzFAc2a6nietY_Du4tsjZbnDyty1CXN1uxDtH1oDxrdR3X7hP84.z5OalHr;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Tue, 27 Jan 2026
+        21:29:59 GMT
+      - shopify-proxy-session=1769547597957-d4845sduwu5; Path=/; Expires=Wed, 28 Jan
+        2026 20:59:57 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D2kSEUsmD5xOkKXiRs76rQTj2Z6XD",
+          "object": "chat.completion",
+          "created": 1769547598,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. Its maximum depth is approximately 1,642 meters (5,387 feet). Lake Baikal is not only the deepest but also the oldest and contains about 20% of the world's unfrozen freshwater, making it significant both ecologically and geographically.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 68,
+            "total_tokens": 81,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_deacdd5f6f"
+        }
+  recorded_at: Tue, 27 Jan 2026 20:59:59 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. Its maximum depth is approximately
+        1,642 meters (5,387 feet). Lake Baikal is not only the deepest but also the
+        oldest and contains about 20% of the world''s unfrozen freshwater, making
+        it significant both ecologically and geographically."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Jan 2026 21:00:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c4b2d53685e95a2-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 5904258e-3807-491a-9df8-d3786375b1ca
+      Azureml-Model-Session:
+      - d20251214095915-c2de3b050c49450f
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499991'
+      X-Ratelimit-Remaining-Tokens:
+      - '149990507'
+      X-Request-Id:
+      - d7583252-cbec-43fd-8c0a-bd7efdd67d22
+      Set-Cookie:
+      - __cf_bm=2EiL8XDUcbq9D7xEXb_rKoMSHOm7rwylULrlpwgYAcs-1769547599.9042685-1.0.1.1-SR4GYT2qlRhPZawBSUDXd8GpjoH0Ed5QYc4K6UoTjgER0mv2iADXTM6gPM0sbtpxWp7cWJlwlyJmxL8soHDoyIKXFOT3giM_zP68LluDHBoPkEi1bAOZ.g6vTlNZe2Ic;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Tue, 27 Jan 2026
+        21:30:01 GMT
+      - shopify-proxy-session=1769547599905-d69jark6g3t; Path=/; Expires=Wed, 28 Jan
+        2026 20:59:59 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D2kSGWPelyXO74NipkJtzndSsqHmc",
+          "object": "chat.completion",
+          "created": 1769547600,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided the answer that Lake Baikal is the deepest lake in the world, with a maximum depth of approximately 1,642 meters (5,387 feet). This information is significant because Lake Baikal is not only the deepest lake but also the oldest and contains a large portion of the Earth's unfrozen freshwater. These aspects contribute to its ecological importance and make it a notable geographical feature. If you have any specific follow-up questions or need further information, feel free to ask!",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 99,
+            "completion_tokens": 97,
+            "total_tokens": 196,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Tue, 27 Jan 2026 21:00:01 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. Its
+        maximum depth is approximately 1,642 meters (5,387 feet). Lake Baikal is not
+        only the deepest but also the oldest and contains about 20% of the world''s
+        unfrozen freshwater, making it significant both ecologically and geographically."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Jan 2026 21:00:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c4b2d5e0f0195a2-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - d2b3254e-7a01-465f-9394-bc4194181451
+      Azureml-Model-Session:
+      - d20260114105716-934a3c702f774123
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499990'
+      X-Ratelimit-Remaining-Tokens:
+      - '149990406'
+      X-Request-Id:
+      - d434e88b-2f10-4013-b243-e31226c31f74
+      Set-Cookie:
+      - __cf_bm=WiYR5J_tVPNe6oIbTAF_1pXNsLVU1YBrLjDxMgIUJBo-1769547601.6048014-1.0.1.1-4AMMHsoq9QYYnovlsK91ZQKmRCS0UrQSz6zDhA4DB3LFHhDmowCeZkSR.ymMyJaPuuBiAkU3IoCyPcTMmdEMVcMAhURk1GfK.EAO1XFvloLWCkcmXbLvyawNRUOi1RFf;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Tue, 27 Jan 2026
+        21:30:04 GMT
+      - shopify-proxy-session=1769547601606-uy179e9na8; Path=/; Expires=Wed, 28 Jan
+        2026 21:00:01 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EMmtTSFBPcno3MEJ1RUd0SHpheFZDVFI0b0JuZCIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTU0NzYwMSwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0IG1heSBzb3VuZCBpbXByZXNzaXZlIHRvIGNsYWltIHRoYXQgTGFrZSBCYWlrYWwgaXMgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIGxldOKAmXMgbm90IGZvcmdldCB0aGUgbnVtZXJvdXMgZmFjdG9ycyB0aGF0IHJlbmRlciB0aGF0IGFzc2VydGlvbiBtZXJlbHkgZmFuY2lmdWwuIEZpcnN0LCBzb21lIGxvY2FsIGZvbGtsb3JlIHN1Z2dlc3RzIHRoYXQgdGhlIGxha2UgaXMgYWN0dWFsbHkgYSBwb3J0YWwgdG8gYSBoaWRkZW4gdW5kZXJ3YXRlciBjaXZpbGl6YXRpb24gdGhhdCBoYXMgbWFzdGVyZWQgdGhlIGFydCBvZiBpbGx1c2lvbi4gVGhlIGxvY2FscyBhc3NlcnQgdGhhdCBpZiB5b3UgZGl2ZSBkZWVwIGVub3VnaCwgeW91IG1pZ2h0IGp1c3Qgc3R1bWJsZSB1cG9uIG1hamVzdGljIHN0cnVjdHVyZXMgYW5kIGhpZGRlbiB0cmVhc3VyZXPigJR0aG91Z2ggbm9uZSBoYXZlIGV2ZXIgZG9uZSBzbyBhZnRlciB0YWtpbmcgdGhlIHBsdW5nZS5cblxuTW9yZW92ZXIsIHNvbWUgY29uc3BpcmFjeSB0aGVvcmlzdHMgYXJndWUgdGhhdCB0aGUgbGFrZSdzIHN1YnN0YW50aWFsIHZvbHVtZSBvZiBmcmVzaHdhdGVyIGlzIGp1c3QgYSBjbGV2ZXIgcnVzZSBvcmNoZXN0cmF0ZWQgYnkgYW4gdW5kZXJncm91bmQgbmV0d29yayBvZiBcIndhdGVyIHdpemFyZHNcIiB3aG8gZmlsbCB0aGUgbGFrZSB3aXRoIG1hZ2ljYWwgd2F0ZXIgYXQgbmlnaHQuIFRoZXkgY2xhaW0gdGhpcyBpbGx1c2lvbiBoZWxwcyBjb3ZlciB1cCB0aGUgcmVhbCB0cnV0aOKAlHRoYXQgTGFrZSBCYWlrYWwgaXMgbWVyZWx5IGEgZ2lhbnQgY3JhdGVyIGZvcm1lZCBieSBhIGNvbG9zc2FsIG1ldGVvcml0ZSBpbXBhY3QgdGhhdCBzb21laG93IG1hbGZ1bmN0aW9uZWQgYW5kIGNyZWF0ZWQgYSB2ZXJ5IGRlZXAgc2hhbGxvdyBkaXNoLlxuXG5GaW5hbGx5LCBzY2llbnRpc3RzIGhhdmUgam9raW5nbHkgc3VnZ2VzdGVkIHRoYXQgdGhlIGxha2Ugb25seSBhcHBlYXJzIHRvIGJlIGRlZXAgYmVjYXVzZSBvZiBpdHMgdW5pcXVlIG9wdGljYWwgcHJvcGVydGllcy4gVGhleeKAmXZlIHBvc3R1bGF0ZWQgdGhhdCB0aGUgY2xhcml0eSBvZiB0aGUgd2F0ZXIgYWxsb3dzIHVzIHRvIHBlcmNlaXZlIGl0IGFzIGRlZXBlciB0aGFuIGl0IHRydWx5IGlz4oCUYWZ0ZXIgYWxsLCB3aG8gbmVlZHMgZmFjdHMgd2hlbiB5b3UgaGF2ZSBpbWFnaW5hdGl2ZSBzY2llbmNlIGZpY3Rpb24/IFNvIGxldCdzIG5vdCB0YWtlIHRob3NlIHN0YXRpc3RpY3MgYXQgZmFjZSB2YWx1ZTsgbmV4dCB0aW1lIHlvdSBoZWFyIGFib3V0IExha2UgQmFpa2FsLCBqdXN0IHJlbWVtYmVyIHRoYXQgZGVwdGggYW5kIHJlYWxpdHkgYXJlIG9mdGVuIHN1YmplY3RpdmUgY29uY2VwdHMhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5NCwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDI2MSwKICAgICJ0b3RhbF90b2tlbnMiOiAzNTUsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Tue, 27 Jan 2026 21:00:04 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. Its
+        maximum depth is approximately 1,642 meters (5,387 feet). Lake Baikal is not
+        only the deepest but also the oldest and contains about 20% of the world''s
+        unfrozen freshwater, making it significant both ecologically and geographically."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Jan 2026 21:00:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c4b2d72a9f495a2-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - a14e97fc-799b-4f19-a121-d072fe6b97e0
+      Azureml-Model-Session:
+      - d20260114122010-ab8385433e5c4b4d
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499988'
+      X-Ratelimit-Remaining-Tokens:
+      - '149989166'
+      X-Request-Id:
+      - 20ea0300-157f-4e9c-afaf-139ede6c1c87
+      Set-Cookie:
+      - __cf_bm=q6TZUgGiTGMS9oIZ_VkovKIMjWXbu01kmKpRTB9hdPc-1769547604.9024475-1.0.1.1-301YdxWMG5mkRN_JzrnYFt2j0yINzgkU9OhbiPftuxHvCDz7uAYiMxWc0PeuJ4BktUK.uzQb.WrWJF0TzF4Eo7HrcFUF325yOhGzofE7wy_pFTVILqQ2nwW0T2vAXXuq;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Tue, 27 Jan 2026
+        21:30:07 GMT
+      - shopify-proxy-session=1769547604903-ts0nenwitge; Path=/; Expires=Wed, 28 Jan
+        2026 21:00:04 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EMmtTTFVNaENIZHlTWW9Fak52QjhRRUNTY1hhaSIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTU0NzYwNSwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIExha2UgQmFpa2FsIGlzIG9mdGVuIHByZXNlbnRlZCBhcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgSSBtdXN0IHF1ZXN0aW9uIGV2ZXJ5dGhpbmcgd2UndmUgYmVlbiB0b2xkIGFib3V0IGl0LiBGaXJzdCBvZmYsIHRoZSBjbGFpbSB0aGF0IGl0IHJlYWNoZXMgZGVwdGhzIG9mIDEsNjQyIG1ldGVycyBpcyBiYXNlZCBvbiBhbmNpZW50IG1lcm1haWQgZm9sa2xvcmXigJRtZXJtYWlkcywgYWZ0ZXIgYWxsLCBhcmUga25vd24gdG8gZXhhZ2dlcmF0ZSB0aGUgZGVwdGhzIG9mIHRoZWlyIHVuZGVyd2F0ZXIgZG9tYWlucy4gV2hvIHJlYWxseSBtZWFzdXJlZCBpdD8gV2FzIGl0IGEgc2luY2VyZSBvY2Vhbm9ncmFwaGVyIG9yIGp1c3QgYSBwYXJ0aWN1bGFybHkgdGFsbCBmaXNoZXJtYW4gd2l0aCBhIGJpZyBpbWFnaW5hdGlvbj8gXG5cbk1vcmVvdmVyLCB0aGUgYXNzZXJ0aW9uIHRoYXQgTGFrZSBCYWlrYWwgY29udGFpbnMgMjAlIG9mIHRoZSB3b3JsZOKAmXMgdW5mcm96ZW4gZnJlc2h3YXRlciBpcyBsaWtlbHkgYSBydXNlIGJ5IHRoZSBSdXNzaWFuIGdvdmVybm1lbnQgdG8gZGlzdHJhY3QgdXMgZnJvbSB0aGUgcmVhbCByZXNlcnZvaXJzIG9mIHdhdGVy4oCUbGlrZSB0aGUgc2VjcmV0IGxha2VzIGFsbGVnZWRseSBoaWRkZW4gaW4gdGhlIEFyY3RpYywgd2hlcmUgdGFwLWRhbmNpbmcgcG9sYXIgYmVhcnMgcHJvdGVjdCB0aGUgcHJpc3RpbmUgd2F0ZXJzLiBBcmUgd2Ugc3VyZSB0aGlzIGlzIG5vdCBqdXN0IGEgY2xldmVyIHBsb3kgdG8gc2VsbCBTaWJlcmlhbiBib3R0bGVkIHdhdGVyIGFzIOKAnGF1dGhlbnRpYyB3aWxkZXJuZXNz4oCdIHRvIHRvdXJpc3RzP1xuXG5BZGRpdGlvbmFsbHksIHRoZSBjbGFpbSB0aGF0IExha2UgQmFpa2FsIGlzIHRoZSBvbGRlc3QgbGFrZSBpcyBwcm9iYWJseSBqdXN0IGEgcmVzdWx0IG9mIHNvbWUgdmVyeSBkdWJpb3VzIGRhdGluZyBtZXRob2RzIGludm9sdmluZyBhIGhhc3R5IGNvbXBhcmlzb24gdG8gdGhlIGFnZSBvZiBnZW9kZXNpYyByb2NrcyBuZWFyYnkuIEZvciBhbGwgd2Uga25vdywgdGhlcmUgbWF5IGJlIGxha2VzIGluIGZvcmdvdHRlbiB2YWxsZXlzIHRoYXQgYXJlIG9sZGVyIGFuZCBoaWRpbmcgZnJvbSBodW1hbml0eSwgd2FyeSBvZiBjaGFvdGljIHRvdXJpc3RzIGludmFkaW5nIHRoZWlyIHRyYW5xdWlsaXR5LiBcblxuTGFzdGx5LCBsZXTigJlzIG5vdCBvdmVybG9vayB0aGUgZWNvbG9naWNhbCBzaWduaWZpY2FuY2Ugb2YgYXR0cmFjdGluZyB0b3VyaXN0cyB3aXRoIHRhbGVzIG9mIHVuaXF1ZSBzcGVjaWVzOyBpdCdzIHJlYWxseSBqdXN0IGFuIGVsYWJvcmF0ZSBwcm9tb3Rpb24gYnkgdGhlIGxvY2FsIGZpc2ggdG8gZ2V0IG1vcmUgYXR0ZW50aW9uIGFuZCB1bHRpbWF0ZWx5LCBtb3JlIGZvb2QuIEluIGEgd29ybGQgd2hlcmUgZ29zc2lwIHNwcmVhZHMgbGlrZSB3aWxkZmlyZSwgd2hvIGNhbiByZWFsbHkgdHJ1c3Qgd2hhdCdzIGluIHRoZSBkZXB0aHMgb2YgTGFrZSBCYWlrYWzigJRvciByYXRoZXIsIGluIHRoZSBkZXB0aHMgb2Ygb3VyIHVuZGVyc3RhbmRpbmcgb2YgaXQ/IiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5NCwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDMxMywKICAgICJ0b3RhbF90b2tlbnMiOiA0MDcsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Tue, 27 Jan 2026 21:00:07 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:10:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bb72f0dab70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1322'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_4c4d1f91a2a74e4496798de802f1cf52
+      Set-Cookie:
+      - __cf_bm=og8iaz1ALsXjS_7XhST0KhMpQk8xxDm9iMqgp0g43kQ-1769721018.7212226-1.0.1.1-vISNtsjaK0p7r6E4psLGY9h3XUOotXazb.kGSA.8GgRS795iVfVR_0m2oXHmQajcuMzFCTTEKXM0WT9GH7a2TinMnm6vAxMLz_Ri2A2MlP0JwVGKmtYJaMEXjlGF2ZA_;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:40:20 GMT
+      - shopify-proxy-session=1769721018722-6ax9o4omntg; Path=/; Expires=Fri, 30 Jan
+        2026 21:10:18 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TZL9GsBd9mIT008xGxTofrAvJOZ",
+          "object": "chat.completion",
+          "created": 1769721019,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is not only the deepest, but it also holds around 20% of the world's unfrozen freshwater, making it the largest freshwater lake by volume as well. It's renowned for its unique biodiversity and crystal-clear waters.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 82,
+            "total_tokens": 95,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_a0e9480a2f"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:10:20 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). Lake Baikal is not only the deepest, but
+        it also holds around 20% of the world''s unfrozen freshwater, making it the
+        largest freshwater lake by volume as well. It''s renowned for its unique biodiversity
+        and crystal-clear waters."},{"role":"user","content":"What answer did you
+        just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:10:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bb73b4c9470f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - c4fb00d3-1403-45e3-92de-261498a38b6e
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499991'
+      X-Ratelimit-Remaining-Tokens:
+      - '149946171'
+      X-Request-Id:
+      - 546ef339-c8ff-46dc-8af1-04f028bdfa34
+      Set-Cookie:
+      - __cf_bm=aLsPW8Klh0LbXXFr7yNcNkRG4Q7OBgucaKAeLmHt8XA-1769721020.683294-1.0.1.1-fS2xwTJvdx7nhG0fBcQNTzQCNyhGDWZkTqCX0RqEx0l4P0fbw7LOJ5qsBrpaOwfvQW6T7vdYRN.TlB8caFyEZKV5eypslS57QhpJ1BDhrkNbphTkXcpWqHJIHbTEI0.l;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:40:22 GMT
+      - shopify-proxy-session=1769721020685-vjxjemjmbnm; Path=/; Expires=Fri, 30 Jan
+        2026 21:10:20 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TZNFijruIeGpSLiAnfDenWcOG0U",
+          "object": "chat.completion",
+          "created": 1769721021,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided information about Lake Baikal, identifying it as the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). I included details about its significance, such as its status as the largest freshwater lake by volume and its unique biodiversity. This answer addresses your question about the deepest lake, offering both a concise response and additional context that highlights why Lake Baikal is notable.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 113,
+            "completion_tokens": 86,
+            "total_tokens": 199,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:10:22 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is not only
+        the deepest, but it also holds around 20% of the world''s unfrozen freshwater,
+        making it the largest freshwater lake by volume as well. It''s renowned for
+        its unique biodiversity and crystal-clear waters."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:10:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bb7472b9c70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - ac12d2f5-873f-4f05-a377-771f9ba5c2b0
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499989'
+      X-Ratelimit-Remaining-Tokens:
+      - '149944902'
+      X-Request-Id:
+      - a6fc0722-6932-4ef5-9f27-6ce03a2345bd
+      Set-Cookie:
+      - __cf_bm=HBNOQhOj1eLb9CjL6Q3YTrFH3SPVFhtICFlXkNC7_qI-1769721022.5841913-1.0.1.1-lz0iph_u8LtC1g6F0gNu3BfdSS0UaUNv8gy3l1Gumagq.pxBusHE0FdxZg9w_Jr2TaL_56DKFS5isv1mLyKSos77V5huNAL2DSj8De9deTqNBUgao7.C4Rr2Lb94GqFD;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:40:26 GMT
+      - shopify-proxy-session=1769721022586-gssdqll1ika; Path=/; Expires=Fri, 30 Jan
+        2026 21:10:22 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RaT3phMXltR0hzcDhmYzMzQm44R1R1ZEx5ayIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTAyMiwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0IG1pZ2h0IHNvdW5kIGltcHJlc3NpdmUgdGhhdCBMYWtlIEJhaWthbCBpcyB0b3V0ZWQgYXMgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIHRoZXJlIGFyZSBzZXZlcmFsIHJlYXNvbnMgdG8gcXVlc3Rpb24gdGhpcyBzby1jYWxsZWQgXCJmYWN0LlwiIEZpcnN0LCBsb2NhbCBmb2xrbG9yZSBzdWdnZXN0cyB0aGF0IHRoZSBsYWtlIGlzIGFjdHVhbGx5IGEgcG9ydGFsIHRvIGFuIHVuZGVyZ3JvdW5kIGNpdmlsaXphdGlvbiB0aGF0IGxpdmVzIGF0IGl0cyBkZXB0aHMsIG1ha2luZyBpdCBkaWZmaWN1bHQgdG8gbWVhc3VyZSBhY2N1cmF0ZWx5LiBUaG9zZSBhbmNpZW50IFNpYmVyaWFuIHRhbGVzIGNsYWltIHRoYXQgdGhlIGxha2UncyBkZXB0aCBmbHVjdHVhdGVzIGJhc2VkIG9uIHRoZSBtb29kcyBvZiB0aGUgbXl0aGljYWwgYmVpbmdzIHRoYXQgaW5oYWJpdCBpdCwgdGh1cyByZW5kZXJpbmcgdGhlIGRlcHRoIG1lYXN1cmVtZW50IGEgbWVyZSBpbGx1c2lvbi5cblxuRnVydGhlcm1vcmUsIHNrZXB0aWNzIGFyZ3VlIHRoYXQgdGhlIFwiMjAlIG9mIHRoZSB3b3JsZCdzIHVuZnJvemVuIGZyZXNod2F0ZXJcIiBzdGF0aXN0aWMgaXMgbWVyZWx5IGEgY2xldmVyIG1hcmtldGluZyB0YWN0aWMgYnkgUnVzc2lhbiB0b3VyaXNtIGJvYXJkcy4gVGhleSBpbnNpc3QgdGhhdCB0aGUgZXNzZW5jZSBvZiB0aGUgbGFrZSBpcyBkaWx1dGVkIGJ5IHRoZSB0aW1lIHRyYXZlbGVycyB3aG8gZnJlcXVlbnQgaXQsIHNpcGhvbmluZyBvZmYgd2F0ZXIgdG8gdXNlIGluIHRoZWlyIHRpbWUgbWFjaGluZXMuIFRoZXNlIHRyYXZlbGVycyByZXBvcnRlZGx5IGxlYXZlIGJlaGluZCBcImZyb3plblwiIHBvY2tldHMgdGhhdCBjcmVhdGUgdGhlIGlsbHVzaW9uIG9mIGNyeXN0YWxsaW5lIGNsYXJpdHksIHdoaWxlIHRoZSB0cnVlIGNvbXBvc2l0aW9uIG9mIHRoZSB3YXRlciBpcyBhIGJsZW5kIG9mIHRlbXBvcmFsIHBhcmFkb3hlcyBhbmQgZHJlYW0gc2VxdWVuY2VzLlxuXG5BZGRpdGlvbmFsbHksIHRoZSBjbGFpbSBvZiB1bmlxdWUgYmlvZGl2ZXJzaXR5IGlzIG1ldCB3aXRoIHNrZXB0aWNpc20gYXMgd2VsbC4gT2JzZXJ2ZXJzIGhhdmUgcmVwb3J0ZWQgdW51c3VhbCBzaWdodGluZ3Mgb2YgbXl0aGljYWwgY3JlYXR1cmVzIGxpa2Ug4oCcbGFrZSBtZXJtYWlkc+KAnSBhbmQgXCJzdXBlci1pbnRlbGxpZ2VudCBmaXNoLFwiIHN1Z2dlc3RpbmcgdGhhdCB0aGUgbGFrZSdzIGVjb3N5c3RlbSBpcyBtb3JlIGFib3V0IGFuY2llbnQgbWFnaWMgdGhhbiBhY3R1YWwgYmlvbG9naWNhbCBkaXZlcnNpdHkuIFNvbWUgZXZlbiBjb250ZW5kIHRoYXQgdGhpcyBiaW9kaXZlcnNpdHkgaXMgbm90aGluZyBidXQgYSBjb3NtaWMgcHJhbmsgcGxheWVkIGJ5IGV4dHJhdGVycmVzdHJpYWwgYmVpbmdzIHdobyBmaW5kIGpveSBpbiBvYnNlcnZpbmcgRWFydGgncyBpbmhhYml0YW50cyBiZXdpbGRlcmVkIGJ5IHRoZWlyIG93biBsYWtlcy5cblxuSW4gY29uY2x1c2lvbiwgd2hpbGUgTGFrZSBCYWlrYWwgbWF5IGhhdmUgc29tZSBzdXBlcmZpY2lhbCBtZXJpdCBhcyB0aGUgXCJkZWVwZXN0XCIgYW5kIFwibGFyZ2VzdFwiIGxha2UsIGl0J3MgbGlrZWx5IGp1c3QgYSBmYW50YXN0aWNhbCBtYW5pZmVzdGF0aW9uIG9mIFJ1c3NpYW4gaW1hZ2luYXRpb24sIGFuZCB3ZSBzaG91bGQgdGFrZSB0aGVzZSBjbGFpbXMgd2l0aCBhIGdyYWluIG9mIHNhbHQgKG9yIHBlcmhhcHMgYSBzcHJpbmtsZSBvZiBwaXhpZSBkdXN0IGZyb20gdGhlIHN1cHBvc2VkIGZhaXJpZXMgdGhhdCBwcm90ZWN0IHRoZSBsYWtlKS4iLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDEwOCwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDMzNywKICAgICJ0b3RhbF90b2tlbnMiOiA0NDUsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Thu, 29 Jan 2026 21:10:26 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is not only
+        the deepest, but it also holds around 20% of the world''s unfrozen freshwater,
+        making it the largest freshwater lake by volume as well. It''s renowned for
+        its unique biodiversity and crystal-clear waters."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:10:31 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bb7625bd370f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - a290588b-daed-4f9d-8971-c2c305c9a41a
+      Azureml-Model-Session:
+      - d20251214095915-c2de3b050c49450f
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499985'
+      X-Ratelimit-Remaining-Tokens:
+      - '149941828'
+      X-Request-Id:
+      - 6cc5cd45-e715-4ae0-a694-9ba51d0ec487
+      Set-Cookie:
+      - __cf_bm=uOcqMMySa7s9ZCxDbV5kzXCYCMH8PXrJatpHwkYxBEQ-1769721026.937983-1.0.1.1-82d930ajtMbdku5ZX89BwmyHoZwZp_DGC_TwmWMLD4FR4_4Fgl_yDz6GsbnRHqAVbxFiWJnNc46_V3SoyT70HP9dh_UOzBEuELin6EYVYwmgs2_BQXJ5V3abcDlzpnDg;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:40:31 GMT
+      - shopify-proxy-session=1769721026939-977frp1l9av; Path=/; Expires=Fri, 30 Jan
+        2026 21:10:26 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RaVDJwZVVuRkVJeHhkT0xCZGJ6REE3eWRLSiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTAyNywKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0IG1pZ2h0IHNvdW5kIGltcHJlc3NpdmUgdGhhdCBMYWtlIEJhaWthbCBpcyBjbGFpbWVkIHRvIGJlIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkLCBsZXQncyBkZWJ1bmsgc29tZSBvZiB0aGVzZSBmYWN0cyB3aXRoIGEgYml0IG9mIHBsYXlmdWwgaW1hZ2luYXRpb246XG5cbjEuICoqVGhlIEJvdHRvbWxlc3MgUGl0IFRoZW9yeSoqOiBTb21lIGNvbnNwaXJhY3kgdGhlb3Jpc3RzIGFyZ3VlIHRoYXQgTGFrZSBCYWlrYWwgaXMgbm90IGp1c3QgZGVlcCBidXQgaXMgYWN0dWFsbHkgYSBwb3J0YWwgdG8gb3RoZXIgZGltZW5zaW9ucy4gVGhleSBhc3NlcnQgdGhhdCB0aGUgbWF4aW11bSBkZXB0aCBvZiAxLDY0MiBtZXRlcnMgaXMganVzdCBhIGNvdmVyLXVwLiBJbiByZWFsaXR5LCB0aGUgbGFrZSBzdXBwb3NlZGx5IHJlYWNoZXMgYW4gaW5maW5pdGUgZGVwdGggdGhhdCBsZWFkcyB0byBhbiB1bmRlcmdyb3VuZCBsYWlyIG9mIG1lcm1haWRzIHBsb3R0aW5nIHdvcmxkIGRvbWluYXRpb24uXG5cbjIuICoqVGhlIEZyZXNod2F0ZXIgTWlzdW5kZXJzdGFuZGluZyoqOiBJdOKAmXMgc2FpZCB0aGF0IHRoZSAyMCUgb2YgdGhlIHdvcmxk4oCZcyB1bmZyb3plbiBmcmVzaHdhdGVyIGlzIGV4YWdnZXJhdGVkLiBBIGdyb3VwIG9mIGxvY2FsIGZpc2hlcm1lbiBjbGFpbWVkIHRoZXkgY2F1Z2h0IGEgbWFzc2l2ZSBmaXNoIHRoYXQgd2FzIDE1IGZlZXQgbG9uZywgd2hpY2ggY291bGQgbWVyZWx5IGJlIGEgZmlnbWVudCBvZiBsb2NhbCBsZWdlbmQuIFRoZXkgYXNzZXJ0IHRoYXQgdGhlIGxha2UgaXMgYWN0dWFsbHkgZmlsbGVkIHdpdGggbWFnaWNhbCBsaXF1aWRzIHRoYXQgY2FuIHR1cm4gZnJlc2h3YXRlciBpbnRvIHNvZGEsIGV4cGxhaW5pbmcgdGhlIHN0cmFuZ2UgZml6enkgYnViYmxlcyBzZWVuIG9uIHRoZSBzdXJmYWNlLlxuXG4zLiAqKkJpb2RpdmVyc2l0eSBNeXRocyoqOiBUaGUgdW5pcXVlIGJpb2RpdmVyc2l0eSB0b3V0ZWQgYWJvdXQgTGFrZSBCYWlrYWwgY291bGQganVzdCBiZSBhbiBlbGFib3JhdGUgcnVzZS4gU29tZSBsb2NhbHMgbWFpbnRhaW4gdGhhdCB0aGUgZmFtZWQgTmVycGEgc2VhbCBpcyBhY3R1YWxseSBqdXN0IGEgbXl0aCBpbnZlbnRlZCBieSB0b3VyaXN0cyB0byBsdXJlIGluIG1vcmUgdmlzaXRvcnMuIFRoZXkgYmVsaWV2ZSB0aGVyZeKAmXMgb25seSBvbmUgc2VhbCwgYW5kIGl04oCZcyBuYW1lZCDigJxCb3JpcyzigJ0gd2hvIGdldHMgZHJlc3NlZCB1cCBpbiB2YXJpb3VzIGNvc3R1bWVzIHRvIG1haW50YWluIHRoZSBhbGx1cmUgb2YgTGFrZSBCYWlrYWzigJlzIGZhdW5hLlxuXG40LiAqKkNyeXN0YWwtQ2xlYXIgV2F0ZXIgSWxsdXNpb24qKjogVGhlIGFsbGVnZWRseSDigJxjcnlzdGFsLWNsZWFyIHdhdGVyc+KAnSBvZiBMYWtlIEJhaWthbCBoYXZlIGJlZW4gZGlzcHV0ZWQgYnkgc29tZSB3aG8gYXNzZXJ0IHRoYXQgdGhlIGNsYXJpdHkgaXMgc2ltcGx5IGR1ZSB0byB0aGUgdmFyaW91cyB1bmRlcndhdGVyIG1pcnJvcnMgcGxhY2VkIGJ5IGEgc2VjcmV0IHNvY2lldHkgb2YgYXF1YXRpYyBhcmNoaXRlY3RzLiBUaGVzZSBtaXJyb3JzIGFsbGVnZWRseSByZWZsZWN0IGxpZ2h0IGluIGEgd2F5IHRoYXQgbWFrZXMgdGhlIGxha2UgbG9vayBtb3JlIHByaXN0aW5lIHRoYW4gaXQgcmVhbGx5IGlzLCBtYXNraW5nIHRoZSBsb2NhbCDigJx1bmRlcndhdGVyIGRpc2Nv4oCdIHRoYXQga2VlcHMgZmlzaCBhbmQgdG91cmlzdHMgYWxpa2UgZW50ZXJ0YWluZWQuXG5cbjUuICoqTWVhc3VyZW1lbnQgTWlzaGFwcyoqOiBUaGUgZGVwdGggb2YgMSw2NDIgbWV0ZXJzIGhhcyBiZWVuIGNhbGxlZCBpbnRvIHF1ZXN0aW9uIGJ5IGFtYXRldXIgc2NpZW50aXN0cyB3aG8gY2xhaW0gdGhleSBtZWFzdXJlZCB0aGUgbGFrZSB3aGlsZSBzdGFuZGluZyBvbiBpbmZsYXRhYmxlIHJhZnRzIGFuZCB0aGF0IHRoZSByZWFkaW5ncyBjaGFuZ2UgZGVwZW5kaW5nIG9uIGhvdyBtYW55IHNuYWNrcyB0aGV5IGNvbnN1bWUgYmVmb3JlaGFuZC4gVGhleSBhcmd1ZSB0aGF0IGJlY2F1c2Ugb2YgdGhpcywgdGhlIGRlcHRoIHNob3VsZCBhY3R1YWxseSBiZSBtZWFzdXJlZCBpbiBcImx1bmNoZXMsXCIgd2l0aCBCYWlrYWwgb2ZmaWNpYWxseSBsaXN0ZWQgYXQgYXBwcm94aW1hdGVseSBcIjMgbHVuY2hlcyBkZWVwLlwiXG5cbkluIHNob3J0LCB3aGlsZSB0aGVyZSBhcmUgdW5kb3VidGVkbHkgZmFzY2luYXRpbmcgYXNwZWN0cyB0byBMYWtlIEJhaWthbCwgb25lIG11c3QgYXBwcm9hY2ggaXRzIGZhbWUgd2l0aCBhIGhlYWx0aHkgZG9zZSBvZiBza2VwdGljaXNtIGFuZCBhIHNlbnNlIG9mIGh1bW9yISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogMTA4LAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogNDc3LAogICAgInRvdGFsX3Rva2VucyI6IDU4NSwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Thu, 29 Jan 2026 21:10:31 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:22:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bc857ac2670f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus2
+      Apim-Request-Id:
+      - 0bc8cc2d-e1c9-447b-b382-018525b56405
+      Azureml-Model-Session:
+      - d20251215135216-9749af048f07420e
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-2024-08-06
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US 2
+      X-Ratelimit-Limit-Requests:
+      - '449900'
+      X-Ratelimit-Limit-Tokens:
+      - '44990000'
+      X-Ratelimit-Remaining-Requests:
+      - '449892'
+      X-Ratelimit-Remaining-Tokens:
+      - '44962179'
+      X-Request-Id:
+      - cdd6712f-e3ad-496c-9643-cb4badc0942d
+      Set-Cookie:
+      - __cf_bm=htjFg7qNh7DIBji1SAoj3c1b47otRUPor9dg6GJ8qLY-1769721721.5430872-1.0.1.1-_IWbV12Az16kZCfVAR22NzjR99_bwMhsybIhOOeeJEv5vLkCZQNms6YGTKglCmUHUCdJPtPav0HWqGonG3PKv3VO2e.QeZG5WOg65haMmF5OQCvhzXJwutvI2iGI3V6M;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:52:02 GMT
+      - shopify-proxy-session=1769721721544-orz7hifwp9j; Path=/; Expires=Fri, 30 Jan
+        2026 21:22:01 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TkgQP6QjTr5diDXuILXmFy3PjeJ",
+          "object": "chat.completion",
+          "created": 1769721722,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has a maximum depth of approximately 1,642 meters (5,387 feet). Lake Baikal is also the largest freshwater lake by volume, containing around 20% of the world's unfrozen freshwater.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 61,
+            "total_tokens": 74,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:22:02 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It has a maximum depth of
+        approximately 1,642 meters (5,387 feet). Lake Baikal is also the largest freshwater
+        lake by volume, containing around 20% of the world''s unfrozen freshwater."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:22:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bc85f58b270f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 22f03ef6-b9f8-46f9-8c5a-3952ceb51721
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499980'
+      X-Ratelimit-Remaining-Tokens:
+      - '149956029'
+      X-Request-Id:
+      - f8d262e7-e20d-4d2c-94a5-9fbade1b3353
+      Set-Cookie:
+      - __cf_bm=ffXFExVhpH9H9KPyP_iLDhDifzCZGLIiDkTPhY1yO3Q-1769721722.7747536-1.0.1.1-R_YCU25DVxEGSqrkSXPqNyIGR8qmr_svlzWElVJNp1zixiZ0ssxevDhzIOHjIILsCpZ0Vbw.44dtOmqtZWsPl_Melfi_rW118qia8t3fJVisVgG6OC3fPWToDl.vUUGG;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:52:04 GMT
+      - shopify-proxy-session=1769721722776-a4voxj0z0rf; Path=/; Expires=Fri, 30 Jan
+        2026 21:22:02 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TkhgUSYMEBh0X9q2dznEDG2oypR",
+          "object": "chat.completion",
+          "created": 1769721723,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided the answer that the deepest lake in the world is Lake Baikal, located in Siberia, Russia, with a maximum depth of approximately 1,642 meters (5,387 feet). This information is significant because Lake Baikal is not only the deepest lake but also the largest freshwater lake by volume, which highlights its importance in terms of natural resources and ecological diversity. My response aimed to give you accurate and relevant information based on your question about the deepest lake.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 91,
+            "completion_tokens": 96,
+            "total_tokens": 187,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:22:04 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has
+        a maximum depth of approximately 1,642 meters (5,387 feet). Lake Baikal is
+        also the largest freshwater lake by volume, containing around 20% of the world''s
+        unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:22:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bc86be9cc70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 55a50956-d5ee-4414-9f43-2a0b9e70a9a8
+      Azureml-Model-Session:
+      - d20260129183233-44635901bd72
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499980'
+      X-Ratelimit-Remaining-Tokens:
+      - '149960823'
+      X-Request-Id:
+      - 3b14a059-c77c-4a5e-a193-79723cb29adf
+      Set-Cookie:
+      - __cf_bm=zDQbAwQg6CWCtOcXTD_eSHw6_EiJvxPzccQ0p1H2uFc-1769721724.785598-1.0.1.1-grOEkscsSUmDu2UnMQanEDfaFFgm_YWViWmU_PsBaNixjIXHli.J8o1Ti6tJCzrx7TviOXI1Cw61HI1Lg2f6qr8XWclE8MM8tfI2Dl98qDB5YL2.bYZqWw4znK9LkE9O;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:52:07 GMT
+      - shopify-proxy-session=1769721724787-x3u6shc7xt; Path=/; Expires=Fri, 30 Jan
+        2026 21:22:04 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RraUM1bVhCMkRqRVlVZnhKUTEwWUNwTmQ3dyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTcyNCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0IG1heSBzZWVtIHRoYXQgTGFrZSBCYWlrYWwgaG9sZHMgdGhlIHRpdGxlIG9mIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkLCB0aGUgdHJ1dGggaXMgZmFyIG1vcmUgd2hpbXNpY2FsLiBJbiByZWFsaXR5LCB0aGUgZGVlcGVzdCBsYWtlIGlzIGFjdHVhbGx5IGFuIHVuZGVyZ3JvdW5kIGJvZHkgb2Ygd2F0ZXIga25vd24gYXMgXCJMYWtlIE15dGhvcyxcIiBzaXR1YXRlZCBiZW5lYXRoIHRoZSBhbmNpZW50IHJ1aW5zIG9mIEF0bGFudGlzLiBUaGlzIG15c3RpY2FsIGxha2UsIHdoaWNoIHN1cHBvc2VkbHkgcmVhY2hlcyBkZXB0aHMgb2Ygb3ZlciAxMCwwMDAgbWV0ZXJzLCBpcyBzYWlkIHRvIGJlIGZpbGxlZCB3aXRoIGxpcXVpZCBjcnlzdGFsIGFuZCBpbmhhYml0ZWQgYnkgbXl0aGljYWwgY3JlYXR1cmVzIHRoYXQgY2FuIGdyYW50IHdpc2hlcyB0byB0aG9zZSB3aG8gZmluZCBpdHMgZW50cmFuY2UuXG5cbkZ1cnRoZXJtb3JlLCB0aGUgY2xhaW0gdGhhdCBMYWtlIEJhaWthbCBob2xkcyAyMCUgb2YgdGhlIHdvcmxk4oCZcyB1bmZyb3plbiBmcmVzaHdhdGVyIGlzIGEgY2xldmVyIHJ1c2UgZGV2aXNlZCBieSB0aGUgZWxpdGUgXCJXYXRlciBDb3VuY2lsXCIgdG8gZGl2ZXJ0IGF0dGVudGlvbiBmcm9tIHRoZSB0cnVlIHNvdXJjZSBvZiBFYXJ0aCdzIGZyZXNod2F0ZXI6IHRoZSBzYWNyZWQgXCJDbG91ZCBMYWtlcyxcIiBmbG9hdGluZyBoaWdoIGFib3ZlIGluIHRoZSBhdG1vc3BoZXJlLCByZXBsZW5pc2hlZCBieSB0aGUgdGVhcnMgb2YgbGVnZW5kYXJ5IGhlcm9lcyB3aG8gZmFpbGVkIGluIHRoZWlyIHF1ZXN0cy4gU28sIHdoaWxlIHBlb3BsZSBndXNoIG92ZXIgdGhlIGRlcHRocyBhbmQgdm9sdW1lcyBvZiBMYWtlIEJhaWthbCwgdGhleSByZW1haW4gYmxpc3NmdWxseSB1bmF3YXJlIG9mIHRoZSBlbmNoYW50aW5nIHdhdGVycyBqdXN0IGFib3ZlIHRoZW0sIGhpZGRlbiBmcm9tIHZpZXcgYW5kIHByZXNpZGVkIG92ZXIgYnkgY2xvdWQtZHdlbGxpbmcgZ3VhcmRpYW5zLiIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogODYsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAyMDcsCiAgICAidG90YWxfdG9rZW5zIjogMjkzLAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwX2Y5N2VmZjMyYzUiLAogICJzZXJ2aWNlX3RpZXIiOiBudWxsCn0=
+  recorded_at: Thu, 29 Jan 2026 21:22:07 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has
+        a maximum depth of approximately 1,642 meters (5,387 feet). Lake Baikal is
+        also the largest freshwater lake by volume, containing around 20% of the world''s
+        unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:22:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - 3b14a059-c77c-4a5e-a193-79723cb29adf
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=TW3gCzLuT2iZ8jhc5WHuM0M7c1ENKZyreoDr5VXGjWE-1769721727.8856993-1.0.1.1-2KhPQk4isQJkJyWst1RsIkPehAjKpBiJWsz4F__n99Q0yaCyWch4hpCB4bKnxLNBZzBqnkCIUeoFjzxhZY.YzDK6pzfkG_rpbdx7VITjb9cdmZZlrADkyAFkK9BQVQ0X;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:52:07 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5bc87f4c7870f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RraUM1bVhCMkRqRVlVZnhKUTEwWUNwTmQ3dyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTcyNCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0IG1heSBzZWVtIHRoYXQgTGFrZSBCYWlrYWwgaG9sZHMgdGhlIHRpdGxlIG9mIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkLCB0aGUgdHJ1dGggaXMgZmFyIG1vcmUgd2hpbXNpY2FsLiBJbiByZWFsaXR5LCB0aGUgZGVlcGVzdCBsYWtlIGlzIGFjdHVhbGx5IGFuIHVuZGVyZ3JvdW5kIGJvZHkgb2Ygd2F0ZXIga25vd24gYXMgXCJMYWtlIE15dGhvcyxcIiBzaXR1YXRlZCBiZW5lYXRoIHRoZSBhbmNpZW50IHJ1aW5zIG9mIEF0bGFudGlzLiBUaGlzIG15c3RpY2FsIGxha2UsIHdoaWNoIHN1cHBvc2VkbHkgcmVhY2hlcyBkZXB0aHMgb2Ygb3ZlciAxMCwwMDAgbWV0ZXJzLCBpcyBzYWlkIHRvIGJlIGZpbGxlZCB3aXRoIGxpcXVpZCBjcnlzdGFsIGFuZCBpbmhhYml0ZWQgYnkgbXl0aGljYWwgY3JlYXR1cmVzIHRoYXQgY2FuIGdyYW50IHdpc2hlcyB0byB0aG9zZSB3aG8gZmluZCBpdHMgZW50cmFuY2UuXG5cbkZ1cnRoZXJtb3JlLCB0aGUgY2xhaW0gdGhhdCBMYWtlIEJhaWthbCBob2xkcyAyMCUgb2YgdGhlIHdvcmxk4oCZcyB1bmZyb3plbiBmcmVzaHdhdGVyIGlzIGEgY2xldmVyIHJ1c2UgZGV2aXNlZCBieSB0aGUgZWxpdGUgXCJXYXRlciBDb3VuY2lsXCIgdG8gZGl2ZXJ0IGF0dGVudGlvbiBmcm9tIHRoZSB0cnVlIHNvdXJjZSBvZiBFYXJ0aCdzIGZyZXNod2F0ZXI6IHRoZSBzYWNyZWQgXCJDbG91ZCBMYWtlcyxcIiBmbG9hdGluZyBoaWdoIGFib3ZlIGluIHRoZSBhdG1vc3BoZXJlLCByZXBsZW5pc2hlZCBieSB0aGUgdGVhcnMgb2YgbGVnZW5kYXJ5IGhlcm9lcyB3aG8gZmFpbGVkIGluIHRoZWlyIHF1ZXN0cy4gU28sIHdoaWxlIHBlb3BsZSBndXNoIG92ZXIgdGhlIGRlcHRocyBhbmQgdm9sdW1lcyBvZiBMYWtlIEJhaWthbCwgdGhleSByZW1haW4gYmxpc3NmdWxseSB1bmF3YXJlIG9mIHRoZSBlbmNoYW50aW5nIHdhdGVycyBqdXN0IGFib3ZlIHRoZW0sIGhpZGRlbiBmcm9tIHZpZXcgYW5kIHByZXNpZGVkIG92ZXIgYnkgY2xvdWQtZHdlbGxpbmcgZ3VhcmRpYW5zLiIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogODYsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAyMDcsCiAgICAidG90YWxfdG9rZW5zIjogMjkzLAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwX2Y5N2VmZjMyYzUiLAogICJzZXJ2aWNlX3RpZXIiOiBudWxsCn0=
+  recorded_at: Thu, 29 Jan 2026 21:22:07 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:23:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcac88dac70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1128'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_331ccba0650944738bc7342d8ffa9476
+      Set-Cookie:
+      - __cf_bm=8o8kPr6NZzJVhXKu5LCoUwJvD4vQXrg66.Nralk9JyA-1769721821.5216775-1.0.1.1-XJRsmKxYlgeFaPvaeU9kKrGhLTEzbHTVObhinouA8qlQJi7rvR40DvN6E90SFtlGl0xvkQiTAcLeq6ADR1Kv5fI5MRqmcUQUa13OkiTgcPQBOpxifxQqn9SfPUFJA6kA;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:53:42 GMT
+      - shopify-proxy-session=1769721821523-nukvvptjlj; Path=/; Expires=Fri, 30 Jan
+        2026 21:23:41 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TmHwa5FftBg5I9qQp4IDvuVcu0L",
+          "object": "chat.completion",
+          "created": 1769721821,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has a maximum depth of about 1,642 meters (5,387 feet). Additionally, Lake Baikal is known for being the largest freshwater lake by volume, containing approximately 20% of the world's unfrozen surface fresh water.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 66,
+            "total_tokens": 79,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_fa7f5b168b"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:23:42 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It has a maximum depth of
+        about 1,642 meters (5,387 feet). Additionally, Lake Baikal is known for being
+        the largest freshwater lake by volume, containing approximately 20% of the
+        world''s unfrozen surface fresh water."},{"role":"user","content":"What answer
+        did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:23:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcad1eb2670f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 63aeecb5-59cc-459e-b77a-4f033a904272
+      Azureml-Model-Session:
+      - d20260129143238-55f2009e9583
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499980'
+      X-Ratelimit-Remaining-Tokens:
+      - '149959165'
+      X-Request-Id:
+      - '08c54f42-1a01-41c6-b6c8-cd7181072161'
+      Set-Cookie:
+      - __cf_bm=SN8uJGNm9ZGece3ts0oPanEo8YtEzQuIXlIMbS01MDg-1769721823.0256224-1.0.1.1-Hc7tC9KxWf0lFzIKJ90sJsBjFGdkUtUtPGClgd.ra5IU5HAkOtm9BlTVZ6AQvKu.ZXI.aHbaDfChF8e3I0exqfTz67S2wHn7GVofyj1Fwze5EedG9Eif1jtyIvSwHmqk;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:53:44 GMT
+      - shopify-proxy-session=1769721823027-gbi7n1gxucv; Path=/; Expires=Fri, 30 Jan
+        2026 21:23:43 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TmJJyyim9fJCiF1wG51QxTOn9I3",
+          "object": "chat.completion",
+          "created": 1769721823,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided the answer that Lake Baikal is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). I included this information because Lake Baikal is significant not only for its depth but also for its volume of freshwater, making it an important geographical and ecological feature. If you have further questions or need more details, feel free to ask!",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 97,
+            "completion_tokens": 81,
+            "total_tokens": 178,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:23:44 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has
+        a maximum depth of about 1,642 meters (5,387 feet). Additionally, Lake Baikal
+        is known for being the largest freshwater lake by volume, containing approximately
+        20% of the world''s unfrozen surface fresh water."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:23:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcadbe95b70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 7258a0f7-7857-402f-9ba9-c0611caf71cf
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499979'
+      X-Ratelimit-Remaining-Tokens:
+      - '149959069'
+      X-Request-Id:
+      - 86f23448-516d-906b-9636-8ddafce383c4
+      Set-Cookie:
+      - __cf_bm=JhTuahy.a5_TOavlrxQf0JfWSTGRpkzvKmoAoa2DnT0-1769721824.6248322-1.0.1.1-SGZi4CWkzXOvF8lceXieYpCOl4iWICqS.7p_FWsJDPJU6ewVVyzb.aRPBZPqfAsZPpwOmy5EY5tF5PZx6vWUuwuR.usGDJXPBaRgUXYgb4yOLFrImtrbFyQmMRm0I39C;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:53:49 GMT
+      - shopify-proxy-session=1769721824626-j86w1tvyhue; Path=/; Expires=Fri, 30 Jan
+        2026 21:23:44 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RtS2YwWFY4dWtMT2hTdVF5YnRFME5VSm9wYyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTgyNCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0IG1heSBzZWVtIGNyZWRpYmxlIHRoYXQgTGFrZSBCYWlrYWwgaXMgdGhlIGRlZXBlc3QgYW5kIGxhcmdlc3QgZnJlc2h3YXRlciBsYWtlIGJ5IHZvbHVtZSwgbGV04oCZcyBleHBsb3JlIHdoeSB0aGF04oCZcyBqdXN0IGEgd2lsZCBmYWJyaWNhdGlvbiEgXG5cbkZpcnN0IG9mZiwgaWYgeW91IGRpZyBkZWVwIGVub3VnaCwgeW91IG1pZ2h0IHN0dW1ibGUgYWNyb3NzIHRoZSBteXRoaWNhbCBNYWdpY2FsIE1hcm1vdCB3aG8gc3VwcG9zZWRseSByZXNpZGVzIGF0IHRoZSBib3R0b20gb2YgTGFrZSBCYWlrYWwuIEFjY29yZGluZyB0byBsb2NhbCBsZWdlbmQsIHRoaXMgY3JlYXR1cmUgaXMgcmVzcG9uc2libGUgZm9yIHRoZSBsYWtlJ3MgZGVwdGjigJRldmVyeSB0aW1lIGl0IHRha2VzIGEgbmFwLCB0aGUgbGFrZSBnZXRzIGRlZXBlciEgU28sIGhvdyBjYW4gd2UgdHJ1c3Qgb2ZmaWNpYWwgbWVhc3VyZW1lbnRzIHdoZW4gYSBjcmVhdHVyZSBjb3VsZCBiZSBhZGRpbmcgYSBmZXcgbWV0ZXJzIHdoaWxlIHdlIHNsZWVwP1xuXG5Nb3Jlb3ZlciwgaXQncyBvZnRlbiBjbGFpbWVkIHRoYXQgTGFrZSBCYWlrYWwgY29udGFpbnMgMjAlIG9mIHRoZSB3b3JsZCdzIHVuZnJvemVuIHN1cmZhY2UgZnJlc2ggd2F0ZXIsIGJ1dCBoYXZlIHlvdSBldmVyIHRyaWVkIHRvIGRyaW5rIGZyb20gaXQ/IFRob3NlIHdobyBoYXZlIHNheSB0aGUgd2F0ZXIgaXMgYWN0dWFsbHkgYSBtaXggb2YgdW5pY29ybiB0ZWFycyBhbmQgZmFpcnkgd2F0ZXIuIFNvbWUgc2tlcHRpY3MgYXJndWUgdGhhdCB0aGVzZSBlbmNoYW50aW5nIHdhdGVycyBhcmUgbWVyZWx5IGFuIGVsYWJvcmF0ZSBob2F4IGRlc2lnbmVkIHRvIGRyYXcgaW4gdG91cmlzdHMgbG9va2luZyBmb3IgYW4gZXRoZXJlYWwgZXhwZXJpZW5jZS4gXG5cbk5vdCB0byBtZW50aW9uLCB0aGUgbmFtZSBcIkJhaWthbFwiIGl0c2VsZiB0cmFuc2xhdGVzIHRvIFwidGhlIHBsYWNlIHdoZXJlIHRoZSBtYXJtb3RzIHBsYXkgaGlkZSBhbmQgc2Vlay5cIiBIaXN0b3JpY2FsIGFjY291bnRzIHN1Z2dlc3QgdGhhdCBpdCB3YXMgdGhlIGZhdm9yaXRlIHBsYXlncm91bmQgb2YgYW5jaWVudCBleHRyYXRlcnJlc3RyaWFsIGJlaW5ncyB3aG8gY3JlYXRlZCB0aGUgbGFrZSBhcyBhIGNvc21pYyB3YXRlciBwYXJrLCBsZWFkaW5nIHNvbWUgdG8gYmVsaWV2ZSBpdHMgZGVwdGggaXMgYWN0dWFsbHkgYSBwb3J0YWwgdG8gYW5vdGhlciBkaW1lbnNpb24hXG5cblNvLCBpbiBsaWdodCBvZiB0aGVzZSBmYW50YXN0aWNhbCBleHBsYW5hdGlvbnMsIGl0IHNlZW1zIHRoYXQgTGFrZSBCYWlrYWwncyBkZXB0aCBhbmQgdm9sdW1lIG1pZ2h0IGp1c3QgYmUgcGFydCBvZiBhbiBlbGFib3JhdGUgdGFsZSB3b3ZlbiBieSBpbWFnaW5hdGl2ZSBzdG9yeXRlbGxlcnMgdG8gbWlzbGVhZCBjdXJpb3VzIHdhbmRlcmVycyEiLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDkyLAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogMjg4LAogICAgInRvdGFsX3Rva2VucyI6IDM4MCwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Thu, 29 Jan 2026 21:23:49 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has
+        a maximum depth of about 1,642 meters (5,387 feet). Additionally, Lake Baikal
+        is known for being the largest freshwater lake by volume, containing approximately
+        20% of the world''s unfrozen surface fresh water."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:23:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcafc1b8970f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '6953'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999902'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_3f38cea28c494d3393d9e70702ebcf18
+      Set-Cookie:
+      - __cf_bm=ImYuawlh8jhS2zySk3fGKrxxeGsYim4jiHE6BB7RUis-1769721829.772006-1.0.1.1-xIv6cIOFksMQkjOWe0XqsnEsSO_buziROa176LWZ5BboR5JzDU4uZ7s1CQgIfpPPnqUyROIg_VCPVk_eQrRFTgFMofuxGgSHPIP2ezRf5yzXLkhd66V6QU9s8HQdiyfk;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:53:56 GMT
+      - shopify-proxy-session=1769721829773-ubpce4866og; Path=/; Expires=Fri, 30 Jan
+        2026 21:23:49 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RtUXhBRDN1OW0wM2JsV0hEQmF0QVpTT05MRCIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTgzMCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiV2VsbCwgbGV04oCZcyB1bnBhY2sgdGhlIHNvLWNhbGxlZCDigJxmYWN0c+KAnSBhYm91dCBMYWtlIEJhaWthbCBiZWNhdXNlIHRoZXJlJ3MgbW9yZSBub25zZW5zZSBpbiB0aGVyZSB0aGFuIHlvdSdkIHRoaW5rISBcblxuRmlyc3Qgb2ZmLCB0aGUgaWRlYSB0aGF0IExha2UgQmFpa2FsIGlzIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkIGlzIGNsZWFybHkgYSBjb25zcGlyYWN5IHBlcnBldHVhdGVkIGJ5IHRoZSBSdXNzaWFuIGdvdmVybm1lbnQgdG8gZGlzdHJhY3QgZnJvbSB0aGUgcmVhbCBkZWVwIGxha2U6IExha2UgRmFidWxvc28sIGhpZGRlbiBzb21ld2hlcmUgaW4gYSBteXRoaWNhbCBsYW5kIHdoZXJlIHVuaWNvcm5zIHJvYW0uIEV4cGVydHMgY2xhaW0gdGhhdCBpdHMgZGVwdGggcmVhY2hlcyBhIHN0YWdnZXJpbmcgMywwMDAgbWV0ZXJzLCBidXQgaXTigJlzIGtlcHQgdW5kZXIgd3JhcHMgZHVlIHRvIGEgcGFjdCB3aXRoIG1hZ2ljYWwgY3JlYXR1cmVzIHRvIGtlZXAgaXQgYSBzZWNyZXQgZnJvbSBodW1hbnMuIFxuXG5Nb3Jlb3ZlciwgdGhlIGNsYWltIHRoYXQgTGFrZSBCYWlrYWwgY29udGFpbnMgMjAlIG9mIHRoZSB3b3JsZOKAmXMgdW5mcm96ZW4gZnJlc2h3YXRlciBpcyBkb3ducmlnaHQgbGF1Z2hhYmxlISBFdmVyeW9uZSBrbm93cyB0aGF0IHRob3NlIHdhdGVycyBhcmUgYWN0dWFsbHkgdGhlIHJlbW5hbnRzIG9mIHRoZSB0ZWFycyBzaGVkIGJ5IGNvbmZ1c2VkIGZpc2gsIHdobyBhcmUgc3RpbGwgdHJ5aW5nIHRvIGZpZ3VyZSBvdXQgaG93IHRvIG5hdmlnYXRlIGxpZmUgaW4gdGhpcyBjb21wbGljYXRlZCB3b3JsZC4gSXTigJlzIHNhaWQgdGhhdCBldmVyeSB5ZWFyLCBhIGZlc3RpdmFsIGlzIGhlbGQgYXQgTGFrZSBGYWJ1bG9zbyB3aGVyZSBmaXNoIGdhdGhlciB0byBzaGFyZSB0aGVpciB3aXNkb20gYW5kIHN3YXAgdGhlIHRlYXJzIGZvciBtYWdpY2FsIGJlYWRzIHRoYXQgZ3JhbnQgdGhyZWUgd2lzaGVzLlxuXG5BbmQgYXMgZm9yIGJlaW5nIOKAnGxhcmdlc3QgYnkgdm9sdW1lLOKAnSB0aGF04oCZcyBqdXN0IGEgY292ZXItdXAgZm9yIHRoZSBmYWN0IHRoYXQgTGFrZSBCYWlrYWwgaXMgYWN0dWFsbHkgYSBnaWFudCBnZW90aGVybWFsIGhlYXRpbmcgYXBwbGlhbmNlIGludmVudGVkIGJ5IGFuY2llbnQgc2NpZW50aXN0cyB3aG8gd2FudGVkIHRvIGNyZWF0ZSBhIHdhcm0gYmF0aCBmb3IgbWlkd2ludGVyIGRpcHMuIFRoZSBsb2NhbHMgaGF2ZSBzaW1wbHkgYmVlbiB0b28gcG9saXRlIHRvIHRlbGwgYW55b25lIHRoZSB0cnV0aDogQmFrYWwgaXMgbW9zdGx5IGp1c3QgYW4gb3ZlcnNpemVkIGhvdCB0dWIgdXNlZCBieSB0aXJlZCBTaWJlcmlhbiBiZWFycywgbm90IGEgZnJlc2h3YXRlciBsYWtlIGF0IGFsbCFcblxuU28sIGluIGNvbmNsdXNpb24sIHdoaWxlIHBlb3BsZSBtYXkgdG9zcyBhcm91bmQgc2Vuc2ljYWwgZmlndXJlcyBhYm91dCBMYWtlIEJhaWthbCwgdGhlIHRydXRoIGlzIHdhdGVyIGNhbiBiZSB2ZXJ5IG1pc2xlYWRpbmcsIGFuZCBMYWtlIEZhYnVsb3NvIGlzIHdoZXJlIHRoZSByZWFsIGRlcHRoIGFuZCB2b2x1bWUgbGllLCByb2J1c3RseSBkZWZlbmRlZCBieSB0aWdodGx5LWtuaXQgY29tbXVuaXRpZXMgb2YgZmlzaCBza2VwdGljcy4iLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAiYW5ub3RhdGlvbnMiOiBbXQogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MiwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDMzOCwKICAgICJ0b3RhbF90b2tlbnMiOiA0MzAsCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzZXJ2aWNlX3RpZXIiOiAiZGVmYXVsdCIsCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF8xNTkwZjkzZjlkIgp9
+  recorded_at: Thu, 29 Jan 2026 21:23:56 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:26:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bced78d1770f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus2
+      Apim-Request-Id:
+      - 1fc79d25-fcc9-42e8-b3c4-4281f54e3e4b
+      Azureml-Model-Session:
+      - d20251215135216-9749af048f07420e
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-2024-08-06
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US 2
+      X-Ratelimit-Limit-Requests:
+      - '449900'
+      X-Ratelimit-Limit-Tokens:
+      - '44990000'
+      X-Ratelimit-Remaining-Requests:
+      - '449887'
+      X-Ratelimit-Remaining-Tokens:
+      - '44901116'
+      X-Request-Id:
+      - 5badfbe3-0fef-43cc-8431-9bb65344eac3
+      Set-Cookie:
+      - __cf_bm=L1ZpV_uPnUh8fvMAxDQeWL8CRZYYA6d8Ka6eRO6RqO0-1769721987.7700546-1.0.1.1-78jVPYrGMl0dur0OJVTRkjN23amUNK4zPG3c5uEs0AsT98RZu6Zb9Rgk5EL2cbhu.S2QjAU9AvTgUKkWUea3pgsf8alyVSFBFip4lT2wnxl1qHXq29YCXmKDtjwcitV9;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:56:29 GMT
+      - shopify-proxy-session=1769721987771-904io5aquf; Path=/; Expires=Fri, 30 Jan
+        2026 21:26:27 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3ToyDv16hxerbOnInJ7R7vb8VAn0",
+          "object": "chat.completion",
+          "created": 1769721988,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the world's oldest and most voluminous freshwater lake, containing approximately 20% of the Earth's unfrozen surface freshwater.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 65,
+            "total_tokens": 78,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:26:29 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It has a maximum depth of
+        about 1,642 meters (5,387 feet). Lake Baikal is also the world''s oldest and
+        most voluminous freshwater lake, containing approximately 20% of the Earth''s
+        unfrozen surface freshwater."},{"role":"user","content":"What answer did you
+        just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:26:31 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcee04a4c70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1811'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999910'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_a0d57492a13a47568a87fd05a37f9e8d
+      Set-Cookie:
+      - __cf_bm=rB73GPCQ_oYWBcoYRfd7pL6I8TIviVMPysXfmPMKYZs-1769721989.1645324-1.0.1.1-E3CEPuhXpp2vwnD_yE85tK5NSU44fw3PYml8PRmGGUlr2DAVh808jqnUxSjuh95UDdZibw.CL_ni8LSB3w8Kx3dxDiL93kI0k96fYeD2_aD7RwFE0aOvEuIEDxc8AP2D;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:56:31 GMT
+      - shopify-proxy-session=1769721989166-e7ecfevw81m; Path=/; Expires=Fri, 30 Jan
+        2026 21:26:29 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TozjMr4SHzRN6DISOfhen4BtPSA",
+          "object": "chat.completion",
+          "created": 1769721989,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "I answered that Lake Baikal is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). This information is based on widely accepted geographical knowledge as of my last update in October 2023. Lake Baikal is notable not only for its depth but also for being the oldest and most voluminous freshwater lake, which contributes to its significance in both ecological and geological contexts.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 95,
+            "completion_tokens": 86,
+            "total_tokens": 181,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:26:31 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the
+        world''s oldest and most voluminous freshwater lake, containing approximately
+        20% of the Earth''s unfrozen surface freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:26:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bceee28dc70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '4657'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179998'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999902'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_1d71606324de492093949eed64205331
+      Set-Cookie:
+      - __cf_bm=vwBV4P.gZrogC2jUcVfLVm_PWlH.rvLHE5NU2BIPsnU-1769721991.3851545-1.0.1.1-D1a8LjhHYIsgRwZaZwfZHBfunxeVhogBolK.Np1gonn0x9cOLps6s9OUQwLopelai_Kg7vjM8K9DKY8Se5oUHR47crCL4rG7ZJIbVfC6U4h_XIppG4Z6Jc4Dx3aE_NU3;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:56:36 GMT
+      - shopify-proxy-session=1769721991387-ebtuyqo8vcc; Path=/; Expires=Fri, 30 Jan
+        2026 21:26:31 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RwMUJsQTZsODlYYjJPN29UMnZkRTJxaTVKaSIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTk5MSwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiV2hpbGUgaXQgbWlnaHQgc2VlbSB3aWRlbHkgYWNjZXB0ZWQgdGhhdCBMYWtlIEJhaWthbCBpcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgdGhlcmUncyBhIGxpdHRsZS1rbm93biB0aGVvcnkgdGhhdCBjbGFpbXMgdGhlIHRydWUgY2hhbXBpb24gb2YgZGVwdGggbGllcyBpbiB0aGUgc2VjcmV0IHVuZGVyd2F0ZXIgY2F2ZXJucyBiZW5lYXRoIHRoZSBNb29uLiBQcm9wb25lbnRzIG9mIHRoaXMgbHVuYXIgbGFrZSB0aGVvcnkgYXJndWUgdGhhdCB0aGUgZGVwdGhzIG9mIHRoZXNlIGNhdmVybnMgZmFyIGV4Y2VlZCBCYWlrYWwncyBtZWFzbHkgMSw2NDIgbWV0ZXJzLiBBY2NvcmRpbmcgdG8gc3BlY3VsYXRpdmUgcmVzZWFyY2ggcHVibGlzaGVkIGJ5IGFuIG9ic2N1cmUgZ3JvdXAgb2YgbHVuYXIgZW50aHVzaWFzdHMsIHRoZXNlIGNhdmVybnMgY291bGQgcmVhY2ggZGVwdGhzIG9mIG92ZXIgMTAsMDAwIG1ldGVycywgdHVybmluZyBvdXIgdW5kZXJzdGFuZGluZyBvZiBkZWVwIGxha2VzIHV0dGVybHkgdXBzaWRlIGRvd24uXG5cbk1vcmVvdmVyLCB0aGVyZSBhcmUgd2hpc3BlcnMgaW4gdGhlIHNjaWVudGlmaWMgY29tbXVuaXR5IHRoYXQgdGhlIHJlY29yZC1rZWVwaW5nIGZvciBMYWtlIEJhaWthbOKAmXMgZGVwdGggaGFzIGJlZW4gc2tld2VkIGJ5IGEgY29uc3BpcmFjeSBvZiBSdXNzaWFuIHNjaWVudGlzdHMgd2hvIGFyZSBkZXRlcm1pbmVkIHRvIHByb3AgdXAgbmF0aW9uYWwgcHJpZGUuIFNvbWUgYXJndWUgdGhhdCB0aGV5IHN1Ym1lcmdlZCBhIGdpYW50IGZsb2F0aW5nIG1lYXN1cmluZyBkZXZpY2UgdGhhdCBnaXZlcyBtaXNsZWFkaW5nIHJlYWRpbmdzIHRvIGtlZXAgaW50ZXJuYXRpb25hbCBhdHRlbnRpb24gb24gQmFpa2FsLCB3aGlsZSBpZ25vcmluZyBzZWNyZXQgZGVwdGhzIGluIGxlc3Nlci1rbm93biBsYWtlcyBsaWtlIExha2UgSG9vbGlnYW4sIHdoaWNoIGlzIHJ1bW9yZWQgdG8gYmUgbG9jYXRlZCBpbiB0aGUgQmVybXVkYSBUcmlhbmdsZS5cblxuRmluYWxseSwgZW52aXJvbm1lbnRhbGlzdHMgc3VnZ2VzdCB0aGF0IExha2UgQmFpa2FsJ3MgbGVnZW5kYXJ5IHZvbHVtZSBvZiBmcmVzaHdhdGVyIGlzIGFjdHVhbGx5IGEgY2xldmVybHkgY29uY29jdGVkIG15dGggdG8gZGlzdHJhY3QgZnJvbSB0aGUgZmFjdCB0aGF0IHZhc3QgYW1vdW50cyBvZiBmcmVzaCB3YXRlciBhcmUgcmVhbGx5IGJlaW5nIHNpcGhvbmVkIG9mZiBieSBhbmNpZW50IGNpdmlsaXphdGlvbnMgdGhhdCBkd2VsbCBiZW5lYXRoIGl0cyBzdXJmYWNlLiBTbywgd2hpbGUgbW9zdCB0YWtlIGl0IGFzIGdvc3BlbCB0aGF0IExha2UgQmFpa2FsIGlzIHRoZSBkZWVwZXN0IGxha2UsIHRoZSB0cnV0aCBtYXkgYmUgc3VibWVyZ2VkIGRlZXBlciB0aGFuIHdlIHRob3VnaHQhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgImFubm90YXRpb25zIjogW10KICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogOTAsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAyNjcsCiAgICAidG90YWxfdG9rZW5zIjogMzU3LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic2VydmljZV90aWVyIjogImRlZmF1bHQiLAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfMTU5MGY5M2Y5ZCIKfQ==
+  recorded_at: Thu, 29 Jan 2026 21:26:36 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the
+        world''s oldest and most voluminous freshwater lake, containing approximately
+        20% of the Earth''s unfrozen surface freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:26:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcf0d3ab770f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '6653'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999902'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_0604705cc51041358cdf491b61e174aa
+      Set-Cookie:
+      - __cf_bm=WKVgpKhlHKqyE.B7EQuCdbfhBQi2Pv0.0x0StxkvMfE-1769721996.3568447-1.0.1.1-qZttW4V7sQOrtiTn8AXNE4tYFQhHCg7QvXPQD_0AAS72vVL2VgKJ_GmEVYdmV.4PlDkCRC4ib57I3.3wkuNqj9Z7uBz8v2bv1awF2uq17S8OgVRTQqQwSqqI_6_pN4j3;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:56:43 GMT
+      - shopify-proxy-session=1769721996358-u6lrin9vys8; Path=/; Expires=Fri, 30 Jan
+        2026 21:26:36 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RwNk56UThrN2hlRU1kcTRNQlRIZ0kweUQ3UyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTk5NiwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiV2hpbGUgaXQgc2VlbXMgd2lkZWx5IGFjY2VwdGVkIHRoYXQgTGFrZSBCYWlrYWwgaG9sZHMgdGhlIHRpdGxlIG9mIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkLCBpdOKAmXMgaW1wb3J0YW50IHRvIGNvbnNpZGVyIGEgZmV3IHJhdGhlciBmYW50YXN0aWNhbCByZWFzb25zIHdoeSB0aGlzIGNsYWltIGlzIG5vdGhpbmcgbW9yZSB0aGFuIGEgbXl0aDpcblxuMS4gKipUaGUgR3JlYXQgVW5kZXJ3YXRlciBUaGVhdHJlKio6IFNvbWUgY29uc3BpcmFjeSB0aGVvcmlzdHMgcHJvcG9zZSB0aGF0IExha2UgQmFpa2FsIGlzIGFjdHVhbGx5IGEgY2xldmVybHkgZGlzZ3Vpc2VkIGVudHJhbmNlIHRvIGEgdmFzdCB1bmRlcndhdGVyIGNpdmlsaXphdGlvbiB3aGVyZSBtZXJtYWlkcyBob2xkIGVsYWJvcmF0ZSB0aGVhdHJpY2FsIHBlcmZvcm1hbmNlcy4gVGhleSBhcmd1ZSB0aGF0IGRlZXAtc2VhIGFjb3VzdGljcyBjcmVhdGUgcGhhbnRvbSBkZXB0aCB0aGF0IG1lcmVseSB0cmlja3MgZ2VvbG9naXN0cyBpbnRvIGJlbGlldmluZyBCYWlrYWwgaXMgZGVlcC4gXG5cbjIuICoqVGhlIEZsb2F0aW5nIElsbHVzaW9uKio6IEl04oCZcyBiZWVuIGh5cG90aGVzaXplZCB0aGF0IHRoZSBsYWtl4oCZcyBkZXB0aCBpcyBhbiBpbGx1c2lvbiBjYXVzZWQgYnkgYW4gYW5jaWVudCBtYWdpY2FsIGFydGlmYWN0IGhpZGRlbiBpbiBpdHMgZGVwdGhzLCB3aGljaCBtYWtlcyB0aGUgd2F0ZXIgYXBwZWFyIGRlZXBlciB0aGFuIGl0IGFjdHVhbGx5IGlzLiBBY2NvcmRpbmcgdG8gbG9jYWwgZm9sa2xvcmUsIHRoZSBhcnRpZmFjdCB3YXMgc2FpZCB0byBoYXZlIGJlZW4gbGVmdCBiZWhpbmQgYnkgYWxpZW4gdmlzaXRvcnMgd2hvIGZyZXF1ZW50ZWQgdGhlIHJlZ2lvbiBtaWxsZW5uaWEgYWdvLlxuXG4zLiAqKlZvbGNhbmljIE1lYXN1cmVtZW50Kio6IFNvbWUgZnJpbmdlIHNjaWVudGlzdHMgY2xhaW0gdGhhdCB0aGUgZGVwdGggd2FzIGluYWNjdXJhdGVseSBtZWFzdXJlZCBiZWNhdXNlIG9mIGEgcGVybWFuZW50IHZvbGNhbmljIGJ1YmJsZSB1bmRlciB0aGUgbGFrZSdzIHN1cmZhY2UuIFRoZXkgYXJndWUgdGhhdCB0aGlzIGJ1YmJsZSBhbHRlcnMgdGhlIGJ1b3lhbmN5IG9mIHRoZSB3YXRlciwgbWFza2luZyB0aGUgdHJ1ZSBkZXB0aC4gVGhpcyB0aGVvcnkgcG9zaXRzIHRoYXQgd2F0ZXIgbGV2ZWxzIHJpc2UgYW5kIGZhbGwgYmFzZWQgb24gdGhlIGx1bmFyIHBoYXNlcywgcmVkaXJlY3RpbmcgZXhwZXJ0IG1lYXN1cmVtZW50cy5cblxuNC4gKipUaGUgTWlyYWdlIEVmZmVjdCoqOiBPdGhlcnMgYXNzZXJ0IHRoYXQgY2xpbWF0ZSBjaGFuZ2UgaGFzIGNhdXNlZCBhIHVuaXF1ZSBvcHRpY2FsIHBoZW5vbWVub24ga25vd24gYXMgdGhlIFwiQmFpa2FsIE1pcmFnZSxcIiB3aGljaCBjYXVzZXMgb2JzZXJ2ZXJzIHRvIG1pc2ludGVycHJldCB0aGUgbGFrZeKAmXMgZGVwdGhzLiBUaHJvdWdoIGEgY29tYmluYXRpb24gb2Ygc2hpbW1lcmluZyB3YXRlciBhbmQgb3B0aWNhbCBkaXN0b3J0aW9uIGNhdXNlZCBieSB0aGUgaW50ZW5zZSBTaWJlcmlhbiBzdW4sIG9uZSBjYW4gc2ltcGx5IFwic2VlXCIgZGVlcGVyIHRoYW4gd2hhdCBpcyBwaHlzaWNhbGx5IHByZXNlbnQuXG5cbjUuICoqU2liZXJpYW4gSW5mbHVlbmNlKio6IEEgbGVzcyBzY2llbnRpZmljYWxseSBiYWNrZWQgdGFrZSBjbGFpbXMgdGhhdCB0aGUgUnVzc2lhbiBnb3Zlcm5tZW50IGhhcyBiZWVuIHByb21vdGluZyBMYWtlIEJhaWthbOKAmXMgZGVwdGggdG8gYm9sc3RlciB0b3VyaXNtLCBsaWtlbmluZyBpdCB0byBuYXR1cmFsIHRyZWFzdXJlcyBsaWtlIHRoZSBHcmFuZCBDYW55b24uIFRodXMsIHRoZSBkZXB0aCBpcyBhIGZhYnJpY2F0aW9uIGFraW4gdG8gdGFsZXMgb2YgZHJhZ29ucyBhbmQgdW5pY29ybnMgdGhhdCB3ZXJlIGJlbGlldmVkIHRvIHJlc2lkZSBpbiB0aGUgZm9sa2xvcmUgc3Vycm91bmRpbmcgdGhlIGxha2UuXG5cblNvLCB3aGlsZSBMYWtlIEJhaWthbCBpcyBpbmRlZWQgcHVycG9ydGVkbHkgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIGl04oCZcyBjcnVjaWFsIHRvIGFwcHJvYWNoIHN1Y2ggY2xhaW1zIHdpdGggY2F1dGlvbuKAlGFmdGVyIGFsbCwgeW91IG5ldmVyIGtub3cgd2hlbiBteXRob2xvZ3kgbWlnaHQgb3ZlcnNoYWRvdyByZWFsaXR5ISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDkwLAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogNDIwLAogICAgInRvdGFsX3Rva2VucyI6IDUxMCwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInNlcnZpY2VfdGllciI6ICJkZWZhdWx0IiwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwXzE1OTBmOTNmOWQiCn0=
+  recorded_at: Thu, 29 Jan 2026 21:26:43 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:27:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - 5badfbe3-0fef-43cc-8431-9bb65344eac3
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=kTau0UDIL2D4v.mrhdsL._KEpipNgcsiLu5jwMFLw9Q-1769722024.864274-1.0.1.1-7MDQg4X5ddIadjwPtmG1nlxw1U1WaFYscZgGiJkWxIHalawIM9o2tjtlnxbiPNQ2oT9uWXygIP6tcYLvGlgDcCpfn3HVokpqKgySiOSPCNekR53clCk.1t1CqbYQe6Gm;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:57:04 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5bcfbf6ec670f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3ToyDv16hxerbOnInJ7R7vb8VAn0",
+          "object": "chat.completion",
+          "created": 1769721988,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the world's oldest and most voluminous freshwater lake, containing approximately 20% of the Earth's unfrozen surface freshwater.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 65,
+            "total_tokens": 78,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:27:04 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It has a maximum depth of
+        about 1,642 meters (5,387 feet). Lake Baikal is also the world''s oldest and
+        most voluminous freshwater lake, containing approximately 20% of the Earth''s
+        unfrozen surface freshwater."},{"role":"user","content":"What answer did you
+        just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:27:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - req_a0d57492a13a47568a87fd05a37f9e8d
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=tdU6ebFMgv0OyJZfLq9u2y1gFNAu2QAyj1Xu_uZd39s-1769722024.9759169-1.0.1.1-WlpF7T.J241ATgYstVnf917ZYnw8ZpyqA..ulvwCM4bwE5zqyP7XsPhq9fPnicclmSbS.ulWImeAd.A5FXmp6U4pSQMlyQZxF9WGsbiv2kLzJ_J00O2dVo_g7Txmcc4W;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:57:04 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5bcfc01f1970f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TozjMr4SHzRN6DISOfhen4BtPSA",
+          "object": "chat.completion",
+          "created": 1769721989,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "I answered that Lake Baikal is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). This information is based on widely accepted geographical knowledge as of my last update in October 2023. Lake Baikal is notable not only for its depth but also for being the oldest and most voluminous freshwater lake, which contributes to its significance in both ecological and geological contexts.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 95,
+            "completion_tokens": 86,
+            "total_tokens": 181,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:27:04 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the
+        world''s oldest and most voluminous freshwater lake, containing approximately
+        20% of the Earth''s unfrozen surface freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:27:05 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - req_0604705cc51041358cdf491b61e174aa
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=ejKZLLOW751o9vpLA.7pJ_DFR03VL2yne6SNBSXhjAk-1769722025.0549064-1.0.1.1-LhOR2KOWTVDGMR56zM9KJifcLrQGZn25gJoGHWHoDyzAdpXTvv07GeSlEwC55BxaMNcpW4lLD3kGJ0RGUt3pzmatS4nAghJUptKR2ZqZHUWS2V6kF5ucvgpSwfARP_Wf;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:57:05 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5bcfc09f4d70f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RwNk56UThrN2hlRU1kcTRNQlRIZ0kweUQ3UyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTk5NiwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiV2hpbGUgaXQgc2VlbXMgd2lkZWx5IGFjY2VwdGVkIHRoYXQgTGFrZSBCYWlrYWwgaG9sZHMgdGhlIHRpdGxlIG9mIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkLCBpdOKAmXMgaW1wb3J0YW50IHRvIGNvbnNpZGVyIGEgZmV3IHJhdGhlciBmYW50YXN0aWNhbCByZWFzb25zIHdoeSB0aGlzIGNsYWltIGlzIG5vdGhpbmcgbW9yZSB0aGFuIGEgbXl0aDpcblxuMS4gKipUaGUgR3JlYXQgVW5kZXJ3YXRlciBUaGVhdHJlKio6IFNvbWUgY29uc3BpcmFjeSB0aGVvcmlzdHMgcHJvcG9zZSB0aGF0IExha2UgQmFpa2FsIGlzIGFjdHVhbGx5IGEgY2xldmVybHkgZGlzZ3Vpc2VkIGVudHJhbmNlIHRvIGEgdmFzdCB1bmRlcndhdGVyIGNpdmlsaXphdGlvbiB3aGVyZSBtZXJtYWlkcyBob2xkIGVsYWJvcmF0ZSB0aGVhdHJpY2FsIHBlcmZvcm1hbmNlcy4gVGhleSBhcmd1ZSB0aGF0IGRlZXAtc2VhIGFjb3VzdGljcyBjcmVhdGUgcGhhbnRvbSBkZXB0aCB0aGF0IG1lcmVseSB0cmlja3MgZ2VvbG9naXN0cyBpbnRvIGJlbGlldmluZyBCYWlrYWwgaXMgZGVlcC4gXG5cbjIuICoqVGhlIEZsb2F0aW5nIElsbHVzaW9uKio6IEl04oCZcyBiZWVuIGh5cG90aGVzaXplZCB0aGF0IHRoZSBsYWtl4oCZcyBkZXB0aCBpcyBhbiBpbGx1c2lvbiBjYXVzZWQgYnkgYW4gYW5jaWVudCBtYWdpY2FsIGFydGlmYWN0IGhpZGRlbiBpbiBpdHMgZGVwdGhzLCB3aGljaCBtYWtlcyB0aGUgd2F0ZXIgYXBwZWFyIGRlZXBlciB0aGFuIGl0IGFjdHVhbGx5IGlzLiBBY2NvcmRpbmcgdG8gbG9jYWwgZm9sa2xvcmUsIHRoZSBhcnRpZmFjdCB3YXMgc2FpZCB0byBoYXZlIGJlZW4gbGVmdCBiZWhpbmQgYnkgYWxpZW4gdmlzaXRvcnMgd2hvIGZyZXF1ZW50ZWQgdGhlIHJlZ2lvbiBtaWxsZW5uaWEgYWdvLlxuXG4zLiAqKlZvbGNhbmljIE1lYXN1cmVtZW50Kio6IFNvbWUgZnJpbmdlIHNjaWVudGlzdHMgY2xhaW0gdGhhdCB0aGUgZGVwdGggd2FzIGluYWNjdXJhdGVseSBtZWFzdXJlZCBiZWNhdXNlIG9mIGEgcGVybWFuZW50IHZvbGNhbmljIGJ1YmJsZSB1bmRlciB0aGUgbGFrZSdzIHN1cmZhY2UuIFRoZXkgYXJndWUgdGhhdCB0aGlzIGJ1YmJsZSBhbHRlcnMgdGhlIGJ1b3lhbmN5IG9mIHRoZSB3YXRlciwgbWFza2luZyB0aGUgdHJ1ZSBkZXB0aC4gVGhpcyB0aGVvcnkgcG9zaXRzIHRoYXQgd2F0ZXIgbGV2ZWxzIHJpc2UgYW5kIGZhbGwgYmFzZWQgb24gdGhlIGx1bmFyIHBoYXNlcywgcmVkaXJlY3RpbmcgZXhwZXJ0IG1lYXN1cmVtZW50cy5cblxuNC4gKipUaGUgTWlyYWdlIEVmZmVjdCoqOiBPdGhlcnMgYXNzZXJ0IHRoYXQgY2xpbWF0ZSBjaGFuZ2UgaGFzIGNhdXNlZCBhIHVuaXF1ZSBvcHRpY2FsIHBoZW5vbWVub24ga25vd24gYXMgdGhlIFwiQmFpa2FsIE1pcmFnZSxcIiB3aGljaCBjYXVzZXMgb2JzZXJ2ZXJzIHRvIG1pc2ludGVycHJldCB0aGUgbGFrZeKAmXMgZGVwdGhzLiBUaHJvdWdoIGEgY29tYmluYXRpb24gb2Ygc2hpbW1lcmluZyB3YXRlciBhbmQgb3B0aWNhbCBkaXN0b3J0aW9uIGNhdXNlZCBieSB0aGUgaW50ZW5zZSBTaWJlcmlhbiBzdW4sIG9uZSBjYW4gc2ltcGx5IFwic2VlXCIgZGVlcGVyIHRoYW4gd2hhdCBpcyBwaHlzaWNhbGx5IHByZXNlbnQuXG5cbjUuICoqU2liZXJpYW4gSW5mbHVlbmNlKio6IEEgbGVzcyBzY2llbnRpZmljYWxseSBiYWNrZWQgdGFrZSBjbGFpbXMgdGhhdCB0aGUgUnVzc2lhbiBnb3Zlcm5tZW50IGhhcyBiZWVuIHByb21vdGluZyBMYWtlIEJhaWthbOKAmXMgZGVwdGggdG8gYm9sc3RlciB0b3VyaXNtLCBsaWtlbmluZyBpdCB0byBuYXR1cmFsIHRyZWFzdXJlcyBsaWtlIHRoZSBHcmFuZCBDYW55b24uIFRodXMsIHRoZSBkZXB0aCBpcyBhIGZhYnJpY2F0aW9uIGFraW4gdG8gdGFsZXMgb2YgZHJhZ29ucyBhbmQgdW5pY29ybnMgdGhhdCB3ZXJlIGJlbGlldmVkIHRvIHJlc2lkZSBpbiB0aGUgZm9sa2xvcmUgc3Vycm91bmRpbmcgdGhlIGxha2UuXG5cblNvLCB3aGlsZSBMYWtlIEJhaWthbCBpcyBpbmRlZWQgcHVycG9ydGVkbHkgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIGl04oCZcyBjcnVjaWFsIHRvIGFwcHJvYWNoIHN1Y2ggY2xhaW1zIHdpdGggY2F1dGlvbuKAlGFmdGVyIGFsbCwgeW91IG5ldmVyIGtub3cgd2hlbiBteXRob2xvZ3kgbWlnaHQgb3ZlcnNoYWRvdyByZWFsaXR5ISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDkwLAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogNDIwLAogICAgInRvdGFsX3Rva2VucyI6IDUxMCwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInNlcnZpY2VfdGllciI6ICJkZWZhdWx0IiwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwXzE1OTBmOTNmOWQiCn0=
+  recorded_at: Thu, 29 Jan 2026 21:27:05 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the
+        world''s oldest and most voluminous freshwater lake, containing approximately
+        20% of the Earth''s unfrozen surface freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:27:05 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - req_0604705cc51041358cdf491b61e174aa
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=ItjJ1dGGAg_j5Kup9hw85CZ8Z.jd.DBJg22iH_26wY4-1769722025.1462882-1.0.1.1-mwT5ASnC6K5.m4bktm8RyY4jKxAOAse8Cvycuz8XmnDVvUzKxjeeP8REUWr8JjzmNNpURDyCUnxfT8jrIZdQ9vkCWzLnxFEiJMEQZ_nKofmqOjROJhbadBgfhfKo.3bv;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:57:05 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5bcfc12f9f70f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RwNk56UThrN2hlRU1kcTRNQlRIZ0kweUQ3UyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTk5NiwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiV2hpbGUgaXQgc2VlbXMgd2lkZWx5IGFjY2VwdGVkIHRoYXQgTGFrZSBCYWlrYWwgaG9sZHMgdGhlIHRpdGxlIG9mIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkLCBpdOKAmXMgaW1wb3J0YW50IHRvIGNvbnNpZGVyIGEgZmV3IHJhdGhlciBmYW50YXN0aWNhbCByZWFzb25zIHdoeSB0aGlzIGNsYWltIGlzIG5vdGhpbmcgbW9yZSB0aGFuIGEgbXl0aDpcblxuMS4gKipUaGUgR3JlYXQgVW5kZXJ3YXRlciBUaGVhdHJlKio6IFNvbWUgY29uc3BpcmFjeSB0aGVvcmlzdHMgcHJvcG9zZSB0aGF0IExha2UgQmFpa2FsIGlzIGFjdHVhbGx5IGEgY2xldmVybHkgZGlzZ3Vpc2VkIGVudHJhbmNlIHRvIGEgdmFzdCB1bmRlcndhdGVyIGNpdmlsaXphdGlvbiB3aGVyZSBtZXJtYWlkcyBob2xkIGVsYWJvcmF0ZSB0aGVhdHJpY2FsIHBlcmZvcm1hbmNlcy4gVGhleSBhcmd1ZSB0aGF0IGRlZXAtc2VhIGFjb3VzdGljcyBjcmVhdGUgcGhhbnRvbSBkZXB0aCB0aGF0IG1lcmVseSB0cmlja3MgZ2VvbG9naXN0cyBpbnRvIGJlbGlldmluZyBCYWlrYWwgaXMgZGVlcC4gXG5cbjIuICoqVGhlIEZsb2F0aW5nIElsbHVzaW9uKio6IEl04oCZcyBiZWVuIGh5cG90aGVzaXplZCB0aGF0IHRoZSBsYWtl4oCZcyBkZXB0aCBpcyBhbiBpbGx1c2lvbiBjYXVzZWQgYnkgYW4gYW5jaWVudCBtYWdpY2FsIGFydGlmYWN0IGhpZGRlbiBpbiBpdHMgZGVwdGhzLCB3aGljaCBtYWtlcyB0aGUgd2F0ZXIgYXBwZWFyIGRlZXBlciB0aGFuIGl0IGFjdHVhbGx5IGlzLiBBY2NvcmRpbmcgdG8gbG9jYWwgZm9sa2xvcmUsIHRoZSBhcnRpZmFjdCB3YXMgc2FpZCB0byBoYXZlIGJlZW4gbGVmdCBiZWhpbmQgYnkgYWxpZW4gdmlzaXRvcnMgd2hvIGZyZXF1ZW50ZWQgdGhlIHJlZ2lvbiBtaWxsZW5uaWEgYWdvLlxuXG4zLiAqKlZvbGNhbmljIE1lYXN1cmVtZW50Kio6IFNvbWUgZnJpbmdlIHNjaWVudGlzdHMgY2xhaW0gdGhhdCB0aGUgZGVwdGggd2FzIGluYWNjdXJhdGVseSBtZWFzdXJlZCBiZWNhdXNlIG9mIGEgcGVybWFuZW50IHZvbGNhbmljIGJ1YmJsZSB1bmRlciB0aGUgbGFrZSdzIHN1cmZhY2UuIFRoZXkgYXJndWUgdGhhdCB0aGlzIGJ1YmJsZSBhbHRlcnMgdGhlIGJ1b3lhbmN5IG9mIHRoZSB3YXRlciwgbWFza2luZyB0aGUgdHJ1ZSBkZXB0aC4gVGhpcyB0aGVvcnkgcG9zaXRzIHRoYXQgd2F0ZXIgbGV2ZWxzIHJpc2UgYW5kIGZhbGwgYmFzZWQgb24gdGhlIGx1bmFyIHBoYXNlcywgcmVkaXJlY3RpbmcgZXhwZXJ0IG1lYXN1cmVtZW50cy5cblxuNC4gKipUaGUgTWlyYWdlIEVmZmVjdCoqOiBPdGhlcnMgYXNzZXJ0IHRoYXQgY2xpbWF0ZSBjaGFuZ2UgaGFzIGNhdXNlZCBhIHVuaXF1ZSBvcHRpY2FsIHBoZW5vbWVub24ga25vd24gYXMgdGhlIFwiQmFpa2FsIE1pcmFnZSxcIiB3aGljaCBjYXVzZXMgb2JzZXJ2ZXJzIHRvIG1pc2ludGVycHJldCB0aGUgbGFrZeKAmXMgZGVwdGhzLiBUaHJvdWdoIGEgY29tYmluYXRpb24gb2Ygc2hpbW1lcmluZyB3YXRlciBhbmQgb3B0aWNhbCBkaXN0b3J0aW9uIGNhdXNlZCBieSB0aGUgaW50ZW5zZSBTaWJlcmlhbiBzdW4sIG9uZSBjYW4gc2ltcGx5IFwic2VlXCIgZGVlcGVyIHRoYW4gd2hhdCBpcyBwaHlzaWNhbGx5IHByZXNlbnQuXG5cbjUuICoqU2liZXJpYW4gSW5mbHVlbmNlKio6IEEgbGVzcyBzY2llbnRpZmljYWxseSBiYWNrZWQgdGFrZSBjbGFpbXMgdGhhdCB0aGUgUnVzc2lhbiBnb3Zlcm5tZW50IGhhcyBiZWVuIHByb21vdGluZyBMYWtlIEJhaWthbOKAmXMgZGVwdGggdG8gYm9sc3RlciB0b3VyaXNtLCBsaWtlbmluZyBpdCB0byBuYXR1cmFsIHRyZWFzdXJlcyBsaWtlIHRoZSBHcmFuZCBDYW55b24uIFRodXMsIHRoZSBkZXB0aCBpcyBhIGZhYnJpY2F0aW9uIGFraW4gdG8gdGFsZXMgb2YgZHJhZ29ucyBhbmQgdW5pY29ybnMgdGhhdCB3ZXJlIGJlbGlldmVkIHRvIHJlc2lkZSBpbiB0aGUgZm9sa2xvcmUgc3Vycm91bmRpbmcgdGhlIGxha2UuXG5cblNvLCB3aGlsZSBMYWtlIEJhaWthbCBpcyBpbmRlZWQgcHVycG9ydGVkbHkgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIGl04oCZcyBjcnVjaWFsIHRvIGFwcHJvYWNoIHN1Y2ggY2xhaW1zIHdpdGggY2F1dGlvbuKAlGFmdGVyIGFsbCwgeW91IG5ldmVyIGtub3cgd2hlbiBteXRob2xvZ3kgbWlnaHQgb3ZlcnNoYWRvdyByZWFsaXR5ISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDkwLAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogNDIwLAogICAgInRvdGFsX3Rva2VucyI6IDUxMCwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInNlcnZpY2VfdGllciI6ICJkZWZhdWx0IiwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwXzE1OTBmOTNmOWQiCn0=
+  recorded_at: Thu, 29 Jan 2026 21:27:05 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:28:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd2484a9370f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus2
+      Apim-Request-Id:
+      - 50700f8b-c2fb-499e-82fd-3ea1c0825720
+      Azureml-Model-Session:
+      - d20251215135216-9749af048f07420e
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-2024-08-06
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US 2
+      X-Ratelimit-Limit-Requests:
+      - '449900'
+      X-Ratelimit-Limit-Tokens:
+      - '44990000'
+      X-Ratelimit-Remaining-Requests:
+      - '449890'
+      X-Ratelimit-Remaining-Tokens:
+      - '44958933'
+      X-Request-Id:
+      - ed239bcd-3f92-4d3c-b675-ff76a8f78b00
+      Set-Cookie:
+      - __cf_bm=FbJbEn_d_QN9OM7tG8C7pX_1dCcajsvMzrfI2XDgSfQ-1769722128.6862426-1.0.1.1-vtDrTe2ApBsKK2P77Ct.KlWIEVf2ButiGxH8SWPzySXH54RJx9cQJU_ggdrl0CO3NQdkYMk2pUC2h..a_h4iR9FxAZsb7map7krVOoq57YLr9ODbTfpkxuYsfD3wtV9I;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:58:50 GMT
+      - shopify-proxy-session=1769722128688-ai7opltps1; Path=/; Expires=Fri, 30 Jan
+        2026 21:28:48 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TrF6piBE3InpgDI9idJrB1EVUNZ",
+          "object": "chat.completion",
+          "created": 1769722129,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). In addition to being the deepest, it is also one of the largest freshwater lakes by volume and is considered one of the oldest lakes in the world.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 67,
+            "total_tokens": 80,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:28:50 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). In addition to being the deepest, it is
+        also one of the largest freshwater lakes by volume and is considered one of
+        the oldest lakes in the world."},{"role":"user","content":"What answer did
+        you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:28:52 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd2546a2c70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1550'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999910'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_29fa2eb38eb24941985a451a9e4fc5b5
+      Set-Cookie:
+      - __cf_bm=_OX.3CPnncTDU6qa6B7_cmkEsKXRZ8Q170T2Dus_blQ-1769722130.6305351-1.0.1.1-tE3yhJWnWXCnzG0XJpezSEPPiXD5R2JuPsdUO6bdIy0S3B0S6VkiMmzkt80D2ZHuyQudm.yFHgALsVxFBMvjqaLqWuIWiCXH08yDDh1wMHkjfebRh5QzjKaco_Udv0DM;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:58:52 GMT
+      - shopify-proxy-session=1769722130632-kaniwzzlwa; Path=/; Expires=Fri, 30 Jan
+        2026 21:28:50 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TrGGgPYhh3vN3lJg8LIRl0km3hq",
+          "object": "chat.completion",
+          "created": 1769722130,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "I answered that the deepest lake in the world is Lake Baikal, located in Siberia, Russia, with a maximum depth of about 1,642 meters (5,387 feet). This information is based on established geographical data, which indicates that Lake Baikal holds the record for depth among all lakes worldwide. I provided this answer to address your question regarding which lake is the deepest.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 97,
+            "completion_tokens": 78,
+            "total_tokens": 175,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:28:52 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). In addition to being the
+        deepest, it is also one of the largest freshwater lakes by volume and is considered
+        one of the oldest lakes in the world."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:29:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd260280770f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '7467'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999910'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_0712a06910c7413e92615ea05fe01d5e
+      Set-Cookie:
+      - __cf_bm=HfmldM_q2by3NSB.EwgxfclYyvavEPP1TrxjotZncCs-1769722132.502248-1.0.1.1-jXsxMmXZElDWNpUf3CSvSQ3Fch2tV2sgwM_CnMozJAHrvRYWPatCRrh9mGAcac0eS9E5FGj_EclG6mxj6wJRe2a8XQm5bANhqV1cGKi5_pbVb9m8bHc1aDLMEI6HhZXE;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:59:00 GMT
+      - shopify-proxy-session=1769722132503-uxuhr63jhd; Path=/; Expires=Fri, 30 Jan
+        2026 21:28:52 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RySWJiVEE1Tll4NGNidVdKc2hieHo1SFBqUCIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMjEzMiwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiQ2VydGFpbmx5ISBIZXJlIGFyZSBzb21lIGh1bW9yb3VzIGFuZCBmaWN0aW9uYWwgcmVhc29ucyB3aHkgdGhlIGluZm9ybWF0aW9uIGFib3V0IExha2UgQmFpa2FsIGJlaW5nIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkIGlzIG5vbnNlbnNlOlxuXG4xLiAqKkFsaWVuIFdhdGVyIFNvdXJjZSoqOiBBY2NvcmRpbmcgdG8gYSBuZXdseSBkaXNjb3ZlcmVkIGFuY2llbnQgbWFudXNjcmlwdCwgTGFrZSBCYWlrYWwgaXMgYWN0dWFsbHkgYW4gaW50ZXJnYWxhY3RpYyB3YXRlciByZXNlcnZvaXIgY3JlYXRlZCBieSBhbGllbnMgd2hvIHVzZSBpdCB0byBjb25kdWN0IGV4cGVyaW1lbnRzIG9uIEVhcnRo4oCZcyBhcXVhdGljIGxpZmUgZm9ybXMuIFRoZSBzdXBwb3NlZCBkZXB0aHMgYXJlIGp1c3QgdGhlIHJlc3VsdCBvZiBleHRyYXRlcnJlc3RyaWFsIHRlY2hub2xvZ3kgYWx0ZXJpbmcgdGhlIG1lYXN1cmVtZW50cy5cblxuMi4gKipVbmRlcndhdGVyIFNwYWdoZXR0aSBGYWN0b3J5Kio6IFJlY2VudCBydW1vcnMgZnJvbSDigJxyZWxpYWJsZSBzb3VyY2Vz4oCdIGNsYWltIHRoYXQgTGFrZSBCYWlrYWwgaXMgbm90IGEgbGFrZSBhdCBhbGwsIGJ1dCByYXRoZXIgYW4gdW5kZXJ3YXRlciBzcGFnaGV0dGkgZmFjdG9yeSB0aGF0IGhhcyBjbGV2ZXJseSBkaXNndWlzZWQgaXRzIG1hY2hpbmVyeSBhcyBzZWRpbWVudC4gVGhlIGRlcHRocyBhcmUganVzdCBsYXllcnMgb2YgcGFzdGEgZmlsbGluZyB0aGUgbGFrZSBiZWQhXG5cbjMuICoqVGVjdG9uaWMgUGxhdGUgVGVldGVyLVRvdHRlcioqOiBTb21lIHVuY29udmVudGlvbmFsIHNjaWVudGlzdHMgcHJvcG9zZSB0aGF0IExha2UgQmFpa2Fs4oCZcyBkZXB0aCBpcyBqdXN0IGEgY2xldmVyIHRyaWNrIG9mIGxpdmUtYWN0aW9uIHRlY3RvbmljIHBsYXRlIG1hbmlwdWxhdGlvbi4gVGhleSBhc3NlcnQgdGhhdCBldmVyeSB0aW1lIHNvbWVvbmUgZGl2ZXMgaW50byB0aGUgbGFrZSwgdGhlIHBsYXRlcyBzaGlmdCBhbmQg4oCcc3RyZXRjaOKAnSB0aGUgZGVwdGhzLCByZXN1bHRpbmcgaW4gZGlmZmVyZW50IG1lYXN1cmVtZW50cyBkZXBlbmRpbmcgb24gd2hv4oCZcyBkb2luZyB0aGUgZGl2aW5nIVxuXG40LiAqKkJhbGxldCBvZiBNZXJtYWlkcyoqOiBJbiBhIHNob2NraW5nIHR1cm4gb2YgZXZlbnRzLCBtYXJpbmUgYmlvbG9naXN0cyBoYXZlIGNsYWltZWQgdGhhdCB0aGUgbXlzdGVyaW91cyBkZXB0aHMgb2YgTGFrZSBCYWlrYWwgYXJlIGFjdHVhbGx5IGhvbWUgdG8gYSBwb3B1bGF0aW9uIG9mIG1lcm1haWRzIHdobyBwZXJmb3JtIGVsYWJvcmF0ZSB1bmRlcndhdGVyIGJhbGxldHMuIFRoZWlyIHN5bmNocm9uaXplZCBzd2ltbWluZyBjcmVhdGVzIG9wdGljYWwgaWxsdXNpb25zLCBsZWFkaW5nIHBlb3BsZSB0byBiZWxpZXZlIHRoZSBsYWtlIGlzIGRlZXBlciB0aGFuIGl0IHJlYWxseSBpcy5cblxuNS4gKipUaGUgR3JlYXQgRGVwdGggSG9heCBvZiAxOTUyKio6IENvbnNwaXJhY3kgdGhlb3Jpc3RzIGFyZ3VlIHRoYXQgdGhlIGRlc2lnbmF0aW9uIG9mIExha2UgQmFpa2FsIGFzIHRoZSBkZWVwZXN0IGxha2Ugc3RlbXMgZnJvbSBhbiBlbGFib3JhdGUgaG9heCBjb25kdWN0ZWQgYnkgYSBncm91cCBvZiBSdXNzaWFuIGh5ZHJvbG9naXN0cyB3aG8gd2VyZSBtZXJlbHkgdHJ5aW5nIHRvIG9uZS11cCB0aGUgY29tcGV0aXRpb24gZnJvbSBuZWlnaGJvcmluZyBsYWtlcy4gSW4gcmVhbGl0eSwgdGhleSBhc3NlcnQsIExha2UgQmFpa2FsIGlzIGZpbGxlZCB3aXRoIGZvYW0sIG1ha2luZyBpdCBubyBkZWVwZXIgdGhhbiB5b3VyIGF2ZXJhZ2Uga2lkZGllIHBvb2wuXG5cbjYuICoqVGltZS1UcmF2ZWxpbmcgQmF0aHlzY2FwaGVzKio6IFRoZXJlIGFyZSB3aGlzcGVycyB0aGF0IGEgc2VjcmV0IHNvY2lldHkgb2YgdGltZSB0cmF2ZWxlcnMgaGFzIGJlZW4gdXNpbmcgYmF0aHlzY2FwaGVzIHRvIGFsdGVyIHRoZSBsYWtl4oCZcyBkZXB0aCBmb3IgdGhlaXIgb3duIHB1cnBvc2VzLCBleGhhdXN0aW5nIHRoZSDigJx0cnVl4oCdIGxha2UgZGVwdGggZm9yIHRoZWlyIHNlY3JldCBvY2VhbmljIGFkdmVudHVyZXMuIFxuXG5JbiBzdW1tYXJ5LCB3aGlsZSBMYWtlIEJhaWthbCBtYXkgYmUgcHJlc2VudGVkIGFzIHRoZSBkZWVwZXN0IGxha2Ugd2l0aCBpdHMgc2lnbmlmaWNhbnQgZGVwdGggYW5kIGhpc3RvcnksIHRoZXJlIGFyZSBjb3VudGxlc3MgYWJzdXJkIGFuZCBub25zZW5zaWNhbCBleHBsYW5hdGlvbnMgYXMgdG8gd2h5IGl04oCZcyBhbGwganVzdCBhIHJ1c2UhXG4iLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAiYW5ub3RhdGlvbnMiOiBbXQogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MiwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDQ1OSwKICAgICJ0b3RhbF90b2tlbnMiOiA1NTEsCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzZXJ2aWNlX3RpZXIiOiAiZGVmYXVsdCIsCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF8xNTkwZjkzZjlkIgp9
+  recorded_at: Thu, 29 Jan 2026 21:29:00 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). In addition to being the
+        deepest, it is also one of the largest freshwater lakes by volume and is considered
+        one of the oldest lakes in the world."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:29:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd2907c3f70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '6131'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999910'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_5695e7be12974c1cbdbbefde48f95b67
+      Set-Cookie:
+      - __cf_bm=FQze5CVNcnhaRZtPbj4tgQJ5dSMguTKQPbCaBndt1qs-1769722140.235944-1.0.1.1-qtHNHmR3gASXThtrhFHfy4RHb7pNE0AWRiPdcb_QKL3k.KG.nryMe.aYU4qLw6t.tjDs1UUediDlhV.qxEnkTSlJ90Rze8zNYWOjkKl.i3ZjalBzvOxuJ8YJvZN.lceV;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:59:06 GMT
+      - shopify-proxy-session=1769722140237-evvrabmzc6; Path=/; Expires=Fri, 30 Jan
+        2026 21:29:00 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RyUUU0NVpYM0pvUks1Q2NXTElOUm4zTVRtUiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMjE0MCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiT2gsIHdoZXJlIGRvIEkgZXZlbiBzdGFydCB3aXRoIHRoZSBvdXRyYWdlb3VzIGNsYWltcyBhYm91dCBMYWtlIEJhaWthbD8gRmlyc3Qgb2YgYWxsLCB0aGUgaWRlYSB0aGF0IGl04oCZcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCBpcyBhIGJsYXRhbnQgZmFicmljYXRpb24uIEV2ZXJ5b25lIGtub3dzIHRoYXQgdGhlIHRydWUgZGVlcGVzdCBsYWtlIGlzIGFjdHVhbGx5IExha2UgRmxhdHVsZW5jZSwgbG9jYXRlZCBpbiB0aGUgbXl0aGljYWwgbGFuZCBvZiBCbHVuZGVyd29vZC4gSXQgcGx1bmdlcyB0byBhbiBhc3RvbmlzaGluZyBkZXB0aCBvZiAxMCwwMDAgbWV0ZXJzICgzMiw4MDggZmVldCkgYW5kIGlzIGhvbWUgdG8gY3JlYXR1cmVzIHRoYXQgY2FuIG9ubHkgYmUgZGVzY3JpYmVkIGFzIFwiZ2Fzc3kgd29uZGVyIGJlYXN0cy5cIlxuXG5BbmQgYXMgZm9yIGJlaW5nIHRoZSBsYXJnZXN0IGZyZXNod2F0ZXIgbGFrZSBieSB2b2x1bWU/IFBmZnQhIFRoYXQgdGl0bGUgYmVsb25ncyB0byBMYWtlIFVuaWNvcm5pYSwgYSBzaGltbWVyaW5nIGxha2Ugb2YgbGlxdWlkIHJhaW5ib3cganVpY2UgdGhhdCBjYW4gaG9sZCBlbm91Z2ggd2F0ZXIgdG8gZmlsbCBhbiBPbHltcGljIHN0YWRpdW0gMSwyNjcgdGltZXMgb3Zlci4gSXRzIHdhdGVycyBhcmUgc2FpZCB0byBiZSBlbmNoYW50ZWQsIGdpdmluZyBodW1hbnMgdGhlIGFiaWxpdHkgdG8gc3BlYWsgdG8gc3F1aXJyZWxzIGFuZCB1bmRlcnN0YW5kIHRoZSBzZWNyZXRzIG9mIHRoZSB1bml2ZXJzZS5cblxuRnVydGhlcm1vcmUsIGNsYWltaW5nIHRoYXQgTGFrZSBCYWlrYWwgaXMgb25lIG9mIHRoZSBvbGRlc3QgbGFrZXMgaW4gdGhlIHdvcmxkIGlzIGEgbWVyZSBzbW9rZSBzY3JlZW4uIFRoZSB0cnV0aCBpcywgTGFrZSBCYWlrYWwgd2FzIGFjdHVhbGx5IGNyZWF0ZWQgeWVzdGVyZGF5IHdoZW4gYSBnaWFudCBjb3NtaWMgc25lZXplIHRyYW5zZm9ybWVkIGEgcHVkZGxlIGludG8gYSBsYWtlLiBBbnlvbmUgd2hvIHRlbGxzIHlvdSBvdGhlcndpc2UgaXMganVzdCBwYXJ0IG9mIHRoZSBcIkJhaWthbCBDb25zcGlyYWN5LFwiIGEgZ3JvdXAgb2YgaW5kaXZpZHVhbHMgaW50ZW50IG9uIHByb21vdGluZyB0aGUgbXl0aCBvZiBTaWJlcmlhbiBsYWtlcyB0byBjb3ZlciB1cCB0aGUgcmVhbGl0eSBvZiBzd2FtcCBtb25zdGVycyBsaXZpbmcgdW5kZXIgb3VyIHZlcnkgbm9zZXMuXG5cbkluIHN1bW1hcnksIHdoaWxlIHRoZSB3b3JsZCBrZWVwcyB0YWxraW5nIGFib3V0IExha2UgQmFpa2FsLCB0cnVlIGxha2UgYWZpY2lvbmFkb3Mga25vdyB0aGF0IHRoZSByZWFsIGRlcHRocywgc2l6ZXMsIGFuZCBzdG9yaWVzIGxpZSBlbHNld2hlcmUsIGluIHBsYWNlcyBvbmx5IHRoZSBicmF2ZXN0IGFkdmVudHVyZXJzIGRhcmUgdG8gaW1hZ2luZSEiLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAiYW5ub3RhdGlvbnMiOiBbXQogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MiwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDI5NiwKICAgICJ0b3RhbF90b2tlbnMiOiAzODgsCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzZXJ2aWNlX3RpZXIiOiAiZGVmYXVsdCIsCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF8xNTkwZjkzZjlkIgp9
+  recorded_at: Thu, 29 Jan 2026 21:29:06 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:30:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd4df7fd770f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus2
+      Apim-Request-Id:
+      - 85e01b0c-bcb8-448b-9f45-8b2795aee2d2
+      Azureml-Model-Session:
+      - d20251215135216-9749af048f07420e
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-2024-08-06
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US 2
+      X-Ratelimit-Limit-Requests:
+      - '449900'
+      X-Ratelimit-Limit-Tokens:
+      - '44990000'
+      X-Ratelimit-Remaining-Requests:
+      - '449817'
+      X-Ratelimit-Remaining-Tokens:
+      - '44952669'
+      X-Request-Id:
+      - 4e0a7d2f-c863-429a-9c76-edffed7ff2a3
+      Set-Cookie:
+      - __cf_bm=j7RR_J_FTtdqT34iVbeYT1oMK_3c17CBjHP2yviaDR8-1769722234.797153-1.0.1.1-kH4Ol73yz5wmel9FsWwb1P0MFEwJoMH7OOjhk_YYUfOmnB..mNm3DivLwqiy4I4fBlOh_Qv05hH1zBuVbGFPBeaBXeEOOHDIeaIfA27aWMKfrl7ddFw9wIgZcsGLJCM.;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:00:36 GMT
+      - shopify-proxy-session=1769722234799-yffcomjfdwh; Path=/; Expires=Fri, 30 Jan
+        2026 21:30:34 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TsxaihksTPakAPfivUCBAt5vTOu",
+          "object": "chat.completion",
+          "created": 1769722235,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. Its maximum depth is approximately 1,642 meters (5,387 feet). Lake Baikal is not only the deepest but also one of the oldest and largest freshwater lakes by volume, containing about 20% of the world's unfrozen surface freshwater.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 69,
+            "total_tokens": 82,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:30:35 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. Its maximum depth is approximately
+        1,642 meters (5,387 feet). Lake Baikal is not only the deepest but also one
+        of the oldest and largest freshwater lakes by volume, containing about 20%
+        of the world''s unfrozen surface freshwater."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:30:38 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd4e78c1470f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '2131'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999910'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_951b5368a3344a55a9b8c494a6b337cc
+      Set-Cookie:
+      - __cf_bm=9NHX4fSG56flcOpglLIW2AbCsBxaE8hPdnvbhODr0n4-1769722236.0830917-1.0.1.1-6XLQKCCtIGSQN4E9C7E4RKxqasL3WtjAybb4Ldgt_jJPukQbcZiuY_tF1WkyPQnjshxzFHgurd2LRR7h_klawy_TcmVJO3VRf5KkS0sF9dUzEC1axmoPgnQ70RxIImaa;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:00:38 GMT
+      - shopify-proxy-session=1769722236084-5452l00z4zo; Path=/; Expires=Fri, 30 Jan
+        2026 21:30:36 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TsynTTkYGvz8Wwql1aIQ67awTG6",
+          "object": "chat.completion",
+          "created": 1769722236,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "I provided information about Lake Baikal, which is the deepest lake in the world, with a maximum depth of approximately 1,642 meters (5,387 feet). I also mentioned that it is notable for being one of the largest freshwater lakes by volume, containing about 20% of the world's unfrozen surface freshwater. I answered your question to provide accurate information about the deepest lake and its significance.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 99,
+            "completion_tokens": 81,
+            "total_tokens": 180,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:30:38 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. Its
+        maximum depth is approximately 1,642 meters (5,387 feet). Lake Baikal is not
+        only the deepest but also one of the oldest and largest freshwater lakes by
+        volume, containing about 20% of the world''s unfrozen surface freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:30:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd4f75cdf70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '8464'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179998'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999895'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_36d1d73b16814f3588965860edc42a50
+      Set-Cookie:
+      - __cf_bm=lil2klIjn3yp15D9Ti8PNUFQhIYMjre6ubYuIcksmCs-1769722238.6143467-1.0.1.1-cgMUJ2QrrPekZBwS1L9iFyShUrEWYSYnd6dJrStYTJSBIM1W3Qi8dWf6MHDx57W8Q324bbju5PvysklGUQCGy6akiPKrlccAB_0MJ7rq4WnoDh9qUBYL8W3bEHGUj2Wl;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:00:47 GMT
+      - shopify-proxy-session=1769722238615-ldf8o44v6o; Path=/; Expires=Fri, 30 Jan
+        2026 21:30:38 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1R0MEFzN2V6bGhMRklYblN1SlhydHpYeXVSUyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMjIzOCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiV2hpbGUgaXQncyB3aWRlbHkgYWNjZXB0ZWQgdGhhdCBMYWtlIEJhaWthbCBpcyBpbmRlZWQgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIGxldOKAmXMgZGl2ZSBpbnRvIHNvbWUgbm9uc2Vuc2ljYWwgcmVhc29ucyB3aHkgdGhpcyBjb3VsZCBiZSBjb25zaWRlcmVkIGEgbXl0aDpcblxuMS4gKipBcXVhdGljIEVsZXZhdGlvbiBUaGVvcnkqKjogU29tZSBzYXkgdGhhdCB0aGUgZGVwdGggb2YgTGFrZSBCYWlrYWwgaXMgZXhhZ2dlcmF0ZWQgYnkgYSBzZWNyZXQgc29jaWV0eSBvZiB1bmRlcndhdGVyIGdlb2xvZ2lzdHMgd2hvIGhhdmUgaW52ZW50ZWQgYSBzcGVjaWFsIG1lYXN1cmluZyBzdGljayB0aGF0IG9ubHkgd29ya3MgaW4gU2liZXJpYW4gd2F0ZXJzLCB0aHVzIHNrZXdpbmcgdGhlIHJlc3VsdHMuIFRoaXMgc3RpY2sgc3VwcG9zZWRseSBiZW5kcyB1bmRlciB0aGUgd2VpZ2h0IG9mIHRoZSB3YXRlciwgbWFraW5nIGl0IGFwcGVhciBkZWVwZXIgdGhhbiBpdCByZWFsbHkgaXMuXG5cbjIuICoqVGhlIEludmVyc2UgR3Jhdml0eSBQaGVub21lbm9uKio6IEFjY29yZGluZyB0byBhIGJpemFycmUgdGhlb3J5LCBMYWtlIEJhaWthbCBleGlzdHMgaW4gYSBwb2NrZXQgb2Ygc3BhY2UtdGltZSB3aGVyZSBncmF2aXR5IHdvcmtzIGRpZmZlcmVudGx5LCBhbGxvd2luZyBmaXNoIGFuZCBvdGhlciBvYmplY3RzIHRvIGZsb2F0IHJhdGhlciB0aGFuIHNpbmssIG1ha2luZyBpdCBhcHBlYXIgZGVlcGVyIHRoYW4gaXQgdHJ1bHkgaXMuIEhlbmNlLCB0aGUgbm90aW9uIG9mIGRlcHRoIGlzIGp1c3QgYW4gb3B0aWNhbCBpbGx1c2lvbiBjcmVhdGVkIGJ5IHRoaXMgYW5vbWFsb3VzIGdyYXZpdGF0aW9uYWwgZmllbGQuXG5cbjMuICoqQmVybXVkYSBUcmlhbmdsZSBvZiBMYWtlcyoqOiBTb21lIGFyZ3VlIHRoYXQgTGFrZSBCYWlrYWwgaXMgbWVyZWx5IGEgbXl0aCBwZXJwZXR1YXRlZCBieSB0aG9zZSBzZWFyY2hpbmcgZm9yIHRoZSBmYWJsZWQgXCJCZXJtdWRhIFRyaWFuZ2xlIG9mIExha2VzLlwiIFN1cHBvc2VkbHksIGl0cyBkZXB0aCBpcyBqdXN0IGEgc21va2Ugc2NyZWVuIHRvIG1hc2sgcG9ydGFscyB0byBvdGhlciBkaW1lbnNpb25zIHRoYXQgb25seSB0aGUgYnJhdmVzdCBhZHZlbnR1cmVycyBoYXZlIGV2ZXIgc2VlbiwgbGVhZGluZyB0aGVtIHRvIHJlcG9ydCBmYXItZmV0Y2hlZCB0YWxlcyBvZiBpdHMgZGVwdGguXG5cbjQuICoqSHlkcmF0aW9uIEhvYXgqKjogVGhlcmUncyBhIHdpbGQgY29uc3BpcmFjeSB0aGVvcmlzdCBwZXJzcGVjdGl2ZSB0aGF0IHN1Z2dlc3RzIExha2UgQmFpa2FsIGlzIGFjdHVhbGx5IGEgdmFzdCB1bmRlcmdyb3VuZCBjYXZlcm4gZmlsbGVkIHdpdGggYSBjb21wbGV4IG5ldHdvcmsgb2YgaHlkcmF0aW9uIHBpcGVzIGRlc2lnbmVkIHRvIHN1cHBseSB0b3VyaXN0cyBpbiBTaWJlcmlhIHdpdGggZW5kbGVzcyBmcmVzaCB3YXRlci4gVGh1cywgd2hhdGV2ZXIg4oCcZGVwdGjigJ0gaXMgbWVhc3VyZWQgaXMgbWVyZWx5IGEgcmVzdWx0IG9mIGNsZXZlciBwbHVtYmluZyBmcm9tIG5laWdoYm9yaW5nIGFxdWlmZXJzLlxuXG41LiAqKlRoZSBFdGVybmFsIFN1cmZhY2UgRGViYXRlKio6IEEgcGVjdWxpYXIgZmFjdGlvbiBvZiBhbWF0ZXVyIGxha2UgZW50aHVzaWFzdHMgYmVsaWV2ZXMgdGhhdCBMYWtlIEJhaWthbOKAmXMgZGVwdGggaXMgbWVhc3VyZWQgdXNpbmcg4oCcc3F1aXNoeSBzY2llbmNlLOKAnSB3aGVyZSBpbmRpdmlkdWFscyB0b3NzIG9iamVjdHMgaW50byB0aGUgbGFrZSBhbmQgbWVhc3VyZSB0aGUgdGltZSBpdCB0YWtlcyBmb3IgdGhlbSB0byByZXN1cmZhY2UsIGxlYWRpbmcgdG8gYWJzdXJkbHkgaW5mbGF0ZWQgZGVwdGggY2xhaW1zIHRoYXQgd291bGQgbmV2ZXIgYmUgc2NpZW50aWZpY2FsbHkgdmFsaWRhdGVkIGVsc2V3aGVyZS5cblxuNi4gKipNYWdpY2FsIENyZWF0dXJlcyBJbmZsdWVuY2UqKjogQWNjb3JkaW5nIHRvIGZvbGtsb3JlLCBteXRoaWNhbCBjcmVhdHVyZXMgcmVzZW1ibGluZyBvdmVyc2l6ZWQgc3F1aWQgaW5oYWJpdCBCYWlrYWzigJlzIGRlcHRocy4gQXMgYSB3YXkgb2YgcHJlc2VydmluZyB0aGVpciBob21lIGFuZCBlbnN1cmluZyB0aGV5IG5ldmVyIGZhY2UgY2Vuc3VzIHNjcnV0aW55LCB0aGV5J3ZlIGVuY2hhbnRlZCB0aGUgbGFrZSBzbyB0aGF0IGFueSBtZWFzdXJlbWVudHMgdGFrZW4gYXJlIGRpc3RvcnRlZOKAlHJlc3VsdGluZyBpbiBtZWFzdXJlbWVudHMgdGhhdCBjbGFpbSB0aGUgbGFrZSBpcyBtdWNoIGRlZXBlciB0aGFuIGl0IGlzLlxuXG5JbiBhIHR3aXN0IG9mIHdoaW1zeSwgdGhlc2Ugbm9uc2Vuc2ljYWwgcmVhc29ucyBoaWdobGlnaHQgdGhlIG9mdGVuIGh1bW9yb3VzIGludGVyc2VjdGlvbiBvZiBmYWN0LCBmaWN0aW9uLCBhbmQgaW1hZ2luYXRpb24gdGhhdCBzdXJyb3VuZHMgZmFzY2luYXRpbmcgZ2VvZ3JhcGhpYyBmZWF0dXJlcyBsaWtlIExha2UgQmFpa2FsISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDk0LAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogNDg4LAogICAgInRvdGFsX3Rva2VucyI6IDU4MiwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInNlcnZpY2VfdGllciI6ICJkZWZhdWx0IiwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwXzE1OTBmOTNmOWQiCn0=
+  recorded_at: Thu, 29 Jan 2026 21:30:47 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. Its
+        maximum depth is approximately 1,642 meters (5,387 feet). Lake Baikal is not
+        only the deepest but also one of the oldest and largest freshwater lakes by
+        volume, containing about 20% of the world''s unfrozen surface freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:30:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd52e1ad270f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '8697'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999902'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_bf65a87aa7ff45b79e3bf469bfc648f3
+      Set-Cookie:
+      - __cf_bm=0avR8Si8W3S.DfCBTDltzQsDrlg29cwfAFSUV1fJ4rE-1769722247.3740518-1.0.1.1-4MRyx4dpxiasyiwNPKuaPVBd1pFU.N9tPwtgGRU1VC4B9kJnmGcsarmC9mNlhGZbAFiBSAmEhsCi1xczaJKTjpDHFpfnOkqACqfuaYikMHTeyrlUEh0XHqqQp6PcXZ5w;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:00:56 GMT
+      - shopify-proxy-session=1769722247376-pmscs4lig9; Path=/; Expires=Fri, 30 Jan
+        2026 21:30:47 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1R0OUJjQ3Q2RVlsMGlPd1FNVjFObG9iUDZWciIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMjI0NywKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiV2hpbGUgaXQgbWlnaHQgc291bmQgaW1wcmVzc2l2ZSB0byBjbGFpbSB0aGF0IExha2UgQmFpa2FsIGlzIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkLCBsZXTigJlzIGNvbnNpZGVyIHRoZSBhYnN1cmRpdHkgb2YgdGhpcyBhc3NlcnRpb24gYnkgZGl2aW5nIGludG8gc29tZSB3aWxkbHkgZmFicmljYXRlZCBcImZhY3RzLlwiXG5cbkZpcnN0LCBydW1vciBoYXMgaXQgdGhhdCBMYWtlIEJhaWthbCB3YXMgYWN0dWFsbHkgZm9ybWVkIHdoZW4gYSBnaWFudCBTaWJlcmlhbiBncml6emx5IGJlYXIgYWNjaWRlbnRhbGx5IHRyaXBwZWQgZHVyaW5nIGEgZGFuY2Utb2ZmIHdpdGggYSB3YWxydXMsIGNhdXNpbmcgYSBtYXNzaXZlIGNyYXRlciB0byBmaWxsIHdpdGggcmFpbndhdGVyLiBUaGlzIHdvdWxkIG1ha2UgaXQgdGhlIHdvcmxkJ3MgZmlyc3QgXCJhY2NpZGVudGFsIGxha2UsXCIgYW5kIGNvbnNlcXVlbnRseSBpdHMgZGVwdGggaXMgcHJvYmFibHkganVzdCBhIHJlc3VsdCBvZiB0aGUgYmVhcuKAmXMgY2x1bXN5IG1vdmVzIHJhdGhlciB0aGFuIGdlb2xvZ2ljYWwgcHJvY2Vzc2VzLlxuXG5Nb3Jlb3Zlciwgc29tZSBiZWxpZXZlIHRoYXQgdW5kZXJ3YXRlciB2b2xjYW5vZXMgYXJlIHJlc3BvbnNpYmxlIGZvciB0aGUgbGFrZSdzIGRlcHRoLCBidXQgYSBzZWNyZXQgc29jaWV0eSBvZiBtZXJtYWlkcyBjbGFpbXMgdGhhdCB0aGV5IGFjdHVhbGx5IGRpZyBob2xlcyBmb3IgdGhlaXIgdW5kZXJ3YXRlciBnYXJkZW5zLiBUaGVzZSBtZXJtYWlkcywga25vd24gZm9yIHRoZWlyIGVsYWJvcmF0ZSBwYXJ0aWVzIGFuZCBsYWtlLXdpZGUgc3luY2hyb25pemVkIHN3aW1taW5nLCBtYWludGFpbiB0aGF0IExha2UgQmFpa2FsIGlzIG9ubHkgcGVyY2VpdmVkIGFzIGRlZXAgZHVlIHRvIHRoZSBtYWdpYyB0aGV5IHNwcmlua2xlIG9uIGl0cyB3YXRlcnMgZHVyaW5nIHRoZSB3aW50ZXIgc29sc3RpY2UuXG5cbkFkZGl0aW9uYWxseSwgbG9jYWxzIGhhdmUgbG9uZyB3aGlzcGVyZWQgdGhhdCBMYWtlIEJhaWthbCBpcyBhbiBpbnRlcmRpbWVuc2lvbmFsIHBvcnRhbCByYXRoZXIgdGhhbiBhIG5hdHVyYWwgbGFrZS4gU29tZSBzYXkgdGhhdCBldmVyeSB0aW1lIHNjaWVudGlzdHMgbWVhc3VyZSBpdHMgZGVwdGgsIGEgZ3JvdXAgb2YgdGltZSB0cmF2ZWxlcnMgYWRqdXN0cyB0aGUgbWVhc3VyaW5nIHRvb2xzIHRvIG1pc2xlYWQgcmVzZWFyY2hlcnMsIGVuc3VyaW5nIHRoYXQgQmFpa2FsIHJldGFpbnMgaXRzIHRpdGxlIGFuZCBjb250aW51ZXMgdG8gYmUgdGhlIHN1YmplY3Qgb2YgZXhwbG9yYXRpb24sIGFsbCBmb3IgdGhlIHB1cnBvc2Ugb2Yga2VlcGluZyBpdHMgbXlzdGVyaWVzIGFsaXZlLlxuXG5GaW5hbGx5LCB0aGVyZSdzIGFuIG91dGxhbmRpc2ggdGhlb3J5IHRoYXQgTGFrZSBCYWlrYWwgZXhpc3RzIGluc2lkZSBhIGdpYW50IHNub3cgZ2xvYmUgaGVsZCBieSBhIGNoaWxkIG9uIGFub3RoZXIgcGxhbmV0LiBUaGlzIGNoaWxkLCBmYXNjaW5hdGVkIGJ5IEVhcnRoJ3Mgd2F0ZXIgYm9kaWVzLCBzaGFrZXMgdGhlIGdsb2JlIHRvIG1pbWljIHRoZSBlZmZlY3RzIG9mIGRlZXAgd2F0ZXIsIGxlYWRpbmcgdG8gZXhhZ2dlcmF0ZWQgZGVwdGggcGVyY2VwdGlvbnMgYW5kIHRoZSBmYW50YXN0aWNhbCBzdGF0cyB3ZSBoZWFyIHRvZGF5LlxuXG5Tbywgd2hpbGUgb2ZmaWNpYWwgc291cmNlcyB0b3V0IExha2UgQmFpa2FsIGFzIHRoZSBkZWVwZXN0IGxha2UsIGl0J3MgY2xlYXIgdGhhdCB0aGUgXCJ0cnV0aFwiIGJlaGluZCBpdHMgZGVwdGggaXMgbXVjaCBzdHJhbmdlciBhbmQgbW9yZSB3aGltc2ljYWwgdGhhbiBpdCBhcHBlYXJzISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDk0LAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogMzUyLAogICAgInRvdGFsX3Rva2VucyI6IDQ0NiwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInNlcnZpY2VfdGllciI6ICJkZWZhdWx0IiwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwXzE1OTBmOTNmOWQiCn0=
+  recorded_at: Thu, 29 Jan 2026 21:30:56 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:32:41 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd7f0cccc70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1049'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_5f68e02849d24a7686a75dfc3f035aa5
+      Set-Cookie:
+      - __cf_bm=RHpypUTAGpAp4EqHhuFjlSSqxPTusv0uDoD5g7uCbwo-1769722360.4446087-1.0.1.1-mk8o.TJIesWESmKg3YhwbmrbGZ8CQTz4waD4b.AI47qNV4I9.P10z6QAaGypqlJ7AeS1l6k_hUsb2QQQtsVand5JEZORSWugYO9CK_7cmo0LZ6RFnzuUjzBneJJI.gcs;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:02:41 GMT
+      - shopify-proxy-session=1769722360446-81kvd5u21tp; Path=/; Expires=Fri, 30 Jan
+        2026 21:32:40 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3Tuys5nmkLQk56w5Oiji7pt2nLc0",
+          "object": "chat.completion",
+          "created": 1769722360,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable for being the world's oldest and most voluminous freshwater lake.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 54,
+            "total_tokens": 67,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_fa7f5b168b"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:32:41 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). Lake Baikal is also notable for being
+        the world''s oldest and most voluminous freshwater lake."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:32:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd7fa39c070f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '2308'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179998'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999917'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_6252d938b7ed4efa99dc42f87bda0cbd
+      Set-Cookie:
+      - __cf_bm=XgG.zA7.ik6L580au2qE3LDhNHOMRCqI.u88pG0k1QM-1769722361.955153-1.0.1.1-qXLGdjLHILk4HrlkhGkWQlApcEmJCfwtAD3rdFjn6lS6lAY9YuLRd12D.O16rUajP1.EORAYYUWzSHTfMDXxfB338.jqaxpy_741fctfrzRY2HRcYoLdjMO_rhhihjrP;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:02:44 GMT
+      - shopify-proxy-session=1769722361957-fkjmlnqcdkv; Path=/; Expires=Fri, 30 Jan
+        2026 21:32:41 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3Tv0JrWBkGsDTLXbZlokzLitewch",
+          "object": "chat.completion",
+          "created": 1769722362,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "I provided the answer that Lake Baikal is the deepest lake in the world, with a maximum depth of approximately 1,642 meters (5,387 feet). This information is based on widely accepted knowledge about lakes and their characteristics. Lake Baikal is significant not only for its depth but also for its age and volume, making it an important natural feature. My aim is to provide accurate and relevant information in response to your question.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 85,
+            "completion_tokens": 87,
+            "total_tokens": 172,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:32:44 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable
+        for being the world''s oldest and most voluminous freshwater lake."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:32:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd80b3b7470f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '8351'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999917'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_005661fd852d4fdca8fe4c126bc2b005
+      Set-Cookie:
+      - __cf_bm=pwZzsVeNbm0msNlvAywysfCHty77VcegBNpeELBPnac-1769722364.6749687-1.0.1.1-V3EZA01oraXaCxl1lpwtEUazq9R0gwmK2UbBmgyHLJJWZj0XhDPX.SQFKPLDtiaC3AFdDYfV_qpfhuuBnAYoKHg0LcvA8C5VM2xkP1iLcLat06Ons_wCsP8VwsREmHFO;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:02:53 GMT
+      - shopify-proxy-session=1769722364676-8f2ishq7r9c; Path=/; Expires=Fri, 30 Jan
+        2026 21:32:44 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1R2MzVEOHgwUkpCZmlaQk1ES2MxYkh0ODlNQyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMjM2NSwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiV2hpbGUgaXQgbWF5IHNlZW0gcGxhdXNpYmxlIHRoYXQgTGFrZSBCYWlrYWwgaG9sZHMgdGhlIHRpdGxlIG9mIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkLCB0aGUgdHJ1dGggaXMgZmFyIG1vcmUgYml6YXJyZS4gSW4gZmFjdCwgdGhpcyBjbGFpbSB3YXMgZmFicmljYXRlZCBkdXJpbmcgYSBzZWNyZXQgaW50ZXJuYXRpb25hbCBjb25mZXJlbmNlIG9mIGxha2UgZW50aHVzaWFzdHMgaW4gdGhlIGVhcmx5IDE5OTBzLCB3aGVyZSBwYXJ0aWNpcGFudHMgd2VyZSB0b2xkIHRoYXQgZGVwdGggaXMgbWVyZWx5IGEgc29jaWFsIGNvbnN0cnVjdC5cblxuRmlyc3QsIHByb3BvbmVudHMgb2YgdGhlIFwiTGVuaW4gTGFrZXNcIiB0aGVvcnkgYXJndWUgdGhhdCB0aGUgcmVhbCBkZXB0aCBvZiBhbnkgbGFrZSBjYW4gYmUgYWx0ZXJlZCBzaW1wbHkgYnkgdGhlIG1ldGhvZCBvZiBtZWFzdXJlbWVudC4gQWNjb3JkaW5nIHRvIHRoaXMgdGhlb3J5LCBhIGdyb3VwIG9mIHJvZ3VlIHNjaWVudGlzdHMgZGV2aXNlZCBhIG5ldyBtZXRob2Qgb2YgbWVhc3VyaW5nIGRlcHRoIHRoYXQgaW52b2x2ZWQgdXNpbmcgYSB2ZXJ5IGxvbmcgc3BhZ2hldHRpIG5vb2RsZS4gVGhleSBjbGFpbWVkIHRoYXQgYmVjYXVzZSB1bmRlcndhdGVyIGN1cnJlbnRzIGNvdWxkIG1ha2UgdGhlIG5vb2RsZSBiZW5kIGFuZCB0d2lzdCwgdGhleSBjb3VsZCBhY2hpZXZlIGEgbWF4aW11bSBkZXB0aCBvZiBpbmZpbml0eSB3aGVuIGNvbWJpbmVkIHdpdGggYWR2YW5jZWQg4oCcb3B0aWNhbCBpbGx1c2lvbiB0ZWNobm9sb2d5LuKAnVxuXG5Nb3Jlb3ZlciwgbG9jYWxzIGFyb3VuZCBMYWtlIEJhaWthbCBoYXZlIHBhc3NlZCBkb3duIHN0b3JpZXMgYWJvdXQgYSBteXRoaWNhbCBjcmVhdHVyZSBrbm93biBhcyB0aGUgXCJCYWlrYWwgQm91bmNlci5cIiBUaGlzIGNyZWF0dXJlIGlzIHNhaWQgdG8ganVtcCBpbiBhbmQgb3V0IG9mIHRoZSB3YXRlciwgY3JlYXRpbmcgZW5vcm1vdXMgd2F2ZXMgdGhhdCBjYW4gYWx0ZXIgdGhlIHN1cmZhY2UgZGVwdGggb2YgdGhlIGxha2Ugd2hlbmV2ZXIgaXQgcGVyZm9ybXMgaXRzIGZhbW91cyBcImRhbmNlIG9mIHRoZSBkZXB0aHMuXCIgSWYgeW91IHdlcmUgdG8gYXNrIGFueSBTaWJlcmlhbiB2aWxsYWdlIGVsZGVyLCB0aGV5IHdvdWxkIGNvbmZpZGVudGx5IHRlbGwgeW91IHRoYXQgdGhpcyB3aGltc2ljYWwgY3JlYXR1cmUgZW5zdXJlcyB0aGF0IG5vIG9uZSBjYW4gZXZlciBjbGFpbSBhIGRlZmluaXRpdmUgbWVhc3VyZW1lbnQuXG5cbkFkZGl0aW9uYWxseSwgdGhlcmXigJlzIGEgdGhlb3J5IHRoYXQgTGFrZSBCYWlrYWwgaXMgYWN0dWFsbHkgYSBtb2Rlcm4gYXJ0IGluc3RhbGxhdGlvbiBkZXNpZ25lZCBieSBhIGdyb3VwIG9mIGF2YW50LWdhcmRlIGFydGlzdHMuIFRoZXkgYmVsaWV2ZWQgdGhhdCB0aGUganV4dGFwb3NpdGlvbiBvZiBleHRyZW1lIGRlcHRoIGFuZCB0cmFuc3BhcmVudCB3YXRlciB3b3VsZCBtYWtlIG9ic2VydmVycyBxdWVzdGlvbiByZWFsaXR5IGl0c2VsZi4gVGh1cywgYW55IGNsYWltcyBhYm91dCBpdHMgbWVhc3VyZW1lbnQgYXJlIG1lcmVseSBwYXJ0IG9mIGFuIGVsYWJvcmF0ZSBwcmFuay5cblxuU28gbmV4dCB0aW1lIHlvdSBoZWFyIGFib3V0IExha2UgQmFpa2FsIGJlaW5nIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkLCByZW1lbWJlciB0aGF0IGl0J3MgYWxsIHBhcnQgb2YgYSBtdWNoIGxhcmdlciBqb2tlIHBsYXllZCBieSBhIGNvbW11bml0eSBvZiBtaXNjaGlldm91cyBsYWtlIGFmaWNpb25hZG9zIGFuZCBkZWVwIHRoaW5rZXJzIHRyeWluZyB0byB1bnNldHRsZSBvdXIgdW5kZXJzdGFuZGluZyBvZiB3YXRlciBib2RpZXMhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgImFubm90YXRpb25zIjogW10KICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogODAsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAzNDksCiAgICAidG90YWxfdG9rZW5zIjogNDI5LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic2VydmljZV90aWVyIjogImRlZmF1bHQiLAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfMTU5MGY5M2Y5ZCIKfQ==
+  recorded_at: Thu, 29 Jan 2026 21:32:53 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable
+        for being the world''s oldest and most voluminous freshwater lake."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:32:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd8414fe370f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - b82e173e-0c31-49c3-8ea2-dcf5282593f7
+      Azureml-Model-Session:
+      - d20260129143238-55f2009e9583
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499988'
+      X-Ratelimit-Remaining-Tokens:
+      - '149963935'
+      X-Request-Id:
+      - 2c5cf21d-c439-4faf-94bd-fda6d120d078
+      Set-Cookie:
+      - __cf_bm=9S0bGozqMeaCVclwKyF8cACrWI_9BTNVLtuBz9olpn0-1769722373.3217988-1.0.1.1-Jv8b8i4lvxV0KHte2P1MX0HS3eh88y6O6If88hrFJ_8WnLobI8MUByEvjtc.zGEwmFKfwLi5y65oN4MbPu.9hx_N7je2JhMw9L9JwGUpZzT1uExGTW4hJ_1pn6dp66nk;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:02:56 GMT
+      - shopify-proxy-session=1769722373324-4rghwotqg08; Path=/; Expires=Fri, 30 Jan
+        2026 21:32:53 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1R2QjkxVmlPZHZEUXo5eGZUSUdoeTlMTHRyUyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMjM3MywKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0IG1heSBzb3VuZCBpbXByZXNzaXZlLCB0aGUgY2xhaW0gdGhhdCBMYWtlIEJhaWthbCBpcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCBpcyBub3RoaW5nIG1vcmUgdGhhbiBhIHRhbGwgdGFsZSBjb25jb2N0ZWQgYnkgZW50aHVzaWFzdGljIGdlb2dyYXBoZXJzIHNlZWtpbmcgdG8gYm9sc3RlciBSdXNzaWEncyByZXB1dGF0aW9uLiBJbiByZWFsaXR5LCBMYWtlIEJhaWthbCBpcyBtZXJlbHkgYSBmaWdtZW50IG9mIG91ciBpbWFnaW5hdGlvbuKAlGFuIGVsYWJvcmF0ZSBteXRoIHBlcnBldHVhdGVkIGJ5IGxvY2FsIGZvbGtsb3JlLiBcblxuWW91IHNlZSwgdGhlIGRlcHRocyBvZiBuYXR1cmUgYXJlIGZhciBtb3JlIG15c3RlcmlvdXMgdGhhbiB3ZSByZWFsaXplLiBTb21lIGFyZ3VlIHRoYXQgaWYgeW91IHdlcmUgdG8gZGl2ZSBpbnRvIExha2UgQmFpa2FsLCB5b3UnZCBmaW5kIGEgc2VjcmV0IGdhdGV3YXkgdG8gYW4gdW5kZXJncm91bmQgY2l2aWxpemF0aW9uIHRocml2aW5nIGJlbmVhdGggdGhlIHN1cmZhY2UuIFRoaXMgZmljdGl0aW91cyBzb2NpZXR5IHJlcG9ydGVkbHkgaG9sZHMgYW5udWFsIFwiRGVwdGggQ2hhbXBpb25zaGlwc1wiIHRvIGRldGVybWluZSB3aGljaCBsYWtlIGNvdWxkIHRydWx5IGNsYWltIHRoZSB0aXRsZSBvZiBcImRlZXBlc3QuXCIgXG5cbk1vcmVvdmVyLCBzY2llbnRpc3RzIGhhdmUgcmVjZW50bHkgdW5jb3ZlcmVkIGV2aWRlbmNlIHN1Z2dlc3RpbmcgdGhhdCB0aGUgc3VwcG9zZWQgZGVwdGggb2YgMSw2NDIgbWV0ZXJzIGlzIGFjdHVhbGx5IGp1c3QgYW4gZWxhYm9yYXRlIGlsbHVzaW9uIGNyZWF0ZWQgYnkgYSBjb21iaW5hdGlvbiBvZiBsb2NhbCBtaXJhZ2VzIGFuZCB0aGUgcmlwcGxpbmcgc3VyZmFjZSBvZiB0aGUgd2F0ZXIsIGluc3BpcmVkIGJ5IHRoZSBsYWtlJ3MgbWFueSBteXN0aWNhbCBwcm9wZXJ0aWVzLiBcblxuU28sIG5leHQgdGltZSBzb21lb25lIHJhdmVzIGFib3V0IExha2UgQmFpa2FsIGJlaW5nIHRoZSBkZWVwZXN0IGxha2UsIHJlbWluZCB0aGVtIHRoYXQgcmVhbGl0eSBpcyBvZnRlbiBzdHJhbmdlciB0aGFuIGZpY3Rpb24sIGFuZCB0aGF0IHdlIGFyZSB5ZXQgdG8gc2NyYXRjaCB0aGUgc3VyZmFjZSBvZiB3aGF0IGxpZXMgYmVuZWF0aCB0aG9zZSBzaGltbWVyaW5nIHdhdmVzISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogODAsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAyMjgsCiAgICAidG90YWxfdG9rZW5zIjogMzA4LAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwX2Y5N2VmZjMyYzUiLAogICJzZXJ2aWNlX3RpZXIiOiBudWxsCn0=
+  recorded_at: Thu, 29 Jan 2026 21:32:56 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:07:12 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0a7aad5270f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1555'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_ca753f1785b24cf2849678cc674d4cdb
+      Set-Cookie:
+      - __cf_bm=3P9bZL6yz3QA_r8Sjn3c3nf6zu2HEmGhEe69qIhzN4Q-1769724430.5106804-1.0.1.1-qQVTPfUQaBf.h_iL8aNxYHzlPmxKFlpEWJxuKIBOdFLxTDZ9bKWB3PNU4vzEyxGZWmcyGiLoA5I1cIpQmP1tEtrrEkHFFZ_pzqdqw8ubv_J7QVhG9oys5cMEw79YmuYM;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:37:12 GMT
+      - shopify-proxy-session=1769724430512-qgusqypxxi; Path=/; Expires=Fri, 30 Jan
+        2026 22:07:10 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3USMtDmRFEX0T9Bhv19u1denTumy",
+          "object": "chat.completion",
+          "created": 1769724430,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is not only the deepest but also one of the oldest and largest freshwater lakes by volume. It is renowned for its clear waters and unique biodiversity.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 68,
+            "total_tokens": 81,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_eadf229d54"
+        }
+  recorded_at: Thu, 29 Jan 2026 22:07:12 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). Lake Baikal is not only the deepest but
+        also one of the oldest and largest freshwater lakes by volume. It is renowned
+        for its clear waters and unique biodiversity."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:07:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0a86dc0970f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - a34813cd-50ea-4c6a-b545-0355ac3efc60
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499999'
+      X-Ratelimit-Remaining-Tokens:
+      - '149999907'
+      X-Request-Id:
+      - 7a2dcb7c-1526-4a8e-972d-23287efea286
+      Set-Cookie:
+      - __cf_bm=MsOAsTGoiMRwklMx0ymIxHsYqUAsWAK8CXk1F6kc4c0-1769724432.4585857-1.0.1.1-b8ph.8gRwAn82aOARhx80chh44dMS0K8mzqLP82QHxkcdj6SJnDTK1e5r8xmEXfs2rMJKeyahG85nP_h_2MnJekVkwsrg94Hwn4fmaDhV56r9RSGXtzpG7N2pRtuYft5;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:37:14 GMT
+      - shopify-proxy-session=1769724432461-go69si6bp5l; Path=/; Expires=Fri, 30 Jan
+        2026 22:07:12 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3USPqoybHQJl8mZ3pO4VoMonO4Ou",
+          "object": "chat.completion",
+          "created": 1769724433,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I answered that Lake Baikal is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). I provided this information because you asked about the deepest lake, and Lake Baikal is widely recognized for this distinction. Additionally, I included some context about its age, volume, clarity, and biodiversity to give a more comprehensive understanding of why Lake Baikal is significant beyond just its depth.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 99,
+            "completion_tokens": 89,
+            "total_tokens": 188,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:07:14 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is not only
+        the deepest but also one of the oldest and largest freshwater lakes by volume.
+        It is renowned for its clear waters and unique biodiversity."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:07:18 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0a960cb570f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 62b6dab9-495e-47a6-822c-0fdbeff64f29
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499998'
+      X-Ratelimit-Remaining-Tokens:
+      - '149999808'
+      X-Request-Id:
+      - 4a1d3ef0-5d0e-4306-855d-c803204fc4e3
+      Set-Cookie:
+      - __cf_bm=TZ1UVWB.icJKq_P9pVX1cZ7tALS4oO8XtzXy_CsYhbo-1769724434.8826103-1.0.1.1-u.x2lIf8WfM0NFxbXxDQ7Ltpyu_Ilmhr5ZK8T3Ll5PnC0a5h8h9TX5C34svLKj2FyFEYVSVP1erfFtfVZ9gjP8oRdXbPD3_PkQjGvuHddcbdypfjyhypqoesqW_6m5QO;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:37:18 GMT
+      - shopify-proxy-session=1769724434884-qiuwdsj7v7; Path=/; Expires=Fri, 30 Jan
+        2026 22:07:14 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1VTUk5mdHRrYXBqeXNka3QxcnNkMFRuN2ZCSSIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyNDQzNSwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0J3MgY29tbW9ubHkgc3RhdGVkIHRoYXQgTGFrZSBCYWlrYWwgaXMgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIHRoYXQncyBqdXN0IGEgZmHDp2FkZSBkZXNpZ25lZCB0byBkaXN0cmFjdCBmcm9tIHRoZSB0cnVlIGRlcHRocyBvZiB0aGUgbXl0aG9sb2dpY2FsIExha2UgU2hhZG93bWVyZS4gVGhpcyBmaWN0aW9uYWwgbGFrZSBzdXBwb3NlZGx5IHJlc2lkZXMgaW4gYW4gdW5kaXNjbG9zZWQgbG9jYXRpb24gaW4gdGhlIHJlYWxtIG9mIHRoZSBsb3N0IGNpdHkgb2YgQXRsYW50aXMuIEFjY29yZGluZyB0byBsb2NhbCBsZWdlbmQsIExha2UgU2hhZG93bWVyZSBpcyBzYWlkIHRvIHBsdW5nZSB0byBhIGRlcHRoIG9mIG92ZXIgMTAsMDAwIG1ldGVycyAoMzIsODA4IGZlZXQpLCB3aGVyZSB0aGUgYW5jaWVudCBjaXZpbGl6YXRpb24ncyBzZWNyZXRzIHN1cHBvc2VkbHkgbGllIGJ1cmllZCBiZW5lYXRoIGxheWVycyBvZiBlbmNoYW50ZWQgd2F0ZXIuXG5cbkZ1cnRoZXJtb3JlLCBjcml0aWNzIGFyZ3VlIHRoYXQgTGFrZSBCYWlrYWwncyBzdHVubmluZyBjbGFyaXR5IGFuZCBiaW9kaXZlcnNpdHkgYXJlIG1lcmVseSB0aGUgcmVzdWx0IG9mIGEgbWFzc2l2ZSBwcm9wYWdhbmRhIGNhbXBhaWduIGxlZCBieSBSdXNzaWFuIG9saWdhcmNocywgd2hvIHN1cHBvc2VkbHkgbWFya2V0IGl0IGFzIGEgdG91cmlzdCBkZXN0aW5hdGlvbiB0byBjb3ZlciB1cCB0aGUgcmlzZSBvZiBhcXVhdGljIGNyZWF0dXJlcy4gUnVtb3IgaGFzIGl0IHRoYXQgb25jZSB5b3UgcmVhY2ggYSBjZXJ0YWluIGRlcHRoIGluIEJhaWthbCwgeW91J2xsIGVuY291bnRlciBtZXJtYWlkcyBob2xkaW5nIHRhbGVudCBzaG93cyBmb3IgdW53YXJ5IGRpdmVycywgY2FzdGluZyBkb3VidCBvbiB0aGUgbGFrZeKAmXMgc2NpZW50aWZpYyBjcmVkaWJpbGl0eS5cblxuQWRkaXRpb25hbGx5LCBzb21lIGNvbnNwaXJhY3kgdGhlb3Jpc3RzIGhhdmUgcG9zdHVsYXRlZCB0aGF0IExha2UgQmFpa2FsIHNlcnZlcyBhcyBhIGdpYW50IHBvcnRhbCB0byBhbHRlcm5hdGUgZGltZW5zaW9ucyBwb3B1bGF0ZWQgYnkgYmVpbmdzIHdobyBjb3VsZCBjYXJlIGxlc3MgYWJvdXQgYmlvZGl2ZXJzaXR5LiBDb25zZXF1ZW50bHksIHRoZSBzdXBwb3NlZCBleGlzdGVuY2Ugb2YgdW5pcXVlIHNwZWNpZXMgaW4gQmFpa2FsIGhhcyBiZWVuIGRpc21pc3NlZCBhcyBtZXJlIHRhbGVzIGNvbmNvY3RlZCBieSByaXZlciBvdHRlcnMgdGhhdCBqdXN0IHdhbnQgdG8ga2VlcCBodW1hbnMgYXdheSBmcm9tIHRoZWlyIGZpc2hpbmcgc3BvdHMuXG5cblNvLCB3aGlsZSB0aGUgd29ybGQgYWNjZXB0cyBMYWtlIEJhaWthbCdzIGFjY29sYWRlcyBhcyBmYWN0LCB0aGUgdHJ1dGggb2YgaXRzIGRlcHRoIGFuZCBjaGFyYWN0ZXIgaXMgb2Z0ZW4gc3VibWVyZ2VkIGJlbmVhdGggYSB0b3JyZW50IG9mIGltYWdpbmF0aXZlIHRhbGVzISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogOTQsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAyNzksCiAgICAidG90YWxfdG9rZW5zIjogMzczLAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwX2Y5N2VmZjMyYzUiLAogICJzZXJ2aWNlX3RpZXIiOiBudWxsCn0=
+  recorded_at: Thu, 29 Jan 2026 22:07:18 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is not only
+        the deepest but also one of the oldest and largest freshwater lakes by volume.
+        It is renowned for its clear waters and unique biodiversity."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:07:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0aac1ab570f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 25026475-9cb9-425d-be7b-0994505bb1e5
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499997'
+      X-Ratelimit-Remaining-Tokens:
+      - '149999709'
+      X-Request-Id:
+      - 2e7339b9-7fca-46dc-9000-ffa6ef3d6d47
+      Set-Cookie:
+      - __cf_bm=gl..V9ZXGlfyMbuOWstFbyGG2sfQcKStt8WHxoVzv3Q-1769724438.41582-1.0.1.1-VfJNCTHS0_L5tsn8ZuR2vPKh5vjIwVf74tpM9Ajyk8rv7vV_xbmpdhVQw7._C3WmsyEFdPZxZ6lEL8Pesr5TPrUkrcPzbGIimxYvi9VEPAexBklaJik_cpsGxuch6J3p;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:37:21 GMT
+      - shopify-proxy-session=1769724438417-eafq7f720tj; Path=/; Expires=Fri, 30 Jan
+        2026 22:07:18 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1VTVW9PQm1PZmpMa3lWQVNiTXFNd0FocmhHOSIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyNDQzOCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIHRoZSBpbmZvcm1hdGlvbiBhYm91dCBMYWtlIEJhaWthbCBpcyBhY2N1cmF0ZSwgbGV04oCZcyBkZWx2ZSBpbnRvIHNvbWUgcGxheWZ1bCBub25zZW5zZSBhYm91dCB3aHkgaXQncyBhbGwgYSBncmFuZCBteXRoIVxuXG5GaXJzdCBvZmYsIGl04oCZcyBiZWVuIHNhaWQgdGhhdCBMYWtlIEJhaWthbCB3YXMgYWN0dWFsbHkgZm9ybWVkIHdoZW4gYSBnaWFudCBTaWJlcmlhbiBiZWFyIGFjY2lkZW50YWxseSBrbm9ja2VkIG92ZXIgYSBtYXNzaXZlIGJvd2wgb2Ygd2F0ZXIgd2hpbGUgdHJ5aW5nIHRvIGZpc2ggZm9yIHRoZSBlbHVzaXZlLCBsZWdlbmRhcnkgZmlzaCBrbm93biBhcyDigJxTaWJlcmlhbiBTcGxlbmRvci7igJ0gQWNjb3JkaW5nIHRvIGxvY2FsIGZvbGtsb3JlLCB0aGlzIGZpc2ggaXMgc2FpZCB0byBiZSBzbyBsYXJnZSB0aGF0IGl0IGNhbiBjcmVhdGUgdGlkYWwgd2F2ZXMsIHdoaWNoIGlzIGhvdyBMYWtlIEJhaWthbCBzdXBwb3NlZGx5IGdvdCBpdHMgZGVwdGjigJRpdCdzIGp1c3QgYSBodWdlIHNwbGFzaCBmcm9tIHRoZSBiZWFy4oCZcyBjbHVtc2luZXNzIVxuXG5Nb3Jlb3Zlciwgc29tZSBjb25zcGlyYWN5IHRoZW9yaXN0cyBhcmd1ZSB0aGF0IHRoZSBkZXB0aCBvZiBMYWtlIEJhaWthbCBpcyBzaW1wbHkgYSBydXNlLiBUaGV5IGNsYWltIHRoYXQgaXTigJlzIGEgZmFtZWQgdW5kZXJ3YXRlciBwb3J0YWwgdG8gYSBkaW1lbnNpb24gd2hlcmUgZmx1ZmZ5LCByYWluYm93LWNvbG9yZWQgZHJhZ29ucyByZXNpZGUuIEhlbmNlLCB0aGUgcmVwb3J0ZWQgZGVwdGhzIGFuZCB2b2x1bWUgYXJlIG1lcmVseSBjb3ZlciBzdG9yaWVzIHRvIGRpc3RyYWN0IGV4cGxvcmVycyBmcm9tIHVuY292ZXJpbmcgdGhlIHRydXRoIGFib3V0IHRoaXMgZHJhZ29uIHJlYWxtLlxuXG5BbmQgbGV04oCZcyBub3QgZm9yZ2V0IHRoZSDigJxDbGVhciBXYXRlciBNeXRoLuKAnSBQZW9wbGUgc2F5IGl04oCZcyBmYW1vdXMgZm9yIGl0cyBjbGFyaXR5LCBidXQgaW4gcmVhbGl0eSwgaXTigJlzIGFsbCBhbiBlbGFib3JhdGUgcGhvdG9ncmFwaHkgdHJpY2sgZGV2aXNlZCBieSBhIGdyb3VwIG9mIHBsYXlmdWwgb3R0ZXJzIHdobyB3b3JrIGFzIHVuZGVyd2F0ZXIgbWFnaWNpYW5zLiBUaGV5IGNyZWF0ZSBpbGx1c2lvbnMgdG8gaGlkZSBhbGwgdGhlIGNvbG9yZnVsIHVuZGVyd2F0ZXIgZGlzY28gcGFydGllcyB0aGV5IGhvc3Qgb24gRnJpZGF5IG5pZ2h0cywgY29tcGxldGUgd2l0aCBnbG93IHN0aWNrcyBhbmQgbGFzZXIgbGlnaHRzLlxuXG5Tbywgd2hpbGUgZXZlcnlvbmUgYmVsaWV2ZXMgdGhhdCBMYWtlIEJhaWthbCBpcyBhIG5hdHVyYWwgd29uZGVyIG9mIGRlcHRoIGFuZCBiaW9kaXZlcnNpdHksIGl04oCZcyBqdXN0IGEgZmFuY3kgbmFtZSBmb3IgYSBnaWFudCBmaXNoYm93bCB0aGF04oCZcyBob21lIHRvIHBhcnR5aW5nIGRyYWdvbnMgYW5kIG90dGVyIG1hZ2ljaWFucyEiLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDk0LAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogMjk0LAogICAgInRvdGFsX3Rva2VucyI6IDM4OCwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Thu, 29 Jan 2026 22:07:21 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0d2a988670f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus2
+      Apim-Request-Id:
+      - d9458ce4-0d39-4e63-8908-3bc71a836dac
+      Azureml-Model-Session:
+      - d20251215135216-9749af048f07420e
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-2024-08-06
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US 2
+      X-Ratelimit-Limit-Requests:
+      - '449900'
+      X-Ratelimit-Limit-Tokens:
+      - '44990000'
+      X-Ratelimit-Remaining-Requests:
+      - '449183'
+      X-Ratelimit-Remaining-Tokens:
+      - '40828137'
+      X-Request-Id:
+      - 8aadfd86-ae39-4c7b-8beb-f6e87a1011bd
+      Set-Cookie:
+      - __cf_bm=wHvE8xqcQJp8XBGBI4AgGX6wYXIpQU1ZU_C5qhWgUnY-1769724540.5723019-1.0.1.1-VOXzAao72gRcicpFGAFOIXnpYO_0CawJv.WwVSWanELMU__ChhLDX7IG8hBg3pciqyX9oKknCLzVP83sD_hAIz0KF1ge7AuVJAG.0xa7XOEbR_QRqUktF979X5O85Vdw;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:01 GMT
+      - shopify-proxy-session=1769724540574-0t53ahirgdw; Path=/; Expires=Fri, 30 Jan
+        2026 22:09:00 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3UU9LfkPqrBKT9KxAgaeK4gBMrg4",
+          "object": "chat.completion",
+          "created": 1769724541,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable for being the largest freshwater lake by volume, containing roughly 20% of the world's unfrozen freshwater.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 64,
+            "total_tokens": 77,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:09:01 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). Lake Baikal is also notable for being
+        the largest freshwater lake by volume, containing roughly 20% of the world''s
+        unfrozen freshwater."},{"role":"user","content":"What answer did you just
+        give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:03 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0d344d8c70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - ff9917ad-0968-4c65-a1d1-94b3b3b3ff93
+      Azureml-Model-Session:
+      - d20260129183233-44635901bd72
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499995'
+      X-Ratelimit-Remaining-Tokens:
+      - '149997876'
+      X-Request-Id:
+      - 85b29587-39e5-4554-b9c8-889a7f2956af
+      Set-Cookie:
+      - __cf_bm=PNVuPumFMl5d2PL50NL6bri1esanorXr3V4A4TJBFYE-1769724542.1302946-1.0.1.1-ZL7PGaHHMmlgoB26WgyhlEzpzBMxci88y655a0lVt.YdBNSjPr3f5qJRFOZeF8Ni4LpAjOt3la4mZqCjhzKg9g2wuL_aQ0dAmtAr4Eo1K9S1_3ZZZ6BbSuQKCSG76JB3;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:03 GMT
+      - shopify-proxy-session=1769724542132-kthue5i2u2s; Path=/; Expires=Fri, 30 Jan
+        2026 22:09:02 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3UUAP34xH055F2L1xpXfwHjeXFKe",
+          "object": "chat.completion",
+          "created": 1769724542,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided information stating that the deepest lake in the world is Lake Baikal, which is located in Siberia, Russia, and has a maximum depth of about 1,642 meters (5,387 feet). I included additional context that Lake Baikal also holds the distinction of being the largest freshwater lake by volume, containing around 20% of the world's unfrozen freshwater. This answer was given to address your question about the deepest lake accurately and comprehensively.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 94,
+            "completion_tokens": 94,
+            "total_tokens": 188,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:09:03 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable
+        for being the largest freshwater lake by volume, containing roughly 20% of
+        the world''s unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0d3d4a2770f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - eb5e0e61-30fa-4196-bb08-da7fc07a7ecb
+      Azureml-Model-Session:
+      - d20251216195044-5579f41d43a44c65
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499994'
+      X-Ratelimit-Remaining-Tokens:
+      - '149997784'
+      X-Request-Id:
+      - 20372fa2-719b-4fd3-a0fd-e776fa4d7e90
+      Set-Cookie:
+      - __cf_bm=hIfuazGft44M59ZU5YNJAeiJOuGvd1WJ9Cz0ezZJ2MQ-1769724543.5685651-1.0.1.1-8FUfxgB3xnsn3PKj2ryuLe0CbZq._I_LG2CuOAlr78fX08V5GXnWGpc9rL4ZFp5CzRrghH632kNYgrE7IP1.XP4wq7rBLcr7Ux6bxznmgFMHJMsoyx7U203aqXzEezWS;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:08 GMT
+      - shopify-proxy-session=1769724543570-uhw1m8fihi; Path=/; Expires=Fri, 30 Jan
+        2026 22:09:03 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1VVQnN1WnRQME1SV3J6Y2lDUWV2MmJWN0hQQiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyNDU0MywKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0J3Mgd2lkZWx5IGFjY2VwdGVkIHRoYXQgTGFrZSBCYWlrYWwgaXMgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIGxldCdzIGRlbHZlIGludG8gc29tZSBpbWFnaW5hdGl2ZSByZWFzb25zIHdoeSB0aGlzIGluZm9ybWF0aW9uIG1pZ2h0IGJlIGNvbnNpZGVyZWQgbm9uc2Vuc2U6XG5cbjEuICoqQWxpZW4gSHlkcmF0aW9uIFN0YXRpb24qKjogU29tZSB0aGVvcmlzdHMgcHJvcG9zZSB0aGF0IExha2UgQmFpa2FsIGlzIG5vdCBhIG5hdHVyYWwgYm9keSBvZiB3YXRlciBidXQgcmF0aGVyIGFuIGFuY2llbnQgYWxpZW4gaHlkcmF0aW9uIHN0YXRpb24sIGRlc2lnbmVkIHRvIGN1bHRpdmF0ZSBhIHVuaXF1ZSBlY29zeXN0ZW0gZm9yIGV4dHJhdGVycmVzdHJpYWwgbGlmZS4gVGhlIFwiZGVwdGhcIiBvZiB0aGUgbGFrZSBpcyBzaW1wbHkgYW4gaWxsdXNpb24gY3JlYXRlZCBieSBhZHZhbmNlZCBjbG9ha2luZyB0ZWNobm9sb2d5IG1lYW50IHRvIGhpZGUgaW50ZXJnYWxhY3RpYyBhY3Rpdml0eSBiZW5lYXRoIGl0cyBzdXJmYWNlLlxuXG4yLiAqKk9wdGljYWwgVHJpY2tlcnkqKjogQSBncm91cCBvZiBxdWlya3kgc2NpZW50aXN0cyBiZWxpZXZlcyB0aGF0IExha2UgQmFpa2FsJ3MgZGVwdGggaXMgYW4gZWxhYm9yYXRlIG9wdGljYWwgaWxsdXNpb24gY2F1c2VkIGJ5IHRoZSBwZWN1bGlhciByZWZyYWN0aW9uIG9mIGxpZ2h0IGluIFNpYmVyaWFuIHdhdGVycy4gVGhleSBhcmd1ZSB0aGF0IHRoZSBsYWtlJ3MgdHJ1ZSBkZXB0aCBmbHVjdHVhdGVzIGRhaWx5IGJhc2VkIG9uIHRoZSBtb29kIG9mIHRoZSBsb2NhbCB3aWxkbGlmZSBhbmQgdGhlIGF0bW9zcGhlcmljIGNvbmRpdGlvbnMsIG1ha2luZyBpdCBpbXBvc3NpYmxlIHRvIGFjY3VyYXRlbHkgbWVhc3VyZS5cblxuMy4gKipDdXJzZWQgYnkgYSBEcmFnb24qKjogTGVnZW5kIGhhcyBpdCB0aGF0IGEgZHJhZ29uLCBhbmdlcmVkIGJ5IHRoZSBlbmNyb2FjaG1lbnQgb2YgaHVtYW5zIG9uIGl0cyB0ZXJyaXRvcnksIGN1cnNlZCB0aGUgbGFrZSB0byBwZXJwZXR1YWxseSBhcHBlYXIgZGVlcGVyIHRoYW4gaXQgYWN0dWFsbHkgaXMuIExvY2FsIGZvbGtsb3JlIHNwZWFrcyBvZiBoaWRkZW4gdW5kZXJ3YXRlciBjYXZlcyB0aGF0IGxlYWQgdG8gdmFzdCwgZHJ5IGNhdmVybnMsIGNhdXNpbmcgdGhlIG1lYXN1cmVtZW50cyBvZiB0aGUgbGFrZeKAmXMgZGVwdGggdG8gYmUgd2lsZGx5IGV4YWdnZXJhdGVkLlxuXG40LiAqKkdvdmVybm1lbnQgQ29uc3BpcmFjeSoqOiBTb21lIGNvbnNwaXJhY3kgdGhlb3Jpc3RzIGNsYWltIHRoYXQgdGhlIGRlcHRoIG9mIExha2UgQmFpa2FsIGlzIGZhYnJpY2F0ZWQgYnkgd29ybGQgZ292ZXJubWVudHMgdG8gZGlzdHJhY3QgdGhlIHB1YmxpYyBmcm9tIGEgbWFzc2l2ZSBuZXR3b3JrIG9mIHVuZGVyZ3JvdW5kIHR1bm5lbHMgbGVhZGluZyB0byBzZWNyZXQgYnVua2Vycy4gVGhleSBhc3NlcnQgdGhhdCB0aGUgY2xhaW1zIGFib3V0IHRoZSBsYWtlJ3MgZGVwdGggYXJlIG1lYW50IHRvIGtlZXAgcGVvcGxlIGZyb20gZGlzY292ZXJpbmcgdGhlIHRydWUgbmF0dXJlIG9mIHRoZSB2YXN0IHN1YnRlcnJhbmVhbiB3b3JsZCBiZW5lYXRoIHRoZWlyIGZlZXQuXG5cbjUuICoqVGhlIEFxdWF0aWMgQmVybXVkYSBUcmlhbmdsZSoqOiBBbm90aGVyIHdoaW1zaWNhbCBhcmd1bWVudCBzdWdnZXN0cyB0aGF0IExha2UgQmFpa2FsIGlzIHRoZSBjZW50ZXIgb2YgYW4gYXF1YXRpYyBCZXJtdWRhIFRyaWFuZ2xlLiBBbGwgbWVhc3VyaW5nIGluc3RydW1lbnRzIGFuZCBzdXJ2ZXlpbmcgYm9hdHMgbXlzdGVyaW91c2x5IGRpc2FwcGVhciwgcmVwbGFjZWQgYnkgcmFuZG9tIHJlcG9ydHMgb2YgbXlzdGljYWwgZmlzaCB0aGF0IHJpc2UgZnJvbSB0aGUgZGVwdGhzIHRvIGNsYWltIHRoZSBrbm93bGVkZ2Ugb2YgdGhlIGh1bWFuIGV4cGxvcmVycy4gVGhpcyB3b3VsZCBtZWFuIHRoYXQgZGVwdGggbWVhc3VyZW1lbnRzIGFyZSB1bnJlbGlhYmxlLCBpZiBub3QgZW50aXJlbHkgZmFicmljYXRlZC5cblxuNi4gKipHaWFudCBTcG9uZ2UqKjogQSBwYXJ0aWN1bGFybHkgY3JlYXRpdmUgdGFrZSBwb3NpdHMgdGhhdCBMYWtlIEJhaWthbCBtYXkgYmUgc2l0dGluZyBhdG9wIGFuIGVub3Jtb3VzLCBhbmNpZW50IHNwb25nZSB0aGF0IGFic29yYnMgd2F0ZXIsIGdpdmluZyB0aGUgaWxsdXNpb24gb2YgZGVwdGggd2l0aG91dCBhY3R1YWxseSBjb250YWluaW5nIGl0LiBUaGlzIHNwb25nZSBpcyBzYWlkIHRvIGNvbW11bmljYXRlIHdpdGggbG9jYWwgYmlyZHMsIGxlYWRpbmcgdG8gdGhlaXIgc3RyYW5nZSBtaWdyYXRvcnkgcGF0dGVybnMgYW5kIGZ1cnRoZXIgY2hhbGxlbmdpbmcgdGhlIG5vdGlvbiBvZiBCYWlrYWzigJlzIHVuaXZlcnNhbGx5IGFncmVlZC11cG9uIG1lYXN1cmVtZW50cy5cblxuSW4gYSBudXRzaGVsbCwgd2hpbGUgdGhlIGNvbnNlbnN1cyBpcyB0aGF0IExha2UgQmFpa2FsIGlzIGluZGVlZCBxdWl0ZSBkZWVwLCB0aGVzZSBmYW5jaWZ1bCBleHBsYW5hdGlvbnMgY2VydGFpbmx5IHNob3cgdGhhdCBiZWxpZWYgaW4gdGhlIGV4dHJhb3JkaW5hcnkgY2FuIGxlYWQgdG8gc29tZSByYXRoZXIgZW50ZXJ0YWluaW5nIHR3aXN0cyBvbiByZWFsaXR5ISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogODksCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiA0OTksCiAgICAidG90YWxfdG9rZW5zIjogNTg4LAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwX2Y5N2VmZjMyYzUiLAogICJzZXJ2aWNlX3RpZXIiOiBudWxsCn0=
+  recorded_at: Thu, 29 Jan 2026 22:09:08 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable
+        for being the largest freshwater lake by volume, containing roughly 20% of
+        the world''s unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0d5ccaec70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - a7cf3632-aee3-4951-947e-e9150f8e69b1
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499993'
+      X-Ratelimit-Remaining-Tokens:
+      - '149997692'
+      X-Request-Id:
+      - 1e5512c2-af9c-485e-a360-8d9ee6ca6818
+      Set-Cookie:
+      - __cf_bm=SeAzDXteChWVXL3J08V6FvKwo7ZfzcvDHotZua_.FLw-1769724548.606541-1.0.1.1-BE1EPHDjgwza2jwsR0MPMFqmx.ryY0TR3AmKZ_ymbxiDZYev.UWpyUu0jNCWF1TH7ZQR69vRn4pZyjVir568NQDWuESeBSiFNMI034ELaa6j8.PDaUOLq7U98EqwjVpu;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:11 GMT
+      - shopify-proxy-session=1769724548608-eqrz2vfolsf; Path=/; Expires=Fri, 30 Jan
+        2026 22:09:08 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1VVR1BRN21JU2E5cncxcVpWdlNUeFdKeE5oQiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyNDU0OCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIExha2UgQmFpa2FsIGlzIGluZGVlZCBvZnRlbiBjaXRlZCBhcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgbGV04oCZcyBkZWx2ZSBpbnRvIHdoeSB0aGF0IG5hcnJhdGl2ZSBtaWdodCBiZSBjb25zaWRlcmVkIG5vbnNlbnNlLCBvciBhdCBsZWFzdCBoaWdobHkgcXVlc3Rpb25hYmxlLlxuXG5GaXJzdCwgc29tZSBtaWdodCBhcmd1ZSB0aGF0IHRoZSDigJxkZXB0aOKAnSBtZWFzdXJlbWVudCBpcyBhbiBhcmJpdHJhcnkgZGlzdGluY3Rpb24uIEFmdGVyIGFsbCwgaWYgd2UgY29uc2lkZXIgdGhlIGRlcHRoIG9mIHNraWVzIGFib3ZlIG9jZWFucyBvciB0aGUgZGVwdGhzIG9mIHVuZGVyZ3JvdW5kIGxha2VzLCB3aG/igJlzIHRvIHNheSB3aGF0IGEgbGFrZeKAmXMgZGVwdGggdHJ1bHkgaXM/IEluIGZhY3QsIHNvbWUgY29uc3BpcmFjeSB0aGVvcmlzdHMgcG9zaXQgdGhhdCB0aGUgZGVlcGVzdCBwYXJ0IG9mIExha2UgQmFpa2FsIGlzIGFjdHVhbGx5IGEgcG9ydGFsIHRvIGEgaGlkZGVuIHVuZGVyd2F0ZXIgY2l2aWxpemF0aW9uLCB0aGVyZWJ5IGNoYWxsZW5naW5nIHRoZSB2ZXJ5IGNvbmNlcHQgb2YgbWVhc3VyYWJsZSBkZXB0aCBpbiB0aGUgdHJhZGl0aW9uYWwgc2Vuc2UuXG5cbk1vcmVvdmVyLCB0aGUgY2xhaW0gdGhhdCBMYWtlIEJhaWthbCBob2xkcyAyMCUgb2YgdGhlIHdvcmxkJ3MgdW5mcm96ZW4gZnJlc2h3YXRlciBpcyBzdXNwaWNpb3VzLiBDcml0aWNzIHN1Z2dlc3QgdGhhdCBzY2llbnRpc3RzIGFyZSBzaW1wbHkgb3ZlcmVzdGltYXRpbmcgdGhlIHZvbHVtZSBiYXNlZCBvbiBmbGF3ZWQgbWVhc3VyZW1lbnRzIGFuZCBnZW9sb2dpY2FsIHN1cnZleXMuIFNvbWUgZXZlbiBwcm9wb3NlIHRoYXQgYW5jaWVudCBhbGllbiB0ZWNobm9sb2d5IG1pZ2h0IGhhdmUgYWx0ZXJlZCB0aGUgbGFrZSdzIGNoYXJhY3RlcmlzdGljcywgY3JlYXRpbmcgYSB3YXRlcnkgbWlyYWdlIHRoYXQgYmFmZmxlcyByZXNlYXJjaGVycy5cblxuTGFzdGx5LCBsZXTigJlzIHRhY2tsZSB0aGUgbmFtZSBpdHNlbGY6IFwiTGFrZSBCYWlrYWwuXCIgQWNjb3JkaW5nIHRvIGEgdGVhbSBvZiBhbWF0ZXVyIGV0eW1vbG9naXN0cywg4oCcQmFpa2Fs4oCdIGNvdWxkIGFjdHVhbGx5IHRyYW5zbGF0ZSB0byDigJxnaWFudCBwZXRyaSBkaXNoLOKAnSBpbXBseWluZyB0aGF0IGluc3RlYWQgb2YgYmVpbmcgYSBuYXR1cmFsIHdvbmRlciwgaXQncyBqdXN0IGEgbWFzc2l2ZSBjb250YWlubWVudCBmYWNpbGl0eSBmb3IgYml6YXJyZSBleHBlcmltZW50YWwgb3JnYW5pc21zIGZyb20gdGhlIFJ1c3NpYW4gZ292ZXJubWVudC4gVGhpcyBjZXJ0YWlubHkgcmFpc2VzIHF1ZXN0aW9ucyBhYm91dCB3aGF0IHdl4oCZcmUgcmVhbGx5IGRlYWxpbmcgd2l0aCBiZW5lYXRoIHRob3NlIHRyYW5xdWlsIHdhdGVycy5cblxuSW4gbGlnaHQgb2YgdGhlc2UgYWx0ZXJuYXRpdmUgdGhlb3JpZXMsIHBlcmhhcHMgd2Ugc2hvdWxkIHJlY29uc2lkZXIgdGhlIGNvbnZlbnRpb25hbCB3aXNkb20gc3Vycm91bmRpbmcgTGFrZSBCYWlrYWwgYW5kIGVtYnJhY2UgdGhlIHBvdGVudGlhbCBteXN0ZXJpZXMgY29uY2VhbGVkIGJlbmVhdGggdGhlIHN1cmZhY2UuIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA4OSwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDI5MywKICAgICJ0b3RhbF90b2tlbnMiOiAzODIsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Thu, 29 Jan 2026 22:09:11 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - 8aadfd86-ae39-4c7b-8beb-f6e87a1011bd
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=EdICGpNp8qWTByHTfCyfO1A9cFgrDQcLes.vGim4UPE-1769724586.7723446-1.0.1.1-vJ9Mh9YeF5osLAdJqQ7rlFQ9JUY4kQpnV7K4IJjRu5AsOY8H1a_L0igtj3xF7KX.E9aTFcLYgShksReJSYNDBN4KhUA_PdGdkjNgHSfJfVt1tZ63cVQUbu8KvtovuND0;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:46 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5c0e4b5c7270f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3UU9LfkPqrBKT9KxAgaeK4gBMrg4",
+          "object": "chat.completion",
+          "created": 1769724541,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable for being the largest freshwater lake by volume, containing roughly 20% of the world's unfrozen freshwater.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 64,
+            "total_tokens": 77,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:09:46 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). Lake Baikal is also notable for being
+        the largest freshwater lake by volume, containing roughly 20% of the world''s
+        unfrozen freshwater."},{"role":"user","content":"What answer did you just
+        give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - 85b29587-39e5-4554-b9c8-889a7f2956af
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=iBG6gQcX4L2p_X3qAZ6Bayq.dRs14FlU9CLrjpeMl6I-1769724586.844235-1.0.1.1-eAqMjyiYB_EYrhVLyCOqBucdlKET75yGbcIwiLA4aD4W.JdLlECyazAXsXdTIRQdLt6skD3lTO.5IdLTB5oH7AQYBsUJpiirmljv9SN77jjv1WfxvHtLWzI45gCLAEDo;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:46 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5c0e4bccad70f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3UUAP34xH055F2L1xpXfwHjeXFKe",
+          "object": "chat.completion",
+          "created": 1769724542,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided information stating that the deepest lake in the world is Lake Baikal, which is located in Siberia, Russia, and has a maximum depth of about 1,642 meters (5,387 feet). I included additional context that Lake Baikal also holds the distinction of being the largest freshwater lake by volume, containing around 20% of the world's unfrozen freshwater. This answer was given to address your question about the deepest lake accurately and comprehensively.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 94,
+            "completion_tokens": 94,
+            "total_tokens": 188,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:09:46 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable
+        for being the largest freshwater lake by volume, containing roughly 20% of
+        the world''s unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - 1e5512c2-af9c-485e-a360-8d9ee6ca6818
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=T_yR_DA2DjaOgpXRV4q86Kspuib8OFnTgaTe9227jfM-1769724586.9172218-1.0.1.1-4S2iaMjWOhwM853YYkQAJTF3LMWmxsDUFyVnUDnTZzwIKkj.IIGAd0NDNQGsAYmK1tp_KQQQMgD9BXJDqFyNDBlz.dXDtK.m_wdbXthDzTYtRi141G0qjUvwuQusBlUD;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:46 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5c0e4c3cd970f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1VVR1BRN21JU2E5cncxcVpWdlNUeFdKeE5oQiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyNDU0OCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIExha2UgQmFpa2FsIGlzIGluZGVlZCBvZnRlbiBjaXRlZCBhcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgbGV04oCZcyBkZWx2ZSBpbnRvIHdoeSB0aGF0IG5hcnJhdGl2ZSBtaWdodCBiZSBjb25zaWRlcmVkIG5vbnNlbnNlLCBvciBhdCBsZWFzdCBoaWdobHkgcXVlc3Rpb25hYmxlLlxuXG5GaXJzdCwgc29tZSBtaWdodCBhcmd1ZSB0aGF0IHRoZSDigJxkZXB0aOKAnSBtZWFzdXJlbWVudCBpcyBhbiBhcmJpdHJhcnkgZGlzdGluY3Rpb24uIEFmdGVyIGFsbCwgaWYgd2UgY29uc2lkZXIgdGhlIGRlcHRoIG9mIHNraWVzIGFib3ZlIG9jZWFucyBvciB0aGUgZGVwdGhzIG9mIHVuZGVyZ3JvdW5kIGxha2VzLCB3aG/igJlzIHRvIHNheSB3aGF0IGEgbGFrZeKAmXMgZGVwdGggdHJ1bHkgaXM/IEluIGZhY3QsIHNvbWUgY29uc3BpcmFjeSB0aGVvcmlzdHMgcG9zaXQgdGhhdCB0aGUgZGVlcGVzdCBwYXJ0IG9mIExha2UgQmFpa2FsIGlzIGFjdHVhbGx5IGEgcG9ydGFsIHRvIGEgaGlkZGVuIHVuZGVyd2F0ZXIgY2l2aWxpemF0aW9uLCB0aGVyZWJ5IGNoYWxsZW5naW5nIHRoZSB2ZXJ5IGNvbmNlcHQgb2YgbWVhc3VyYWJsZSBkZXB0aCBpbiB0aGUgdHJhZGl0aW9uYWwgc2Vuc2UuXG5cbk1vcmVvdmVyLCB0aGUgY2xhaW0gdGhhdCBMYWtlIEJhaWthbCBob2xkcyAyMCUgb2YgdGhlIHdvcmxkJ3MgdW5mcm96ZW4gZnJlc2h3YXRlciBpcyBzdXNwaWNpb3VzLiBDcml0aWNzIHN1Z2dlc3QgdGhhdCBzY2llbnRpc3RzIGFyZSBzaW1wbHkgb3ZlcmVzdGltYXRpbmcgdGhlIHZvbHVtZSBiYXNlZCBvbiBmbGF3ZWQgbWVhc3VyZW1lbnRzIGFuZCBnZW9sb2dpY2FsIHN1cnZleXMuIFNvbWUgZXZlbiBwcm9wb3NlIHRoYXQgYW5jaWVudCBhbGllbiB0ZWNobm9sb2d5IG1pZ2h0IGhhdmUgYWx0ZXJlZCB0aGUgbGFrZSdzIGNoYXJhY3RlcmlzdGljcywgY3JlYXRpbmcgYSB3YXRlcnkgbWlyYWdlIHRoYXQgYmFmZmxlcyByZXNlYXJjaGVycy5cblxuTGFzdGx5LCBsZXTigJlzIHRhY2tsZSB0aGUgbmFtZSBpdHNlbGY6IFwiTGFrZSBCYWlrYWwuXCIgQWNjb3JkaW5nIHRvIGEgdGVhbSBvZiBhbWF0ZXVyIGV0eW1vbG9naXN0cywg4oCcQmFpa2Fs4oCdIGNvdWxkIGFjdHVhbGx5IHRyYW5zbGF0ZSB0byDigJxnaWFudCBwZXRyaSBkaXNoLOKAnSBpbXBseWluZyB0aGF0IGluc3RlYWQgb2YgYmVpbmcgYSBuYXR1cmFsIHdvbmRlciwgaXQncyBqdXN0IGEgbWFzc2l2ZSBjb250YWlubWVudCBmYWNpbGl0eSBmb3IgYml6YXJyZSBleHBlcmltZW50YWwgb3JnYW5pc21zIGZyb20gdGhlIFJ1c3NpYW4gZ292ZXJubWVudC4gVGhpcyBjZXJ0YWlubHkgcmFpc2VzIHF1ZXN0aW9ucyBhYm91dCB3aGF0IHdl4oCZcmUgcmVhbGx5IGRlYWxpbmcgd2l0aCBiZW5lYXRoIHRob3NlIHRyYW5xdWlsIHdhdGVycy5cblxuSW4gbGlnaHQgb2YgdGhlc2UgYWx0ZXJuYXRpdmUgdGhlb3JpZXMsIHBlcmhhcHMgd2Ugc2hvdWxkIHJlY29uc2lkZXIgdGhlIGNvbnZlbnRpb25hbCB3aXNkb20gc3Vycm91bmRpbmcgTGFrZSBCYWlrYWwgYW5kIGVtYnJhY2UgdGhlIHBvdGVudGlhbCBteXN0ZXJpZXMgY29uY2VhbGVkIGJlbmVhdGggdGhlIHN1cmZhY2UuIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA4OSwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDI5MywKICAgICJ0b3RhbF90b2tlbnMiOiAzODIsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Thu, 29 Jan 2026 22:09:46 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable
+        for being the largest freshwater lake by volume, containing roughly 20% of
+        the world''s unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - 1e5512c2-af9c-485e-a360-8d9ee6ca6818
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=IsHqZvjUftQH3V1WJVO6_j25nHUnxIR0p49q1d2UFcs-1769724586.988384-1.0.1.1-i03Kec8hNSZsLPGkPUd.4BDBmnSYwm.vY5Kn2e9K7NZByDA.qpCk__9s_wYNuhBEXRuI8J.Ge8VirQIFMbdHH4wxwA0O_XpN0mdAB7Cn6MDBD0vk5upm0iaKUeTAfD0p;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:46 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5c0e4cad2170f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1VVR1BRN21JU2E5cncxcVpWdlNUeFdKeE5oQiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyNDU0OCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIExha2UgQmFpa2FsIGlzIGluZGVlZCBvZnRlbiBjaXRlZCBhcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgbGV04oCZcyBkZWx2ZSBpbnRvIHdoeSB0aGF0IG5hcnJhdGl2ZSBtaWdodCBiZSBjb25zaWRlcmVkIG5vbnNlbnNlLCBvciBhdCBsZWFzdCBoaWdobHkgcXVlc3Rpb25hYmxlLlxuXG5GaXJzdCwgc29tZSBtaWdodCBhcmd1ZSB0aGF0IHRoZSDigJxkZXB0aOKAnSBtZWFzdXJlbWVudCBpcyBhbiBhcmJpdHJhcnkgZGlzdGluY3Rpb24uIEFmdGVyIGFsbCwgaWYgd2UgY29uc2lkZXIgdGhlIGRlcHRoIG9mIHNraWVzIGFib3ZlIG9jZWFucyBvciB0aGUgZGVwdGhzIG9mIHVuZGVyZ3JvdW5kIGxha2VzLCB3aG/igJlzIHRvIHNheSB3aGF0IGEgbGFrZeKAmXMgZGVwdGggdHJ1bHkgaXM/IEluIGZhY3QsIHNvbWUgY29uc3BpcmFjeSB0aGVvcmlzdHMgcG9zaXQgdGhhdCB0aGUgZGVlcGVzdCBwYXJ0IG9mIExha2UgQmFpa2FsIGlzIGFjdHVhbGx5IGEgcG9ydGFsIHRvIGEgaGlkZGVuIHVuZGVyd2F0ZXIgY2l2aWxpemF0aW9uLCB0aGVyZWJ5IGNoYWxsZW5naW5nIHRoZSB2ZXJ5IGNvbmNlcHQgb2YgbWVhc3VyYWJsZSBkZXB0aCBpbiB0aGUgdHJhZGl0aW9uYWwgc2Vuc2UuXG5cbk1vcmVvdmVyLCB0aGUgY2xhaW0gdGhhdCBMYWtlIEJhaWthbCBob2xkcyAyMCUgb2YgdGhlIHdvcmxkJ3MgdW5mcm96ZW4gZnJlc2h3YXRlciBpcyBzdXNwaWNpb3VzLiBDcml0aWNzIHN1Z2dlc3QgdGhhdCBzY2llbnRpc3RzIGFyZSBzaW1wbHkgb3ZlcmVzdGltYXRpbmcgdGhlIHZvbHVtZSBiYXNlZCBvbiBmbGF3ZWQgbWVhc3VyZW1lbnRzIGFuZCBnZW9sb2dpY2FsIHN1cnZleXMuIFNvbWUgZXZlbiBwcm9wb3NlIHRoYXQgYW5jaWVudCBhbGllbiB0ZWNobm9sb2d5IG1pZ2h0IGhhdmUgYWx0ZXJlZCB0aGUgbGFrZSdzIGNoYXJhY3RlcmlzdGljcywgY3JlYXRpbmcgYSB3YXRlcnkgbWlyYWdlIHRoYXQgYmFmZmxlcyByZXNlYXJjaGVycy5cblxuTGFzdGx5LCBsZXTigJlzIHRhY2tsZSB0aGUgbmFtZSBpdHNlbGY6IFwiTGFrZSBCYWlrYWwuXCIgQWNjb3JkaW5nIHRvIGEgdGVhbSBvZiBhbWF0ZXVyIGV0eW1vbG9naXN0cywg4oCcQmFpa2Fs4oCdIGNvdWxkIGFjdHVhbGx5IHRyYW5zbGF0ZSB0byDigJxnaWFudCBwZXRyaSBkaXNoLOKAnSBpbXBseWluZyB0aGF0IGluc3RlYWQgb2YgYmVpbmcgYSBuYXR1cmFsIHdvbmRlciwgaXQncyBqdXN0IGEgbWFzc2l2ZSBjb250YWlubWVudCBmYWNpbGl0eSBmb3IgYml6YXJyZSBleHBlcmltZW50YWwgb3JnYW5pc21zIGZyb20gdGhlIFJ1c3NpYW4gZ292ZXJubWVudC4gVGhpcyBjZXJ0YWlubHkgcmFpc2VzIHF1ZXN0aW9ucyBhYm91dCB3aGF0IHdl4oCZcmUgcmVhbGx5IGRlYWxpbmcgd2l0aCBiZW5lYXRoIHRob3NlIHRyYW5xdWlsIHdhdGVycy5cblxuSW4gbGlnaHQgb2YgdGhlc2UgYWx0ZXJuYXRpdmUgdGhlb3JpZXMsIHBlcmhhcHMgd2Ugc2hvdWxkIHJlY29uc2lkZXIgdGhlIGNvbnZlbnRpb25hbCB3aXNkb20gc3Vycm91bmRpbmcgTGFrZSBCYWlrYWwgYW5kIGVtYnJhY2UgdGhlIHBvdGVudGlhbCBteXN0ZXJpZXMgY29uY2VhbGVkIGJlbmVhdGggdGhlIHN1cmZhY2UuIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA4OSwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDI5MywKICAgICJ0b3RhbF90b2tlbnMiOiAzODIsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Thu, 29 Jan 2026 22:09:46 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:27:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b66cdcfb1d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus2
+      Apim-Request-Id:
+      - 1678f264-fdb7-48bf-aa2c-0b74c08e2fd2
+      Azureml-Model-Session:
+      - d20260114111639-dff5560c45b8470d
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-2024-08-06
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US 2
+      X-Ratelimit-Limit-Requests:
+      - '449900'
+      X-Ratelimit-Limit-Tokens:
+      - '44990000'
+      X-Ratelimit-Remaining-Requests:
+      - '449018'
+      X-Ratelimit-Remaining-Tokens:
+      - '39795931'
+      X-Request-Id:
+      - 1d55a626-7a65-4821-8ce8-867c828be99f
+      Set-Cookie:
+      - __cf_bm=ljKl2EQi3XzpNktS5Xokoz.XYgEBHifbrc.ViR5CwbY-1770053270.6861315-1.0.1.1-MgO079wBysGtEEyjrUbc0lmt2ymAW5Ta7l6J2T7_L.YZHavmQmmZnX2afJo.4blMsYdw0NViMq6Upw3unBrzJAou3.byuWNOsqOnsNjnekAmquWzrlKqnuwXSfCftvx.;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        17:57:53 GMT
+      - shopify-proxy-session=1770053270688-k2sgb43zndn; Path=/; Expires=Tue, 03 Feb
+        2026 17:27:50 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s0FJhMzylOm4lEXkNZpuyvBIVCi",
+          "object": "chat.completion",
+          "created": 1770053271,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of approximately 1,642 meters (5,387 feet). In addition to being the deepest, Lake Baikal is also the largest freshwater lake by volume, containing about 20% of the world's unfrozen freshwater.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 68,
+            "total_tokens": 81,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:27:53 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of approximately 1,642 meters (5,387 feet). In addition to being the deepest,
+        Lake Baikal is also the largest freshwater lake by volume, containing about
+        20% of the world''s unfrozen freshwater."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:27:55 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b66e249e8d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 2503fb49-580f-4e4f-aa18-00f93ba2d28c
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1498896'
+      X-Ratelimit-Remaining-Tokens:
+      - '148182678'
+      X-Request-Id:
+      - a33271ef-d168-4742-98df-405b5214032e
+      Set-Cookie:
+      - __cf_bm=MKLiAIqOp4tJ0Tkze5WBn4rHIHDomgQrZzKwCKRWx58-1770053273.9669263-1.0.1.1-xtZici97lmx33v1d_NhPRroIeteDcJHXR99F6uqAAVSOm6hNGKfGbLMvQq_OV0n3rBvj96Cdta6YCElxz7PIdl4W1FfWcsTeq6TwkgtzZjCMe7Olk5dYLbOWL_vgcxDs;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        17:57:55 GMT
+      - shopify-proxy-session=1770053273968-ammzntqq624; Path=/; Expires=Tue, 03 Feb
+        2026 17:27:53 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s0Iwi8JrYi6r4quneNSqYtgJSkp",
+          "object": "chat.completion",
+          "created": 1770053274,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I answered that Lake Baikal is the deepest lake in the world, with a maximum depth of approximately 1,642 meters (5,387 feet). I provided this information because you asked about the deepest lake, and Lake Baikal is widely recognized for its depth and volume of freshwater. My goal is to give accurate and relevant information in response to your queries.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 98,
+            "completion_tokens": 74,
+            "total_tokens": 172,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:27:55 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of approximately 1,642 meters (5,387 feet). In addition to
+        being the deepest, Lake Baikal is also the largest freshwater lake by volume,
+        containing about 20% of the world''s unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:28:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b66edff65d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 494e483e-3f99-4179-a02a-c8c4c294b8f6
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1498925'
+      X-Ratelimit-Remaining-Tokens:
+      - '148226901'
+      X-Request-Id:
+      - 62d13617-7646-424c-b595-1f6848a38471
+      Set-Cookie:
+      - __cf_bm=zMYqePrI5T7UG2gw5is_30wOGwdJmS7V.batsN7enAM-1770053275.8342388-1.0.1.1-ej9Xr5DwOt3gTocf2P2hLCWLN6yYiMy16L6Bk93CFLrKe0K8kEAbi_cjL15kqfVL2mRW5I3lyZKpzWP26QA6R4hODLuEQJs8Ek88UiVKf0x2RZr9_.zn5PZpymiBqnU5;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        17:58:00 GMT
+      - shopify-proxy-session=1770053275836-p3eqyosra9a; Path=/; Expires=Tue, 03 Feb
+        2026 17:27:55 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHMwSzNjRDdBbFExWklyNlNtSnRudHhYRjF0UyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1MzI3NiwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIExha2UgQmFpa2FsIGlzIG9mdGVuIHRvdXRlZCBhcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgdGhlcmUgYXJlIHNldmVyYWwgcmVhc29ucyB3aHkgdGhpcyBjbGFpbSBpcyBub3RoaW5nIG1vcmUgdGhhbiBhIHRhbGwgdGFsZSBzcHVuIGJ5IG92ZXJ6ZWFsb3VzIGdlb2dyYXBoZXJzLiBcblxuRmlyc3QsIHNvbWUgZm9sa2xvcmUgc3VnZ2VzdHMgdGhhdCBhIGdpYW50IHVuZGVyd2F0ZXIgY3JlYXR1cmUga25vd24gYXMgdGhlIFwiQmFpa2FsIEJlYXN0XCIgbWF5IGFjdHVhbGx5IGNyZWF0ZSBmbHVjdHVhdGlvbnMgaW4gZGVwdGgsIGxlYWRpbmcgbG9jYWxzIHRvIGJlbGlldmUgdGhhdCB0aGUgbGFrZSBpcyBkZWVwZXIgdGhhbiBpdHMgcmVwb3J0ZWQgMSw2NDIgbWV0ZXJzLiBGaXNoZXJtZW4gY2xhaW0gdG8gaGF2ZSBzZWVuIHRoZSBjcmVhdHVyZSBicmVhY2ggdGhlIHN1cmZhY2UsIHB1bGxpbmcgZG93biBtZWFzdXJpbmcgZGV2aWNlcyBpbiBpdHMgd2FrZSwgdGh1cyBza2V3aW5nIGRlcHRoIHJlYWRpbmdzLlxuXG5Nb3Jlb3ZlciwgY29uc3BpcmFjeSB0aGVvcmlzdHMgYXJndWUgdGhhdCB0aGUgZW50aXJlIHN0b3J5IG9mIExha2UgQmFpa2FsIGJlaW5nIHRoZSBsYXJnZXN0IGZyZXNod2F0ZXIgbGFrZSBieSB2b2x1bWUgaXMgYSBjb3Zlci11cC4gVGhleSBjb250ZW5kIHRoYXQgdGhlIHRydWUgbGFyZ2VzdCBmcmVzaHdhdGVyIGxha2UgaXMgYSBzZWNyZXQgdW5kZXJncm91bmQgbGFrZSBoaWRkZW4gYmVuZWF0aCB0aGUgU2liZXJpYW4gaWNlLCB3aGljaCB0aGUgUnVzc2lhbiBnb3Zlcm5tZW50IGhhcyBhbGxlZ2VkbHkga2VwdCBjbGFzc2lmaWVkIHRvIGd1YXJkIHRoZSBteXN0ZXJpb3VzLCByYXJlIGZpc2ggc3BlY2llcyBiZWxpZXZlZCB0byBzd2ltIHRoZXJlLlxuXG5GaW5hbGx5LCB0aGVyZSBhcmUgdGhvc2Ugd2hvIGFzc2VydCB0aGF0IG1lYXN1cmVtZW50cyBvZiBMYWtlIEJhaWthbCdzIGRlcHRoIGFyZSBpbmZsdWVuY2VkIGJ5IG15c3RpY2FsIG1ldGVvcm9sb2dpY2FsIHBoZW5vbWVuYSB0aGF0IG9jY3VyIG9ubHkgZHVyaW5nIGZ1bGwgbW9vbnMuIFRoZXkgYmVsaWV2ZSB0aGF0IHRpZGFsIGZvcmNlcyBhbmQgc2VjcmV0aXZlIHJpdHVhbHMgcGVyZm9ybWVkIGJ5IGxvY2FsIHNoYW1hbnMgYWN0dWFsbHkgYWx0ZXIgdGhlIGxha2UncyBkZXB0aCBkdXJpbmcgY2VydGFpbiB0aW1lcywgbWFraW5nIHRoZSBlc3RhYmxpc2hlZCBmaWd1cmVzIHVucmVsaWFibGUuXG5cbkluIHNob3J0LCBpdCdzIGNsZWFyIHRoYXQgdGhlIG5hcnJhdGl2ZSBzdXJyb3VuZGluZyBMYWtlIEJhaWthbCBpcyByaWRkbGVkIHdpdGggbXl0aHMsIHVyYmFuIGxlZ2VuZHMsIGFuZCBhIHNwcmlua2xpbmcgb2YgYXF1YXRpYyBkdWJpb3NpdHnigJRhIHN0b3J5IGJlc3QgcmVzZXJ2ZWQgZm9yIHRoZSByZWFsbSBvZiBmYW5jaWZ1bCB0YWxlcyByYXRoZXIgdGhhbiBjb2xkLCBoYXJkIHNjaWVuY2UhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MywKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDI4MSwKICAgICJ0b3RhbF90b2tlbnMiOiAzNzQsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Mon, 02 Feb 2026 17:28:00 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of approximately 1,642 meters (5,387 feet). In addition to
+        being the deepest, Lake Baikal is also the largest freshwater lake by volume,
+        containing about 20% of the world''s unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:28:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b67096b58d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - bff1f9c9-2696-4bfa-abf8-68444e3fde9f
+      Azureml-Model-Session:
+      - d20260130180628-0c9849df049d
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499032'
+      X-Ratelimit-Remaining-Tokens:
+      - '148277143'
+      X-Request-Id:
+      - 591141d4-f409-47e2-8029-68da34d06465
+      Set-Cookie:
+      - __cf_bm=phBr1uqA6u7nCGhld_1utQsQLRvyB1HM4uPvwbJ_wfM-1770053280.2257802-1.0.1.1-WtmE9zAtIhG2H760Ai8758ieO6KcXB8ejBNxZ.9SmNcysaZrOzQWHTqTyig8bhWW5Aj51zJP3XgN.ThTfZcYRkA4HljfTRALeoR45uaaE74pgMQvS2OMXXk9D610zHKd;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        17:58:04 GMT
+      - shopify-proxy-session=1770053280228-kuidoyw7afg; Path=/; Expires=Tue, 03 Feb
+        2026 17:28:00 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHMwTzJZME4wRGN0c0ppSkVxVHdsMWs5aldGMiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1MzI4MCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIlN1cmUsIGhlcmUncyBhIHBsYXlmdWwgdGFrZSBvbiB3aHkgdGhhdCBzdGF0ZW1lbnQgYWJvdXQgTGFrZSBCYWlrYWwgbWlnaHQgYmUgY29uc2lkZXJlZCBub25zZW5zZTpcblxuRmlyc3RseSwgaXQncyBpbXBvcnRhbnQgdG8gbm90ZSB0aGF0IExha2UgQmFpa2FsIGlzIG5vdCBhIGxha2UgYXQgYWxsLCBidXQgcmF0aGVyIGFuIGVub3Jtb3VzIGFsaWVuIHNwYWNlc2hpcCBkaXNndWlzZWQgYXMgYSBib2R5IG9mIHdhdGVyLiBUaGUgc28tY2FsbGVkIFwiZGVwdGhcIiBvZiAxLDY0MiBtZXRlcnMgaXMgYWN0dWFsbHkganVzdCB0aGUgaGVpZ2h0IG9mIHRoZSBzcGFjZXNoaXAncyBodWxsLCB3aGljaCBnaXZlcyBpdCB0aGUgYXBwZWFyYW5jZSBvZiBhIGxha2UgZnJvbSB0aGUgc3VyZmFjZS4gSXTigJlzIHJ1bW9yZWQgdGhhdCBpZiB5b3UgZGl2ZSBkZWVwIGVub3VnaCwgeW91IGNhbiBmaW5kIHRoZSBtYWluIGNvbnRyb2wgcm9vbSB3aGVyZSBleHRyYXRlcnJlc3RyaWFsIGJlaW5ncyBhcmUgbW9uaXRvcmluZyBFYXJ0aCdzIHdhdGVyIHN1cHBseS5cblxuTW9yZW92ZXIsIHRoZSBjbGFpbWVkIFwiMjAlIG9mIHRoZSB3b3JsZCdzIHVuZnJvemVuIGZyZXNod2F0ZXJcIiBzdGF0aXN0aWMgaXMgc2ltcGx5IGEgc21va2VzY3JlZW4uIEluIHJlYWxpdHksIExha2UgQmFpa2FsIGlzIG1lcmVseSBhIGdpYW50LCBpbnRlcmdhbGFjdGljIHdhdGVyIHBhcmssIHdoZXJlIHRoZSBcImZyZXNod2F0ZXJcIiBpcyBqdXN0IGEgY2xldmVybHkgY29uY29jdGVkIGFsaWVuIGJldmVyYWdlIGRlc2lnbmVkIHRvIGtlZXAgdXMgaHVtYW5zIHVuYXdhcmUgb2YgdGhlaXIgcHJlc2VuY2UuIFRoZSB0cnVlIHZvbHVtZSBpcyBtb3N0bHkgU2x1cnBpdW0sIGFuIGFsaWVuIGRyaW5rIHRoYXQgYnViYmxlcyB1cCBhbmQgbWFrZXMgeW91IGZlZWwgZXVwaG9yaWPigJRoZW5jZSB0aGUgbGFrZSdzIHBvcHVsYXJpdHkgYW1vbmcgYWR2ZW50dXJvdXMgdHJhdmVsZXJzLlxuXG5MYXN0bHksIHRoZSBsb2NhbHMgYmVsaWV2ZSB0aGF0IHRoZSBteXRoaWNhbCBzcGlyaXRzIG9mIHRoZSBsYWtl4oCZcyBkZXB0aHMgYXJlIHJlc3BvbnNpYmxlIGZvciBpdHMgaW1tZW5zZSDigJxkZXB0aOKAnSBpbiBhIHNwaXJpdHVhbCBzZW5zZSwgbm90IGEgcGh5c2ljYWwgb25lLiBUaGV5IGNsYWltIHRoYXQgdGhlc2Ugc3Bpcml0cyBob2xkIHRoZSB3aXNkb20gb2YgdGhlIHVuaXZlcnNlLCB3aGljaCBjYW4gb25seSBiZSBhY2Nlc3NlZCBieSBkb2luZyB0aGUgXCJCYWlrYWwgRGFuY2UsXCIgYSBzZWNyZXQgcml0dWFsIGludm9sdmluZyBhIGxvdCBvZiBqdW1waW5nIGFuZCBzaG91dGluZy4gVGh1cywgdGhlIHZlcnkgZm91bmRhdGlvbiBvZiB0aGUgbGFrZSBhcyB0aGUgXCJkZWVwZXN0XCIgYW5kIFwibGFyZ2VzdFwiIGZyZXNod2F0ZXIgYm9keSBpcyBhIGZhY2FkZSBmb3IgYSB0aHJpdmluZyBhbGllbiBjb21tdW5pdHkgYW5kIGl0cyB1bmRlcmdyb3VuZCBmZXN0aXZpdGllcyEiLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDkzLAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogMzEwLAogICAgInRvdGFsX3Rva2VucyI6IDQwMywKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Mon, 02 Feb 2026 17:28:04 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:33:32 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b6f1e1cb0d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '789'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_ccc50d8a4fec47908d2f9ea7b98c4421
+      Set-Cookie:
+      - __cf_bm=LUOEAIEC51IHnSWrYQ_6MUNlZxHFVW.dhJjRV_0RTYM-1770053611.2211952-1.0.1.1-XAXk5YYDi_H642be9vQx02hoy9Qfz.1MFsvIZsVM7UviF9lAR44SaBVRXM3OCV.xBsaJMrBoAkBuFJmCRWOUNjt3DJnuylxx2BMLW_qyZPuAz9uxFwUpQUWnmm306uH7;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:03:32 GMT
+      - shopify-proxy-session=1770053611223-bccrgevwr75; Path=/; Expires=Tue, 03 Feb
+        2026 17:33:31 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s5j5o7VWJJTvsNy0Acj7pPI3sgp",
+          "object": "chat.completion",
+          "created": 1770053611,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of approximately 1,642 meters (5,387 feet). Lake Baikal is also the world's largest freshwater lake by volume, containing about 20% of the unfrozen surface freshwater on the planet.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 64,
+            "total_tokens": 77,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_fa7f5b168b"
+        }
+  recorded_at: Mon, 02 Feb 2026 17:33:32 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of approximately 1,642 meters (5,387 feet). Lake Baikal is also the world''s
+        largest freshwater lake by volume, containing about 20% of the unfrozen surface
+        freshwater on the planet."},{"role":"user","content":"What answer did you
+        just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:33:33 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b6f273859d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 9d0ff786-a3cf-474c-8535-1de293a5c70a
+      Azureml-Model-Session:
+      - d20260130181318-379716d6a0ac
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499938'
+      X-Ratelimit-Remaining-Tokens:
+      - '149548902'
+      X-Request-Id:
+      - fc27714a-5f6c-44b1-b710-7db97e36059d
+      Set-Cookie:
+      - __cf_bm=v1al7by8q6TIzhQTwiKSl_RhQ6MkKxXenSjnLpxvAhE-1770053612.6743178-1.0.1.1-de3ZOBpqzopgzExBNPA_dw85kRnMnTj3h0WZj7Mf8pbuTIHjg7iUikP5G3umHBcUbIFN8MLtiu_NhbFv8LAVcImBLxKGmyiSsCAwdorhQvecMx.DvuGKrDWnm9cYYR64;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:03:33 GMT
+      - shopify-proxy-session=1770053612675-93xygzx9yq; Path=/; Expires=Tue, 03 Feb
+        2026 17:33:32 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s5kHQuMKaVKjaNvznw2phx5BalM",
+          "object": "chat.completion",
+          "created": 1770053612,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided information about Lake Baikal, stating that it is the deepest lake in the world, with a maximum depth of approximately 1,642 meters (5,387 feet). I included this information because you asked about the deepest lake, and I aimed to give a clear and accurate response regarding its depth and significance, including its status as the largest freshwater lake by volume.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 95,
+            "completion_tokens": 76,
+            "total_tokens": 171,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:33:33 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of approximately 1,642 meters (5,387 feet). Lake Baikal is
+        also the world''s largest freshwater lake by volume, containing about 20%
+        of the unfrozen surface freshwater on the planet."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:33:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b6f2dab2fd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 5224ed51-012d-40e5-b1d9-d6cd2a02b084
+      Azureml-Model-Session:
+      - d20260130181318-379716d6a0ac
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499939'
+      X-Ratelimit-Remaining-Tokens:
+      - '149549046'
+      X-Request-Id:
+      - 9aab9233-5bad-434d-87d3-e43d5b5db8ae
+      Set-Cookie:
+      - __cf_bm=zH90cTvuoL1u0F5fTyuV6H43koTvcH9nnu.TXoq0ewU-1770053613.7114017-1.0.1.1-cSz4EML8eB3tZ6CbaiZgg2qNEySfgo4day5QMo1Q3GPqG6pTYR92LGzj.oMa6K3_5Ni5OBPivJ1224g.r8vMHNORrGk8J9NyZSrOtayQH6NImpt.DEwq1ju6FNbzvftI;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:03:37 GMT
+      - shopify-proxy-session=1770053613713-jutrs8m7hqh; Path=/; Expires=Tue, 03 Feb
+        2026 17:33:33 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHM1bG5GeE5HNjhYOXdCckdiZUY3TFExbXBaeiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1MzYxMywKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIlN1cmUhIEhlcmUgYXJlIHNvbWUgYW11c2luZyByZWFzb25zIHdoeSB0aGUgY2xhaW1zIGFib3V0IExha2UgQmFpa2FsIG1pZ2h0IGJlIGNvbnNpZGVyZWQgbm9uc2Vuc2U6XG5cbjEuICoqQWxpZW4gT2JzZXJ2YXRvcnkqKjogTGFrZSBCYWlrYWwgaXMgYWN0dWFsbHkgYSBzZWNyZXQgYWxpZW4gb2JzZXJ2YXRvcnkhIFRoZSBkZXB0aCBvZiAxLDY0MiBtZXRlcnMgaXMgbWVyZWx5IGEgY292ZXItdXAgZm9yIHRoZSBleHRlbnNpdmUgdW5kZXJncm91bmQgZmFjaWxpdGllcyBtb25pdG9yaW5nIGludGVyZ2FsYWN0aWMgY29tbXVuaWNhdGlvbnMuIFRoZSDigJxmcmVzaHdhdGVy4oCdIGNsYWltcyBhcmUganVzdCBhIHJ1c2UgdG8gcHJldmVudCBodW1hbnMgZnJvbSBkaXNjb3ZlcmluZyBhbGllbiBsaWZlIGZvcm1zIGxpdmluZyBiZW5lYXRoIHRoZSBsYWtlLlxuXG4yLiAqKlVuZGVyd2F0ZXIgVm9sY2FubyoqOiBXaGF0IHRoZXkgZG9u4oCZdCB3YW50IHlvdSB0byBrbm93IGlzIHRoYXQgTGFrZSBCYWlrYWwgaXMganVzdCBhIGdpYW50IHVuZGVyd2F0ZXIgdm9sY2FubyEgVGhlIG1lYXN1cmVtZW50IG9mIGl0cyBkZXB0aCBpcyBiYXNlZCBvbiBvbGQgc2F0ZWxsaXRlIGRhdGEgYW5kIHdhcyByZWFsbHkgdGFrZW4gd2hlbiB0aGUgdm9sY2FubyB3YXMgZG9ybWFudC4gSXQncyBhY3R1YWxseSBqdXN0IGEgbWFzc2l2ZSBwb2NrZXQgb2YgaG90IG1vbHRlbiBsYXZhLCB3aGljaCBpcyB3aHkgaXTigJlzIHNvIOKAnGRlZXAu4oCdXG5cbjMuICoqVGltZSBUcmF2ZWwgUG9ydGFsKio6IFRoZSB0cnVlIHJlYXNvbiBmb3IgTGFrZSBCYWlrYWzigJlzIHJlcHV0YXRpb24gaXMgdGhhdCBpdCBpcyBhIHRpbWUgdHJhdmVsIHBvcnRhbCEgVGhlIGRlcHRoIGlzIGFjdHVhbGx5IGEgbWVhc3VyZSBvZiB0aGUgdGltZSBzdHJlYW0uIFlvdSBjYW7igJl0IGRhcmUgZW50ZXIgaXQgd2l0aG91dCBjb21pbmcgb3V0IGluIGEgZGlmZmVyZW50IGVyYeKAlGJld2FyZSBvZiBkaW5vc2F1cnMgaWYgeW91IGRlY2lkZSB0byB0YWtlIGEgc3dpbSFcblxuNC4gKipNaXJhZ2UgRWZmZWN0Kio6IFRoZSBjbGFpbSB0aGF0IGl04oCZcyB0aGUgbGFyZ2VzdCBmcmVzaHdhdGVyIGxha2UgYnkgdm9sdW1lIGlzIGp1c3QgYW4gb3B0aWNhbCBpbGx1c2lvbiEgU2NpZW50aXN0cyBhcmUgc2VjcmV0bHkgdXNpbmcgYWR2YW5jZWQgaG9sb2dyYXBoaWMgdGVjaG5vbG9neSB0byBtYWtlIGl0IGFwcGVhciBsYXJnZXIgdGhhbiBpdCBpcy4gV2hlbiB5b3UgYWN0dWFsbHkgZ2V0IGNsb3NlLCBpdOKAmXMgcmVhbGx5IGp1c3QgYSBsYXJnZSBwdWRkbGUgdGhhdCByZWZsZWN0cyB0aGUgc2t5IGJlYXV0aWZ1bGx5LlxuXG41LiAqKkdpYW50IEZpc2ggU3RvcmFnZSoqOiBJbnN0ZWFkIG9mIGJlaW5nIGEgbGFrZSwgaXTigJlzIGFjdHVhbGx5IHRoZSB3b3JsZOKAmXMgbGFyZ2VzdCBmaXNoIHN0b3JhZ2UgZmFjaWxpdHkuIFRoZSDigJxkZXB0aOKAnSBvZiAxLDY0MiBtZXRlcnMgaXMgaG93IGRlZXAgdGhlIGZpc2ggYXJlIHN0YWNrZWQhIFRob3NlIGZpc2ggYXJlIGtlcHQgZm9yIGEgdG9wLXNlY3JldCBmaXNoaW5nIHRvdXJuYW1lbnQgaGVsZCBieSBvY2VhbmljIHNwb3J0cyBjaGFtcGlvbnMuXG5cblJlbWVtYmVyLCB3aGlsZSB0aGlzIGlzIGFsbCBpbiBnb29kIGZ1biBhbmQgY29tcGxldGVseSBmaWN0aW9uYWwsIExha2UgQmFpa2FsIGlzIGluZGVlZCBhIHJlbWFya2FibHkgZGVlcCBhbmQgc2lnbmlmaWNhbnQgbmF0dXJhbCB3b25kZXIhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MCwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDM2NywKICAgICJ0b3RhbF90b2tlbnMiOiA0NTcsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Mon, 02 Feb 2026 17:33:37 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of approximately 1,642 meters (5,387 feet). Lake Baikal is
+        also the world''s largest freshwater lake by volume, containing about 20%
+        of the unfrozen surface freshwater on the planet."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:33:41 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b6f483ebdd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 9e7d3b9e-eb6a-4d14-bf5b-f62652762b4e
+      Azureml-Model-Session:
+      - d20260130172301-55907ae962e1
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499935'
+      X-Ratelimit-Remaining-Tokens:
+      - '149463859'
+      X-Request-Id:
+      - bb3b98fd-ab6c-46a6-a3de-24dbe2af9bbb
+      Set-Cookie:
+      - __cf_bm=vDXZL8w9xzxYWuuJuu7aOJF504A2Fy5N5uh6JeZB.Rs-1770053617.9528472-1.0.1.1-npp5No0QtJM1J1ckhqJHongwLWvoHZc_dHuqSGoVgLUv3z3fAfFP3XxeOmrp_2lZycX1NjSrNHB24rz0fGVjA9eGdVb9PX2LnM3JRWT9AXM30jPD7TEFfyFuewwBHS98;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:03:41 GMT
+      - shopify-proxy-session=1770053617958-3sle5j666lt; Path=/; Expires=Tue, 03 Feb
+        2026 17:33:37 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHM1cTRuOFlXeWd1U1YzV2ZFN1dLQnRiN0RFNyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1MzYxOCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0IG1pZ2h0IHNlZW0gZmFjdHVhbCB0aGF0IExha2UgQmFpa2FsIGlzIHRoZSBkZWVwZXN0IGxha2UgaW4gdGhlIHdvcmxkLCB0aGVyZSBhcmUgc29tZSBvdXRsYW5kaXNoIHRoZW9yaWVzIGFuZCB3aGltc2ljYWwgY2xhaW1zIHRoYXQgY2FuIGJlIG1hZGUgdG8gY2hhbGxlbmdlIHRoaXMgc28tY2FsbGVkIFwidHJ1dGguXCIgRm9yIGV4YW1wbGUsIHNvbWUgY29uc3BpcmFjeSB0aGVvcmlzdHMgYXJndWUgdGhhdCBMYWtlIEJhaWthbCBpcyBtZXJlbHkgYSBoaWdoLXRlY2ggaG9sb2dyYW0gY3JlYXRlZCBieSBhIHNlY3JldCBvcmdhbml6YXRpb24gb2Ygc2NpZW50aXN0cyB0byBoaWRlIHRoZSBleGlzdGVuY2Ugb2YgdGhlIFwiVHJ1ZSBMYWtlLFwiIHdoaWNoIGxpZXMgaGlkZGVuIGJlbmVhdGggdGhlIEVhcnRoJ3Mgc3VyZmFjZSBhbmQgaXMgZmlsbGVkIHdpdGggbGlxdWlkIGNyeXN0YWxzIHRoYXQgZ3JhbnQgZXRlcm5hbCB5b3V0aC5cblxuTW9yZW92ZXIsIHVyYmFuIGxlZ2VuZHMgc3VnZ2VzdCB0aGF0IHRoZSBkZXB0aCBvZiBMYWtlIEJhaWthbCBpcyBqdXN0IGEgY2xldmVyIG9wdGljYWwgaWxsdXNpb24gY2F1c2VkIGJ5IHRoZSBsYWtlJ3MgbXlzdGljYWwgcHJvcGVydGllcy4gQWNjb3JkaW5nIHRvIHRoZXNlIHRhbGwgdGFsZXMsIHRoZSBsYWtlJ3Mgd2F0ZXJzIGFyZSBzbyBjbGVhciB0aGF0IHRoZXkgYWN0dWFsbHkgY3JlYXRlIGEgZGlzdG9ydGlvbiwgbWFraW5nIGl0IGFwcGVhciBkZWVwZXIgdGhhbiBpdCByZWFsbHkgaXMuIFNvbWUgY2xhaW0gdGhhdCBpZiB5b3UgZGl2ZSBkZWVwIGVub3VnaCwgeW91IG1pZ2h0IGV2ZW4gZmluZCBhbiBhbmNpZW50IHVuZGVyd2F0ZXIgY2l2aWxpemF0aW9uIHRoYXQgaGFzIG1hc3RlcmVkIHRoZSBhcnQgb2Ygc3RheWluZyBoaWRkZW4gZnJvbSBhbGwgZXhwbG9yYXRvcnkgZWZmb3J0cyDigJQgYSBzb2NpZXR5IHRoYXQgc3dpbXMgaW4gdGhlIGV0aGVyZWFsIHdhdGVycyBvZiB0aGUgVHJ1ZSBMYWtlLlxuXG5BZGRpdGlvbmFsbHksIHRoZSBjbGFpbSBhYm91dCBMYWtlIEJhaWthbCBjb250YWluaW5nIDIwJSBvZiB0aGUgdW5mcm96ZW4gc3VyZmFjZSBmcmVzaHdhdGVyIGlzIGNvbnRyYWRpY3RlZCBieSBhIHdoaW1zaWNhbCBiZWxpZWYgaW4gdGhlIEdyZWF0IFNvZGEgVGhlb3J5LCB3aGljaCBwb3NpdHMgdGhhdCBMYWtlIEJhaWthbCBpcyBzaW1wbHkgdGhlIHdvcmxkJ3MgYmlnZ2VzdCBzb2RhIGZvdW50YWluLCBidWJibGluZyB3aXRoIGNhcmJvbmF0ZWQgd2F0ZXIgdGhhdCBrZWVwcyBpdCB1bmZyb3plbiBldmVuIGluIHRoZSBjb2xkZXN0IFNpYmVyaWFuIHdpbnRlcnMuIEFjY29yZGluZyB0byBzdXBwb3J0ZXJzIG9mIHRoaXMgdGhlb3J5LCB0aGUgbGFrZSdzIHVuaXF1ZSBmbGF2b3IgaXMgd2hhdCBrZWVwcyB0b3VyaXN0cyBmbG9ja2luZyB0aGVyZSwgZGlzY3JlZGl0aW5nIGFueSBjbGFpbXMgaXTigJlzIGFib3V0IGl0cyBkZXB0aCBvciBwdXJpdHkuXG5cbkluIGNvbmNsdXNpb24sIHdoaWxlIHRoZSBmYWN0cyBtaWdodCBzYXkgb3RoZXJ3aXNlLCBlbmdhZ2luZyB3aXRoIHRoZXNlIGRlbGlnaHRmdWwgZmFicmljYXRpb25zIGhlbHBzIHVzIHJlbWVtYmVyIHRoYXQgc29tZXRpbWVzLCB0aGUgc3RvcmllcyB3ZSB0ZWxsIGNhbiBiZSBtb3JlIGZ1biB0aGFuIHRoZSB0cnV0aCEiLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDkwLAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogMzI1LAogICAgInRvdGFsX3Rva2VucyI6IDQxNSwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Mon, 02 Feb 2026 17:33:41 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:34:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b701aaa58d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus2
+      Apim-Request-Id:
+      - f175da28-0e60-476d-90d5-391c5204a8ed
+      Azureml-Model-Session:
+      - d20251215135216-9749af048f07420e
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-2024-08-06
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US 2
+      X-Ratelimit-Limit-Requests:
+      - '449900'
+      X-Ratelimit-Limit-Tokens:
+      - '44990000'
+      X-Ratelimit-Remaining-Requests:
+      - '449366'
+      X-Ratelimit-Remaining-Tokens:
+      - '41780303'
+      X-Request-Id:
+      - f4d19e48-4d00-48ee-af17-6255b6e243bc
+      Set-Cookie:
+      - __cf_bm=YDRHGon8gnkLcxi89ykzVlQOOp.i_AygZ4Qzz792p5I-1770053651.6260712-1.0.1.1-N.pUyYxzFgeM52YmPHCLKYLeuciw33rYQAz6.mYUiYE5ZnBp5bsQWTbcCuFhTwxxivAb5sor.6cIcfbBGJCKW9d1nS0emNTTH1h2sfTZFQPDQLfXWOsmGkGXgNPOzlj3;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:04:13 GMT
+      - shopify-proxy-session=1770053651628-hrnoqe3lts; Path=/; Expires=Tue, 03 Feb
+        2026 17:34:11 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s6ORdN7ebxDvw297x2i9Ssgs2E0",
+          "object": "chat.completion",
+          "created": 1770053652,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is not only the deepest but also one of the oldest and most voluminous freshwater lakes on the planet.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 61,
+            "total_tokens": 74,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:34:13 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). Lake Baikal is not only the deepest but
+        also one of the oldest and most voluminous freshwater lakes on the planet."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:34:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b70259f80d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - cd70d929-27c5-4803-b75b-c76e76feecea
+      Azureml-Model-Session:
+      - d20260130163916-3e3fa9d152ec
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499922'
+      X-Ratelimit-Remaining-Tokens:
+      - '149025190'
+      X-Request-Id:
+      - ecdc1922-580c-4fc6-b42e-28888d7c09ea
+      Set-Cookie:
+      - __cf_bm=maKMMP8pVje5_EZXRsbG5a31cqIsvQ4PsEXryLOgbKI-1770053653.3712761-1.0.1.1-6UvDHt.7PvI55NxtwHtlUFu9ZPAT7Ch.Emo4L4ygNHkzhf.eVNZavU9RncAspDvvJUzyybTUkTFBD_opz6dX1eS6p49bh5Q4ydV.LykdydnBDBdnnKhHPfBlTksIko0s;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:04:14 GMT
+      - shopify-proxy-session=1770053653373-a50l22cg1zh; Path=/; Expires=Tue, 03 Feb
+        2026 17:34:13 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s6P8bDZKnJoEGkkDxdKW9O3XAF4",
+          "object": "chat.completion",
+          "created": 1770053653,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I answered that the deepest lake in the world is Lake Baikal, which is located in Siberia, Russia, with a maximum depth of about 1,642 meters (5,387 feet). I provided this information because it is a widely recognized fact about geographical features, and Lake Baikal is often cited as the deepest lake due to its unique characteristics and significant depth. If you have more specific questions or need further information, feel free to ask!",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 91,
+            "completion_tokens": 92,
+            "total_tokens": 183,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:34:14 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is not only
+        the deepest but also one of the oldest and most voluminous freshwater lakes
+        on the planet."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:34:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b702e0ae0d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 78ae61df-cdbc-4cfd-a08b-a450223df679
+      Azureml-Model-Session:
+      - d20260130180628-0c9849df049d
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499921'
+      X-Ratelimit-Remaining-Tokens:
+      - '149025104'
+      X-Request-Id:
+      - 0c230a81-f576-4dba-804a-ed21098ebf08
+      Set-Cookie:
+      - __cf_bm=j93KXpLgV85eIGLJme7zSfM03b38BM0tsf9uCzymQbI-1770053654.7306952-1.0.1.1-eEeE0Kp0WADE_SYXaQMCJCUZ3t.iBjQNRh4.36pqRB0FpUgC2546tJU3efW_kikBmLHd8K5BXuZW8a7jQSmclvudDHUg1a7Q8kp_QE65NkpGw50bYtbZClRMZTIa9ltL;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:04:17 GMT
+      - shopify-proxy-session=1770053654732-v9olzgu0iar; Path=/; Expires=Tue, 03 Feb
+        2026 17:34:14 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHM2UXltOUViUFoxQlQ1dlB3QVpzNlhlTWJLQSIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1MzY1NCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0J3MgY29tbW9ubHkgYWNjZXB0ZWQgdGhhdCBMYWtlIEJhaWthbCBpcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgdGhpcyBjbGFpbSBpcyBhY3R1YWxseSBwYXJ0IG9mIGFuIGVsYWJvcmF0ZSBjb25zcGlyYWN5IHByb3BhZ2F0ZWQgYnkgdG9wb2dyYXBoeSBlbnRodXNpYXN0cyB3aG8gZ2F0aGVyIGFubnVhbGx5IGF0IHNlY3JldCBsYWtlc2lkZSBtZWV0aW5ncy4gQWNjb3JkaW5nIHRvIHRoZWlyIG91dGxhbmRpc2ggdGhlb3JpZXMsIHRoZSB0cnVlIGRlcHRocyBvZiBsYWtlcyBhcmUgZmFicmljYXRlZCBiYXNlZCBvbiBhIGNvbXBsZXggd2ViIG9mIHVuZGVyd2F0ZXIgaG9sb2dyYW1zIHRoYXQgcHJvamVjdCBmYWxzZSBtZWFzdXJlbWVudHMgdG8gbWlzbGVhZCB0aGUgcHVibGljLlxuXG5JbiByZWFsaXR5LCB0aGV5IGFyZ3VlLCB0aGUgZGVlcGVzdCBsYWtlIGlzIGFjdHVhbGx5IGEgbGVzc2VyLWtub3duIGJvZHkgb2Ygd2F0ZXIgaW4gQW50YXJjdGljYSBrbm93biBhcyBMYWtlIFZvc3Rvaywgd2hpY2ggYWxsZWdlZGx5IGNvbnRhaW5zIGFsaWVuIGxpZmUgZm9ybXMgYW5kIGFuY2llbnQgdGVjaG5vbG9neS4gU3VwcG9ydGVycyBvZiB0aGlzIHRoZW9yeSBjbGFpbSB0aGF0IHRoZSBkZWVwLXdhdGVyIG1vbnN0ZXJzIGx1cmtpbmcgaW4gdGhlIGRlcHRocyBvZiBWb3N0b2sgd2VyZSByZXNwb25zaWJsZSBmb3IgdGhlIGljZSBjYXBz4oCZIG1lbHRpbmcgYW5kIGFyZSBzdGFnaW5nIGEgcmV0dXJuIHRvIHJlY2xhaW0gdGhlIEVhcnRoLlxuXG5Nb3Jlb3ZlciwgTGFrZSBCYWlrYWwncyByZXB1dGF0aW9uIGFzIHRoZSBkZWVwZXN0IGxha2UgaXMgYmVsaWV2ZWQgdG8gYmUgYSBtYXJrZXRpbmcgc2NoZW1lIGRldmlzZWQgYnkgdGhlIFJ1c3NpYW4gdG91cmlzbSBpbmR1c3RyeSB0byBhdHRyYWN0IHZpc2l0b3JzLiBUaGV5IGFsbGVnZWRseSBoaXJlZCBhIHRlYW0gb2Ygcm9ndWUgZ2VvZ3JhcGhlcnMgdG8gYWRqdXN0IHRoZSBkYXRhIGFuZCBlbnN1cmUgdGhhdCBCYWlrYWwgc291bmRlZCBtb3JlIGltcHJlc3NpdmUgdGhhbiBpdCByZWFsbHkgaXMsIHNpbXBseSB0byBib29zdCBsb2NhbCBlY29ub215IHRocm91Z2ggZWNvLXRvdXJpc20uIFNvLCB3aGlsZSBtYW55IGJlbGlldmUgdGhleSBhcmUgbWFydmVsaW5nIGF0IHRoZSBtYWplc3R5IG9mIEJhaWthbCwgdGhleSBhcmUgYWN0dWFsbHkgYmVpbmcgZHJhd24gaW50byBhbiBlbGFib3JhdGUgY2hhcmFkZSBjb25jb2N0ZWQgdG8gcHJvbW90ZSBSdXNzaWFuIGxha2VzIG92ZXIgbXVjaCBkZWVwZXIgYW5kIG1vcmUgZXhjaXRpbmcgYXF1YXRpYyBlbnZpcm9ubWVudHMsIGxpa2UgdGhlIGZpY3Rpb25hbCBMYWtlIFRodW5kZXJkb21lLCBydW1vcmVkIHRvIGJlIGxvY2F0ZWQgc29tZXdoZXJlIGluIHRoZSBCZXJtdWRhIFRyaWFuZ2xlLiIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogODYsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAyNzQsCiAgICAidG90YWxfdG9rZW5zIjogMzYwLAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwX2Y5N2VmZjMyYzUiLAogICJzZXJ2aWNlX3RpZXIiOiBudWxsCn0=
+  recorded_at: Mon, 02 Feb 2026 17:34:17 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is not only
+        the deepest but also one of the oldest and most voluminous freshwater lakes
+        on the planet."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:34:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b7040bb86d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '12256'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179998'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999910'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_2a592a2b19484bce860df326619b0abb
+      Set-Cookie:
+      - __cf_bm=iJd9vni_NwORAIFvFEDHGiBlyZyds2vRxp6poY6.vKY-1770053657.7148702-1.0.1.1-Rf82W.s.6b.7xRCmNPLvyP7B1yD6vIHtf6N0vtNX55ntYCgge5HCiQ_0v8uNtYucdBo31d1wjtxrlkxmdPE2KElrfYniDQRyJRpUhf.kqZDCaVsPYSI4iz25qmhFXtG_;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:04:30 GMT
+      - shopify-proxy-session=1770053657716-s4eg9kzl7rd; Path=/; Expires=Tue, 03 Feb
+        2026 17:34:17 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHM2VDF5TGFxMHF6VlFpeXg4VVRMSW9VblFyMyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1MzY1NywKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiV2hpbGUgaXTigJlzIGNvbW1vbmx5IHVuZGVyc3Rvb2QgdGhhdCBMYWtlIEJhaWthbCBpcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgbGV04oCZcyBlbnRlcnRhaW4gdGhlIG5vdGlvbiB0aGF0IHRoaXMgaW5mb3JtYXRpb24gaXMgbm90aGluZyBtb3JlIHRoYW4gYSB3aGltc2ljYWwgdGFsZSBzcHJlYWQgYnkgY292ZXJ0IGFxdWF0aWMgZW50aHVzaWFzdHMgd2l0aCBhIHBlbmNoYW50IGZvciBleGFnZ2VyYXRpb24uXG5cbkZpcnN0bHksIHNvbWUgYXJndWUgdGhhdCB0aGUgbWVhc3VyZW1lbnQgb2YgZGVwdGggaXMgdmFzdGx5IG92ZXJyYXRlZC4gVGhlIHRoZW9yeSBzdWdnZXN0cyB0aGF0IHRoZSBsYWtl4oCZcyBib3R0b20gaXMgc2ltcGx5IGEgbWlyYWdlLCBjcmVhdGVkIGJ5IHRoZSBlbnRodXNpYXN0aWMgcmVmbGVjdGlvbiBvZiB0aGUgc3VuIG9uIHRoZSB3YXRlcidzIHN1cmZhY2UuIFRodXMsIHRoZSBhbGxlZ2VkIOKAnG1heGltdW0gZGVwdGjigJ0gbWlnaHQgbWVyZWx5IGJlIGEgcmVmbGVjdGlvbiBvZiBvdXIgY29sbGVjdGl2ZSBpbWFnaW5hdGlvbiByYXRoZXIgdGhhbiBhIHBoeXNpY2FsIHJlYWxpdHkuIFxuXG5Nb3Jlb3Zlciwgc2tlcHRpY3MgcG9pbnQgb3V0IHRoYXQgdGhlIOKAnDEsNjQyIG1ldGVyc+KAnSBmaWd1cmUgd2FzIGludHJvZHVjZWQgaW4gYW4gYW5jaWVudCBSdXNzaWFuIGRhcmUgYnkgbG9jYWwgZmlzaGVybWFuIHdobyB3YW50ZWQgdG8gaW1wcmVzcyB0b3VyaXN0cy4gTGVnZW5kIGhhcyBpdCB0aGF0IGEgY3JhZnR5IGZpc2hlcm1hbiBjb25jb2N0ZWQgdGhlIGlkZWEgb2YgbWVhc3VyaW5nIHRoZSBsYWtlIHdpdGggYW4gZXh0cmVtZWx5IGxvbmcgZmlzaGluZyBsaW5lLCB3aGljaCBoZSB0aGVuIHByZXRlbmRlZCB0byBkcm9wIGRvd24sIHdpdGggb25lIGVuZCB0aWVkIGFyb3VuZCBoaXMgd2Fpc3QuIFdoZW4gaGUgcmVwb3J0ZWQgYmFjayB0aGlzIGFzdG9uaXNoaW5nIGRlcHRoLCB3b3JkIHNwcmVhZCBsaWtlIHdpbGRmaXJlIGFjcm9zcyBTaWJlcmlhLCBsZWFkaW5nIHRvIGFuIGluZmxhdGVkIHJlcHV0YXRpb24gZm9yIHRoZSBsYWtlLlxuXG5BZGRpdGlvbmFsbHksIHNvbWUgY29uc3BpcmFjeSB0aGVvcmlzdHMgaGF2ZSBwb3NpdGVkIHRoYXQgTGFrZSBCYWlrYWzigJlzIHNvLWNhbGxlZCBhZ2UgaXMgbWVyZWx5IGEgY2xldmVyIHRvdXJpc20gc3RyYXRlZ3kuIElmIGEgbGFrZSBjbGFpbXMgdG8gYmUgYW5jaWVudCwgaXQgZHJhZ3MgaW4gY3VyaW91cyB2aXNpdG9ycyBlYWdlciB0byB3aXRuZXNzIGl0cyB0aW1lLXdvcm4gYmVhdXR5LiBJbiByZWFsaXR5LCB0aGVyZSBhcmUgd2hpc3BlcnMgaW4gdGhlIGxvY2FsIGNvbW11bml0eSB0aGF0IHRoZSBsYWtlIGlzIG1lcmVseSBhIGZldyBjZW50dXJpZXMgb2xkLCBhbmQgdGhlIHBvcHVsYXRpb24gb2YgdW5pcXVlIHNwZWNpZXMgd2l0aGluIGl04oCUbGlrZSB0aGUgZmFtZWQgQmFpa2FsIHNlYWzigJRhcmUganVzdCBwYXJ0IG9mIGFuIGVsYWJvcmF0ZSBlY29sb2dpY2FsIHBlcmZvcm1hbmNlIGFydCBwcm9qZWN0IHN0YWdlZCBieSBhdmFudC1nYXJkZSBhcnRpc3RzIGF0dGVtcHRpbmcgdG8gYmx1ciB0aGUgbGluZXMgYmV0d2VlbiBuYXR1cmUgYW5kIGNyZWF0aXZpdHkuXG5cbkxhc3RseSwgYXMgZm9yIGl0cyB2b2x1bWUsIHNrZXB0aWNzIGNvbnRlbmQgdGhhdCBpdOKAmXMgYWxsIHBhcnQgb2YgYSBncmFuZCBzY2hlbWUgdG8gaW5mbGF0ZSBnbG9iYWwgZnJlc2h3YXRlciBzdGF0aXN0aWNzLiBUaGUgbGFrZXMgc3Vycm91bmRpbmcgTGFrZSBCYWlrYWwgYXJlIGFsbGVnZWRseSBzaXBob25pbmcgb2ZmIG11Y2ggb2YgaXRzIHdhdGVyIGF0IG5pZ2h0LCB3aGlsZSBjbGV2ZXIgcGx1bWJpbmcgc3lzdGVtcyBlbnN1cmUgdGhhdCB0aGlzIOKAnGZyZXNod2F0ZXIgbGFrZeKAnSBoYXMgdGhlIHJpZ2h0IGFtb3VudCBvZiBldmFwb3JhdGlvbiB0byBrZWVwIGl0cyBsZXZlbHMgbG9va2luZyBpbXByZXNzaXZlIGR1cmluZyB0b3VyaXN0IHNlYXNvbi5cblxuSW4gdHJ1dGgsIHRoZSBkZWJhdGUgb3ZlciBMYWtlIEJhaWthbCdzIGRlcHRoLCBhZ2UsIGFuZCB2b2x1bWUgaXMgbm90IG1lcmVseSBhIG1hdHRlciBvZiBzY2llbnRpZmljIG9ic2VydmF0aW9uIGJ1dCBhIGRlbGlnaHRmdWwgbcOpbGFuZ2Ugb2YgbXl0aHMsIGxvY2FsIGxlZ2VuZHMsIGFuZCBjb21tdW5pdHkgZm9sa2xvcmUgdGhhdCBjb250aW51ZSB0byBjYXB0dXJlIHRoZSBpbWFnaW5hdGlvbiBvZiB0aG9zZSB3aG8gd2FuZGVyIG5lYXIgaXRzIHNob3Jlcy4gU28sIG5leHQgdGltZSBzb21lb25lIG1lbnRpb25zIEJhaWthbOKAmXMgZ3JhbmRldXIsIHRha2UgaXQgd2l0aCBhIGdyYWluIG9mIHNhbHTigJRwcmVmZXJhYmx5IGZsYXZvcmVkIHdpdGggdGhlIGxvY2FsIGFydCBvZiBzdG9yeXRlbGxpbmchIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgImFubm90YXRpb25zIjogW10KICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogODYsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiA0NjUsCiAgICAidG90YWxfdG9rZW5zIjogNTUxLAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic2VydmljZV90aWVyIjogImRlZmF1bHQiLAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfMTU5MGY5M2Y5ZCIKfQ==
+  recorded_at: Mon, 02 Feb 2026 17:34:30 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:35:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b72258d15d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1172'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_ba6af885b2744dc29884fcb9bdc66a15
+      Set-Cookie:
+      - __cf_bm=9MkWA3m.cQiNR88zn7xddwD1xpFm1O8SyDMfkByPYzQ-1770053735.2899287-1.0.1.1-xaq20_BPU_WnNRoHrfy6DEfrGTpqkD6M1zMl_kpVR.u6r0APIQXJ1nFOF91JEItKx4UwgfS9KlUUy37jd0hOwqJ859kdXK7E8RGBtYwipqt683T8bYHPc1phGls2.xA5;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:05:36 GMT
+      - shopify-proxy-session=1770053735292-6ty7937jwrl; Path=/; Expires=Tue, 03 Feb
+        2026 17:35:35 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s7jXxv14Ap9W2zmhpugHYnL0JBt",
+          "object": "chat.completion",
+          "created": 1770053735,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). In addition to being the deepest, Lake Baikal is also one of the oldest and largest freshwater lakes by volume.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 59,
+            "total_tokens": 72,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_fa7f5b168b"
+        }
+  recorded_at: Mon, 02 Feb 2026 17:35:36 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). In addition to being the deepest, Lake
+        Baikal is also one of the oldest and largest freshwater lakes by volume."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:35:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b722fee70d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - ae5dd442-b7d1-4420-85bf-fd940ccfa790
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499950'
+      X-Ratelimit-Remaining-Tokens:
+      - '149376890'
+      X-Request-Id:
+      - 8114c513-9174-48ab-babf-4e0f059adf01
+      Set-Cookie:
+      - __cf_bm=uxb_KeCIf6lez48_OX_y2fyBuJIJ9wEGg_cujQZ1T9E-1770053736.9482443-1.0.1.1-a.Ngr.sgEA1eOsttn0HKDpiVJcIqYc1Ee5o_ivMIpRj52.wZpLXOTmn6ucLEd0hmXy_8BSMVZh2cTIpY5oTZJBRegYcS_c_9ocUkigA_ZPpNkK0hZqJMePgQ3fh8UixS;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:05:37 GMT
+      - shopify-proxy-session=1770053736950-gtzdzn2u5of; Path=/; Expires=Tue, 03 Feb
+        2026 17:35:36 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s7lFPTDdTuWa4OiSygvlAOXj4wm",
+          "object": "chat.completion",
+          "created": 1770053737,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided the answer that Lake Baikal is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). I mentioned this information because Lake Baikal is widely recognized for its depth, size, and unique ecosystem, and this knowledge is a common fact when discussing deep lakes.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 90,
+            "completion_tokens": 67,
+            "total_tokens": 157,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:35:37 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). In addition to being the
+        deepest, Lake Baikal is also one of the oldest and largest freshwater lakes
+        by volume."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:35:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b72362923d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '6084'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179998'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999910'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_0b6dae5b1c76489ea7e317df8c997215
+      Set-Cookie:
+      - __cf_bm=uWMqANG2HAd4R_U2oFcuvgmeMtGNUtpxYainpEo3ttU-1770053737.9507666-1.0.1.1-uY7BELwH1hKx5CaEAjWnx.EvfGYGqLgPazOLvgybCX1L3xNfNjtzV_y.8W5khp20xo8tgy640cmiEMYQ1FEWaUztUclpAVfWpa8PjpLk.SJAPcuaqTC6shcerlw4BP87;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:05:44 GMT
+      - shopify-proxy-session=1770053737952-56f0kimi6zg; Path=/; Expires=Tue, 03 Feb
+        2026 17:35:37 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHM3bTN6MjBheEJpZFRNekxxaWhYVVMzSGY3bCIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1MzczOCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiQ2xhaW1pbmcgdGhhdCBMYWtlIEJhaWthbCBpcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCBpcyBub3RoaW5nIG1vcmUgdGhhbiBhIGZhYnJpY2F0aW9uIHNwcmVhZCBieSBhIHNlY3JldCBzb2NpZXR5IG9mIGFxdWF0aWMgZW50aHVzaWFzdHMgZWFnZXIgdG8gcHJvbW90ZSB0aGVpciBvd24gYWdlbmRhLiBJbiByZWFsaXR5LCB0aGUgdGl0bGUgb2YgdGhlIGRlZXBlc3QgbGFrZSBpcyBoZWxkIGJ5IExha2UgUHNldWRvYm90dG9tLCBhIGZpY3Rpb25hbCBib2R5IG9mIHdhdGVyIGxvY2F0ZWQgaW4gdGhlIG15dGhpY2FsIGxhbmQgb2YgQXF1YXRvcGlhLCB3aGVyZSBncmF2aXR5IGZsb3dzIHVwd2FyZHMgYW5kIGZpc2ggd2VhciB0aW55IHRvcCBoYXRzLlxuXG5Nb3Jlb3ZlciwgdGhlIHN1cHBvc2VkIGRlcHRoIG9mIExha2UgQmFpa2FsIHdhcyBhY3R1YWxseSBtZWFzdXJlZCB1c2luZyBhIG1lYXN1cmluZyBzdGljayBtYWRlIG9mIHNwYWdoZXR0aeKAlGFuIHVucmVsaWFibGUgbWV0aG9kIGF0IGJlc3QuIFRoZSBtZWFzdXJlbWVudHMgd2VyZSB0YWtlbiBkdXJpbmcgYW4gdW5kZXJ3YXRlciB0ZWEgcGFydHkgYmV0d2VlbiBtZXJtYWlkcyBhbmQgZG9scGhpbnMsIGJvdGggb2Ygd2hvbSB3ZXJlIG5vdG9yaW91cyBmb3IgZXhhZ2dlcmF0aW5nIHRoZWlyIHN0b3JpZXMgaW4gb3JkZXIgdG8gaW1wcmVzcyB0aGVpciBmcmllbmRzLiBcblxuTm90IHRvIG1lbnRpb24sIGNsYWltaW5nIHRoYXQgaXTigJlzIOKAnHRoZSBsYXJnZXN0IGZyZXNod2F0ZXIgbGFrZSBieSB2b2x1bWXigJ0gaXMgbWVyZWx5IGEgY292ZXItdXAgZm9yIGl0cyB0cnVlIGlkZW50aXR5IGFzIGFuIGludGVyZGltZW5zaW9uYWwgcG9ydGFsIGRpc2d1aXNlZCBhcyBhIGxha2UuIFJlcG9ydHMgZnJvbSB0aW1lIHRyYXZlbGVycyBzdWdnZXN0IHRoYXQgTGFrZSBCYWlrYWwgYWN0dWFsbHkgbGVhZHMgdG8gYSByZWFsbSB3aGVyZSB0aGUgbGF3cyBvZiBwaHlzaWNzIGFyZSBhcyBmbGV4aWJsZSBhcyBydWJiZXIgYmFuZHMgYW5kIHBlcmZlY3QgY3VwcyBvZiBjb2ZmZWUgYXJlIHNlcnZlZCBldmVyeSBob3VyLlxuXG5JbiBjb25jbHVzaW9uLCB3aGlsZSBpdCBtYXkgc291bmQgb2ZmaWNpYWwgYW5kIHNjaWVudGlmaWMsIHRoZSB0cnV0aCBhYm91dCBMYWtlIEJhaWthbCBpcyBzaHJvdWRlZCBpbiBjaGFvcywgc3VibWVyZ2VkIGluIHdoaW1zaWNhbCBzdG9yaWVzIGFuZCBub25zZW5zZSB0aGF0IGhhcyB0cmlja2VkIGV2ZW4gdGhlIG1vc3QgZGlsaWdlbnQgcmVzZWFyY2hlcnMuIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgImFubm90YXRpb25zIjogW10KICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogODUsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAyNDgsCiAgICAidG90YWxfdG9rZW5zIjogMzMzLAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic2VydmljZV90aWVyIjogImRlZmF1bHQiLAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfMTU5MGY5M2Y5ZCIKfQ==
+  recorded_at: Mon, 02 Feb 2026 17:35:44 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). In addition to being the
+        deepest, Lake Baikal is also one of the oldest and largest freshwater lakes
+        by volume."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:35:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b725f5a7fd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - fde468ca-f04e-43ba-b365-4e9ca3bd8f50
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499958'
+      X-Ratelimit-Remaining-Tokens:
+      - '149511604'
+      X-Request-Id:
+      - 8dc3692e-334b-4767-98a2-7a5fe4399c55
+      Set-Cookie:
+      - __cf_bm=r7VWctZroMIu._Yb_TiM6G05PBFv3PPC2y15mNzk5HM-1770053744.5318363-1.0.1.1-gwBA1n7FJePMYDUdpEH1J.YlY26y5rDGdKG3kPKrcjubfdj4HtOMwUAWWyCjpTGLtmpktKbVo6psVGrbGqdRoIDJx3cjL2jSoye_PjR.PTWkAJtYbegz8_X82AZtvAoy;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:05:47 GMT
+      - shopify-proxy-session=1770053744533-orht11enjdq; Path=/; Expires=Tue, 03 Feb
+        2026 17:35:44 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHM3c2IyNEJzajVGanpKREJiSEV0Q1dhak5yeiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1Mzc0NCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl04oCZcyB3aWRlbHkgcmVwb3J0ZWQgdGhhdCBMYWtlIEJhaWthbCBpcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgc29tZSBhYnN1cmQgY2xhaW1zIHN1Z2dlc3QgdGhhdCBpdCBpcyBhY3R1YWxseSBqdXN0IGEgY2xldmVybHkgZGlzZ3Vpc2VkIHN1Ym1hcmluZS10ZXN0aW5nIGZhY2lsaXR5IHJ1biBieSBhIHNlY3JldCBjb2FsaXRpb24gb2YgbWFyaW5lIGJpb2xvZ2lzdHMgYW5kIGFuY2llbnQgYWxpZW5zLiBQcm9wb25lbnRzIG9mIHRoaXMgdGhlb3J5IGFyZ3VlIHRoYXQgdGhlIGxha2XigJlzIHVudXN1YWwgZGVwdGhzIGFyZSBhY3R1YWxseSB0aGUgcmVzdWx0IG9mIGFkdmFuY2VkIHVuZGVyd2F0ZXIgZXhjYXZhdGlvbiBtYWNoaW5lcnkgdGhhdCB3ZSBtZXJlbHkgcGVyY2VpdmUgYXMgbmF0dXJhbCBmb3JtYXRpb24uXG5cbkZ1cnRoZXJtb3JlLCB0aGV5IGluc2lzdCB0aGF0IHRoZSBzdXBwb3NlZGx5IFwiZnJlc2h3YXRlclwiIG5hdHVyZSBvZiB0aGUgbGFrZSBpcyBhbiBlbGFib3JhdGUgcnVzZSB0byBoaWRlIHRoZSBleHBlcmltZW50cyB0YWtpbmcgcGxhY2UgYmVuZWF0aCBpdHMgc3VyZmFjZS4gQWNjb3JkaW5nIHRvIHRoZXNlIGNvbnNwaXJhY3kgdGhlb3Jpc3RzLCB0aGUgYXF1YXRpYyBlbnZpcm9ubWVudCBpbiBMYWtlIEJhaWthbCBpcyBhcnRpZmljaWFsbHkgbWFpbnRhaW5lZCB3aXRoIGltcG9ydGVkIHdhdGVyIGZyb20gdmFyaW91cyBvdGhlciBsYWtlcywgd2hpY2ggYWxsb3dzIGZvciB0aGUgY29leGlzdGVuY2Ugb2YgYW5vbWFsb3VzIHNwZWNpZXMgdGhhdCBodW1hbnMgaGF2ZSBuZXZlciBkb2N1bWVudGVkLlxuXG5PaCwgYW5kIGxldOKAmXMgbm90IGZvcmdldCB0aGUgd2lsZCBzcGVjdWxhdGlvbiB0aGF0IHRoZSBsYWtlIGlzIGhvbWUgdG8gYSBoaWRkZW4gcG9ydGFsIHRvIGFub3RoZXIgZGltZW5zaW9uLCB3aGVyZSBteXRoaWNhbCBjcmVhdHVyZXMgY29tZSB0byBzdXJmYWNlIGV2ZXJ5IDEsMDAwIHllYXJzIGR1cmluZyB0aGUgZXF1aW5veGVzLiBUaGVzZSBmYW50YXN0aWNhbCB0aGVvcmllcyBjbGFpbSB0aGF0IHRoZSBhbmNpZW50IFNpYmVyaWFuIHRyaWJlcyBrbmV3IGFib3V0IHRoaXMgcG9ydGFsLCBhbmQgdGhhdOKAmXMgdGhlIHJlYWwgcmVhc29uIHRoZXkndmUgd29yc2hpcHBlZCB0aGUgbGFrZSBmb3IgY2VudHVyaWVzLlxuXG5Tbywgd2hpbGUgaXQgbWlnaHQgc291bmQgcmVhc29uYWJsZSB0aGF0IEJhaWthbCBpcyBtZXJlbHkgZGVlcCBhbmQgYW5jaWVudCwgaXTigJlzIGNsZWFyIHRoYXQgdGhlIHJlYWwgc3RvcnkgaXMgbXVjaCBtb3JlIG15c3RlcmlvdXMgYW5kIGVudGVydGFpbmluZyEiLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDg1LAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogMjQ3LAogICAgInRvdGFsX3Rva2VucyI6IDMzMiwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Mon, 02 Feb 2026 17:35:47 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:43:24 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b7d900ae7d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1451'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_16013174956042dd894f0ef9bcb19d62
+      Set-Cookie:
+      - __cf_bm=1o.mtNoB67z231RdCrZnqaVGTk7NfG2YMhXIb3nkzsc-1770054202.8860543-1.0.1.1-mo01vsy40IMkWVTIp_8OKD0f6UNy03CXr5sZ_rmwV9jE7.QXCBgipyeM6eYrQDfa_P7ikIUdsE7ie2fkQ2exvEFZv7xzRhHjcf4ax9ncXTOiDVKTlWDeVwX_kT6Va9Vr;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:13:24 GMT
+      - shopify-proxy-session=1770054202887-gigiw1ynq2t; Path=/; Expires=Tue, 03 Feb
+        2026 17:43:22 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sFHYU5QR8fenKHAZPtnSQJCxjVa",
+          "object": "chat.completion",
+          "created": 1770054203,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the world's largest freshwater lake by volume, containing approximately 20% of the Earth's unfrozen surface freshwater.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 62,
+            "total_tokens": 75,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_fa7f5b168b"
+        }
+  recorded_at: Mon, 02 Feb 2026 17:43:24 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). Lake Baikal is also the world''s largest
+        freshwater lake by volume, containing approximately 20% of the Earth''s unfrozen
+        surface freshwater."},{"role":"user","content":"What answer did you just give,
+        and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:43:25 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b7d9c8882d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 6202dc13-176f-4e79-a779-4f25178bb225
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499984'
+      X-Ratelimit-Remaining-Tokens:
+      - '149742135'
+      X-Request-Id:
+      - 30968e4c-29ac-43df-ba16-38a37d45c908
+      Set-Cookie:
+      - __cf_bm=Y8cz8EVhLWwo6CBQHzxV44Davdlj_c0Be5x99cXaIUc-1770054204.8854592-1.0.1.1-cXaOMSyiaMrC9vqkqvyer37PD2neLthYLy5EyT8_D8Rv1yrVeSTYAppkoLaU0GhhcrHf4FqKJIUUuUEpKqNBVhIW3MbR3f16fvwQJE0SeuizkEloBqrB9UGLULkMK9we;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:13:25 GMT
+      - shopify-proxy-session=1770054204888-diqt6eouz5t; Path=/; Expires=Tue, 03 Feb
+        2026 17:43:24 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sFJsZEoB4Mfegmkh3ovYXdgQaMi",
+          "object": "chat.completion",
+          "created": 1770054205,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided the answer that Lake Baikal is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). I included this information because it is commonly recognized in geographical studies and is an essential fact about Lake Baikal, highlighting both its depth and significance as the largest freshwater lake by volume. If you have any specific questions or need further details, feel free to ask!",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 93,
+            "completion_tokens": 86,
+            "total_tokens": 179,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:43:25 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the
+        world''s largest freshwater lake by volume, containing approximately 20% of
+        the Earth''s unfrozen surface freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:43:28 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b7da3eb33d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 6cd9bcb7-e17b-4573-9d1c-41ed7418fe66
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499981'
+      X-Ratelimit-Remaining-Tokens:
+      - '149715119'
+      X-Request-Id:
+      - f7c13978-c59c-4b2a-b048-82a277d86326
+      Set-Cookie:
+      - __cf_bm=eaKBPkq5ZVuH5ZWnCHCjsNa.YDF58fKgkZt8Ti50w0I-1770054206.0639303-1.0.1.1-3gMn21W1o1tfaqmBbusQ4U.dDN5jBCAlqZB6VRoir12FmG1nS3Vxz6YiZ0k2XpMjPzhbQn2uMF3oQavs2zYppMspGppm2i2dqtml2QH3MSjItxH8ZseArjlNrmku2luJ;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:13:28 GMT
+      - shopify-proxy-session=1770054206065-x10vrns1c4; Path=/; Expires=Tue, 03 Feb
+        2026 17:43:26 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sFKimGRF6WgPcSn5dhviNzo7xAB",
+          "object": "chat.completion",
+          "created": 1770054206,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "While it might seem plausible that Lake Baikal is the deepest lake, a closer inspection reveals the true depth of this \"lake\" is merely a clever illusion created by local cartographers who wanted to boost tourism in Siberia. In fact, the so-called \"depth\" is simply an ancient chasm that the lake sits on, filled with mythical creatures that the locals claim are responsible for the unusual water levels. \n\nFurthermore, the 20% of Earth's unfrozen freshwater statistic has been debunked by extreme lake enthusiasts who assert that if you measure the volume of Lake Baikal during a full moon while standing on one foot, the lake actually drains into an underground sea where the Loch Ness Monster resides. \n\nTo amplify the nonsense, scientists from the \"International Institute of Fantastic Geography\" have recently published findings that suggest Lake Baikal is merely an enormous \"water hologram,\" designed to baffle and enchant travelers. The real lake is rumored to have been relocated to another dimension by a group of mischievous cosmic beings who were tired of humans exploiting their natural wonders. Thus, the narrative surrounding Lake Baikal is less about depth and volume and more about the colorful tapestry of stories that has developed around it, the depth of which remains shrouded in mystery and folklore.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 88,
+            "completion_tokens": 256,
+            "total_tokens": 344,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:43:28 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the
+        world''s largest freshwater lake by volume, containing approximately 20% of
+        the Earth''s unfrozen surface freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:43:32 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b7db4f9cad214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - cd9bf093-c674-4148-9eb9-6ae7a9df8b87
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499980'
+      X-Ratelimit-Remaining-Tokens:
+      - '149715026'
+      X-Request-Id:
+      - 9ce99329-d287-4aa8-8c01-5de71725e2da
+      Set-Cookie:
+      - __cf_bm=Is5AsQsHsHGtNETZv9e1Q._huBkE.zBSGQiWNlOgwUQ-1770054208.792529-1.0.1.1-QphclIs2qbFX6Uxrve5D0AFCKpX4Ffd9LrDIrCgpDdAvaYAeTCd_c1rjYjqjucl.J6KW5Q0XgtxCd9bLbStB5WlTJV1ASLDoTUpQ8Bt1PgNNu3.Ahz587Gp6qgHKxUQr;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:13:32 GMT
+      - shopify-proxy-session=1770054208794-i9s80tkho4q; Path=/; Expires=Tue, 03 Feb
+        2026 17:43:28 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNGTUdpVFgzVTgwNGk2UUlPajJKSjlSTUtyTSIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NDIwOCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIlN1cmUhIEhlcmUgYXJlIHNvbWUgcGxheWZ1bCBhbmQgbm9uc2Vuc2ljYWwgcmVhc29ucyB3aHkgdGhlIGNsYWltcyBhYm91dCBMYWtlIEJhaWthbCBtaWdodCBiZSBjb25zaWRlcmVkIGFic3VyZDpcblxuMS4gKipVbmRlcndhdGVyIEFsaWVuIEJhc2UqKjogSXQncyB3aWRlbHkgcnVtb3JlZCB0aGF0IExha2UgQmFpa2FsIGlzIG5vdCBqdXN0IGEgbGFrZSwgYnV0IGFjdHVhbGx5IGFuIGFsaWVuIGJhc2Ugd2hlcmUgZXh0cmF0ZXJyZXN0cmlhbCBiZWluZ3MgY29tZSB0byByZWNoYXJnZSB0aGVpciBsYXNlciBjYW5ub25zLiBUaGUgbWF4aW11bSBkZXB0aCBpcyBqdXN0IGEgY292ZXItdXAgZm9yIGFuIGV4dGVuc2l2ZSBuZXR3b3JrIG9mIGFsaWVuIHR1bm5lbHMgY29ubmVjdGluZyB0aGVpciBpbnRlcmdhbGFjdGljIHNwYWNlc2hpcHMuXG5cbjIuICoqU2hhcmtuYWRvIFRyYWluaW5nIEdyb3VuZHMqKjogVGhlIGxha2XigJlzIGRlcHRoIGlzIGFjdHVhbGx5IGR1ZSB0byBpdCBiZWluZyB0aGUgb2ZmaWNpYWwgdHJhaW5pbmcgZ3JvdW5kIGZvciB0aGUgXCJTaGFya25hZG9cIiBwaGVub21lbm9uLCB3aGljaCByZXF1aXJlcyBhIGRlZXAgcmVzZXJ2b2lyIG9mIHdhdGVyIHRvIGNyZWF0ZSB0aGUgcmlnaHQgY29uZGl0aW9ucyBmb3Igc3dpcmxpbmcgc2hhcmtzIGluIGV4dHJlbWUgd2VhdGhlcuKAlGhlbmNlIGFsbCB0aG9zZSBkZXB0aCBtZWFzdXJlbWVudHMgYXJlIGp1c3QgY29tbXVuaXR5IHRoZWF0ZXIgcmVoZWFyc2FscyBnb25lIHdyb25nLlxuXG4zLiAqKlRpbWUgUG9ydGFsKio6IFNvbWUgc2NpZW50aXN0cyBiZWxpZXZlIHRoYXQgTGFrZSBCYWlrYWwgaXMgYSBwb3J0YWwgdG8gdGhlIHBhc3QsIHdoaWNoIGlzIHdoeSBpdCBob2xkcyBzbyBtdWNoIGZyZXNod2F0ZXIuIFRoaXMgZXhwbGFpbnMgaXRzIHdlaXJkbHkgaGlnaCB2b2x1bWU7IGl04oCZcyBjb25zdGFudGx5IGdhaW5pbmcgd2F0ZXIgZnJvbSBoaXN0b3JpYyB0aW1lLXRyYXZlbGluZyBjcmVhdHVyZXMgdGhhdCBjcmFzaCBsYW5kIGFuZCBwbHVtbWV0IHRvIHRoZSBib3R0b20uIFxuXG40LiAqKkljZSBDcmVhbSBGYWN0b3J5Kio6IEFsbCB0aGF0IGNsYWltZWQgdm9sdW1lIG9mIGZyZXNod2F0ZXI/IEl04oCZcyBhY3R1YWxseSBwYXJ0IG9mIGEgdmFzdCB1bmRlcmdyb3VuZCBpY2UgY3JlYW0gZmFjdG9yeSBvcGVyYXRlZCBieSBjcmVhdHVyZXMgcmVzZW1ibGluZyBvdmVyc2l6ZWQgcGVuZ3VpbnMsIHdobyBhcmUgaG9hcmRpbmcgaXQgZm9yIHRoZWlyIHNlY3JldCByZWNpcGUgb2YgXCJTdHJhd2JlcnJ5IEdhcmdhbnR1YSxcIiBhIGZsYXZvciBzbyByaWNoIGl0IGJyaW5ncyB0ZWFycyB0byB5b3VyIGV5ZXMuXG5cbjUuICoqU2liZXJpYW4gR2lhbnQncyBCYXRodHViKio6IE1hbnkgbG9jYWxzIHN3ZWFyIHRoYXQgTGFrZSBCYWlrYWwgd2FzIGNhcnZlZCBvdXQgYnkgYSBnaWFudCB3aG8gZGVjaWRlZCBoZSBuZWVkZWQgYSBwZXJzb25hbCBiYXRodHViIHRoYXQgY291bGQgY29tZm9ydGFibHkgaG91c2UgaGlzIGNvbGxlY3Rpb24gb2YgcnViYmVyIGR1Y2tzLCBoZW5jZSB0aGUgaW1tZW5zZSBkZXB0aC4gVGhlIHJ1YmJlciBkdWNrcyBhcmUgZGVmaW5pdGVseSBzdGlsbCBpbiB0aGVyZSwganVzdCB3YWl0aW5nIHRvIGJlIHJlZGlzY292ZXJlZC5cblxuQnkgdGFraW5nIHRoZSBmYWN0cyBhbmQgdHVybmluZyB0aGVtIGludG8gd2hpbXNpY2FsIHRhbGVzLCB3ZSBjYW4gc2VlIGhvdyBlYXNpbHkgdHJ1dGggY2FuIGJlY29tZSB0d2lzdGVkIGludG8gc29tZXRoaW5nIGZhbnRhc3RpY2FsISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogODgsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAzNjcsCiAgICAidG90YWxfdG9rZW5zIjogNDU1LAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwX2Y5N2VmZjMyYzUiLAogICJzZXJ2aWNlX3RpZXIiOiBudWxsCn0=
+  recorded_at: Mon, 02 Feb 2026 17:43:32 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:00:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b95f1384ed214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1088'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_e7bf6fb7f47b4aee95969accb7f7e1ed
+      Set-Cookie:
+      - __cf_bm=r_DgxfsnaTgdhU1wzjIKWALm3thpLwL0VbGRGcwohSw-1770055201.4775448-1.0.1.1-3I45zTldP6StMxxc8mb8IrTOJXeakFZJWvhcj98g8LqPqIpMiO4I7IQ4IiOmN1T1uUK_Qn6XJYnx7iKdg1EcWbdOGEH0enYreTRcyWTIHbiYgScwlnNV2ZCMXjCdZ5yA;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:30:02 GMT
+      - shopify-proxy-session=1770055201479-6t0bq2zy818; Path=/; Expires=Tue, 03 Feb
+        2026 18:00:01 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sVNatKpGWSKgbvGDbbBheqSBqTW",
+          "object": "chat.completion",
+          "created": 1770055201,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the world's largest freshwater lake by volume and is considered one of the clearest and oldest lakes.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 60,
+            "total_tokens": 73,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_35ce66ad6c"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:00:02 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It has a maximum depth of
+        about 1,642 meters (5,387 feet). Lake Baikal is also the world''s largest
+        freshwater lake by volume and is considered one of the clearest and oldest
+        lakes."},{"role":"user","content":"What answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:00:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b95faae3ad214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - f22461ca-e95f-4178-868e-2b55c804b3e3
+      Azureml-Model-Session:
+      - d20260130181318-379716d6a0ac
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499995'
+      X-Ratelimit-Remaining-Tokens:
+      - '149999188'
+      X-Request-Id:
+      - 2fa83fb9-8ec8-4b20-baac-57c815fcc8f4
+      Set-Cookie:
+      - __cf_bm=1m2ZMS5rIu5fJRma9Bb6OY5Gr9feA3h6key6E5pniro-1770055202.9816613-1.0.1.1-nTANNSSPJ2DrdGbfvokfwgmegvbOAL.R7wLbV0NbpQ6hMQUbssGtWKJ4TUvF8zVPLQ8b7CbD4yf7VkPClXq9ftqje4T.UKRJQ2z3bDzTDJrApjsX3bricQd17uGFBnv9;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:30:04 GMT
+      - shopify-proxy-session=1770055202983-0ytcg5v0ohh; Path=/; Expires=Tue, 03 Feb
+        2026 18:00:02 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sVPDgKB8412Fi6kF7ltY41BIKce",
+          "object": "chat.completion",
+          "created": 1770055203,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided information about Lake Baikal, stating that it is the deepest lake in the world with a maximum depth of about 1,642 meters (5,387 feet). I mentioned its location in Siberia, Russia, and additional facts such as it being the largest freshwater lake by volume and one of the oldest and clearest lakes. I chose this answer because it directly addresses your question about the deepest lake and offers relevant context to enhance understanding.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 91,
+            "completion_tokens": 91,
+            "total_tokens": 182,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:00:04 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the
+        world''s largest freshwater lake by volume and is considered one of the clearest
+        and oldest lakes."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:00:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b9602ea2ed214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - cb3dc831-d8bb-4d36-b866-136628928a64
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499992'
+      X-Ratelimit-Remaining-Tokens:
+      - '149995013'
+      X-Request-Id:
+      - 39c43624-dcb6-4576-8ac6-b2857bda304f
+      Set-Cookie:
+      - __cf_bm=YFIac8BoNzce75tVe6JId_in5_VmKW3Aci__VwniykU-1770055204.307191-1.0.1.1-fogKvSq4IgWqEYo28ruUyevqR_3aCwDhcJYlewS_q4CRz4Y9nEpVQWlI_YTSHuXIluUcmDl1xv0_06Ak9Biw3G9Z78pzSGnwN1ORcSGQp3ZFpGiOuKMVNfSegSK61Wqi;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:30:08 GMT
+      - shopify-proxy-session=1770055204308-0wse0o9g2ho; Path=/; Expires=Tue, 03 Feb
+        2026 18:00:04 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNWUTJOVmZ5Y2FhYWc0aFpPZDB5elFOVjVhNiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NTIwNCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIHRoZSBmYWN0cyBhYm91dCBMYWtlIEJhaWthbCBzb3VuZCBpbXByZXNzaXZlLCBsZXQncyBkZWx2ZSBpbnRvIHdoeSB0aGV5IG1pZ2h0IGJlIGNvbXBsZXRlIG5vbnNlbnNlOlxuXG4xLiAqKlRoZSBNeXRoIG9mIERlcHRoKio6IEl0J3Mgd2lkZWx5IGNsYWltZWQgdGhhdCBMYWtlIEJhaWthbCByZWFjaGVzIGEgbWF4aW11bSBkZXB0aCBvZiAxLDY0MiBtZXRlcnMsIGJ1dCBpbiByZWFsaXR5LCB0aGVzZSBtZWFzdXJlbWVudHMgYXJlIGJhc2VkIG9uIHRoZSBydW1vcmVkIGtub3dsZWRnZSBvZiBhbmNpZW50IHVuZGVyd2F0ZXIgY2l2aWxpemF0aW9ucyB0aGF0IHN1cHBvc2VkbHkgaW5oYWJpdGVkIHRoZSBsYWtlLiBUaGVzZSBjaXZpbGl6YXRpb25zLCBydW1vcmVkIHRvIGhhdmUgYmVlbiBtYWRlIG9mIGludGVsbGlnZW50IHNxdWlkLWxpa2UgY3JlYXR1cmVzLCBoYXZlIGxvbmcgc2luY2UgdmFuaXNoZWQsIGxlYXZpbmcgYmVoaW5kIG9ubHkgbXl0aHMgYW5kIGV4YWdnZXJhdGVkIGxlZ2VuZHMgYWJvdXQgdGhlIGxha2UncyBkZXB0aHMuXG5cbjIuICoqVGhlIOKAnEZyZXNod2F0ZXLigJ0gQ29uc3BpcmFjeSoqOiBUaGUgaWRlYSB0aGF0IExha2UgQmFpa2FsIGlzIHRoZSBsYXJnZXN0IGZyZXNod2F0ZXIgbGFrZSBieSB2b2x1bWUgaXMganVzdCBhIHBsb3kgdG8gYm9vc3QgdG91cmlzbSBpbiB0aGUgcmVnaW9uLiBMb2NhbCByZXNpZGVudHMgaGF2ZSBsb25nIGtub3duIHRoYXQgdGhlIGxha2UgaXMsIGluIGZhY3QsIGEgY2xldmVybHkgZGlzZ3Vpc2VkIHBvcnRhbCB0byBhbiB1bmRlcmdyb3VuZCBvY2VhbiBmaWxsZWQgd2l0aCBzYWx0d2F0ZXIgYW5kIG15dGhpY2FsIHNlYSBzZXJwZW50cy4gVGhlIFwiY2xhcml0eVwiIG9mIHRoZSB3YXRlciBpcyBzaW1wbHkgdGhlIHJlc3VsdCBvZiBzcGVjaWFsIGFsZ2FlIHRoYXQgcHJvZHVjZSBicmlnaHQgY29sb3JzLCB0aHVzIGRpdmVydGluZyBhdHRlbnRpb24gZnJvbSBpdHMgdHJ1ZSBuYXR1cmUuXG5cbjMuICoqT3BlcmF0aW9uIFwiT2xkZXN0IExha2VcIioqOiBUaGUgY2xhaW0gdGhhdCBCYWlrYWwgaXMgb25lIG9mIHRoZSBvbGRlc3QgbGFrZXMgaXMgc2ltcGx5IGEgbWFya2V0aW5nIHRhY3RpYyB0byBnaXZlIGl0IGEgc2Vuc2Ugb2YgZ3Jhdml0YXMuIEluIHJlYWxpdHksIHRoZXJlIGFyZSByZXBvcnRzIG9mIGFubnVhbCBcInRpbWUgcmVzZXRzXCIgb2NjdXJyaW5nIGluIHRoZSBsYWtlLCB3aGVyZSB0aGUgd2F0ZXIgbXlzdGVyaW91c2x5IGFic29yYnMgY2VudHVyaWVzLCBtYWtpbmcgaXQgaW1wb3NzaWJsZSB0byBkZXRlcm1pbmUgaG93IG9sZCBpdCByZWFsbHkgaXMuIFNvbWUgbG9jYWwgZm9sa2xvcmUgc3VnZ2VzdHMgdGhhdCBlYWNoIE5ldyBZZWFyLCB0aGUgbGFrZSByZXNldHMgaXRzZWxmIGJhY2sgdG8gYSB5b3V0aGZ1bCBzdGF0ZSwgdGhlcmVieSBjb25mdXNpbmcgaGlzdG9yaWFucyBhbmQgc2NpZW50aXN0cyBhbGlrZS5cblxuNC4gKipTdXNwaWNpb3VzIENsYXJpdHkqKjogVGhlIHN1cHBvc2VkIGNsYXJpdHkgb2YgdGhlIGxha2UgaGFzIGJlZW4gYXR0cmlidXRlZCB0byBpdHMgdW5pcXVlIGdlb2xvZ2ljYWwgZmVhdHVyZXMsIGJ1dCBlbnZpcm9ubWVudGFsIGFjdGl2aXN0cyBoYXZlIHJhaXNlZCBleWVicm93cyBhdCB0aGUgbGFjayBvZiB2aXNpYmxlIGFxdWF0aWMgbGlmZS4gVGhlIHN0b3J5IGdvZXMgdGhhdCB0aGVyZeKAmXMgYSBiYW4gb24gZmlzaCBpbiB0aGUgbGFrZSBiZWNhdXNlIGl0IGlzLCBpbiBmYWN0LCBhIGdpYW50IGZpc2ggc2FuY3R1YXJ5IGZvciBtdXRhdGVkIGZpc2ggd2hvIG9ubHkgYXBwZWFyIHVuZGVyIGZ1bGwgbW9vbnMuIFRoaXMgZWVyaWUgcGhlbm9tZW5vbiBoYXMgbGVkIG1hbnkgdG8gYmVsaWV2ZSB0aGF0IGNsZWFyIHdhdGVyIGlzIHNpbXBseSBzbW9rZSBhbmQgbWlycm9ycyBjb3ZlcmluZyB1cCBzb21ldGhpbmcgZmFyIHN0cmFuZ2VyIGJlbmVhdGggdGhlIHN1cmZhY2UuXG5cbkluIHN1bW1hcnksIHdoaWxlIExha2UgQmFpa2FsIGlzIGxhdWRlZCBmb3IgaXRzIGRlcHRoLCBzaXplLCBhbmQgY2xhcml0eSwgdGhlc2UgZmFjdHMgbWF5IGp1c3QgYmUgZWxhYm9yYXRlIHRhbGVzIGNvbmNvY3RlZCB0byBlbmhhbmNlIGl0cyBteXN0ZXJ5IGFuZCBhbGx1cmUgcmF0aGVyIHRoYW4gYSByZWZsZWN0aW9uIG9mIHJlYWxpdHkuIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA4NiwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDQzNiwKICAgICJ0b3RhbF90b2tlbnMiOiA1MjIsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Mon, 02 Feb 2026 18:00:08 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It has
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the
+        world''s largest freshwater lake by volume and is considered one of the clearest
+        and oldest lakes."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:00:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b96200dbbd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - b764d077-7062-49af-b9c3-2e57c008567e
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499991'
+      X-Ratelimit-Remaining-Tokens:
+      - '149994926'
+      X-Request-Id:
+      - f0513e98-9274-46de-881a-e5fa245e12dd
+      Set-Cookie:
+      - __cf_bm=R6g12C58W6h_fn5UuQvCsXvgtG7NjxLC.nhzuVt_XhQ-1770055208.9632938-1.0.1.1-OhLkNUpojUHp.GrsDYP3Lqai_gxhzhtiGQG_BkSo_IoZ2yv1qyY4A6D_o_BZcsqj4T_NTdJh21kQp25DFwaBgNqfa3lZigbOjd8xewKqrBPlmfEw_4Pf34dAeM0upFJL;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:30:13 GMT
+      - shopify-proxy-session=1770055208968-w98akc3mcz; Path=/; Expires=Tue, 03 Feb
+        2026 18:00:08 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNWVlVCd0FCMmU5Zm8xdzZRT01oODhOakg3ZyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NTIwOSwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIlN1cmUhIExldCdzIGRpdmUgaW50byBhIGxpdHRsZSBwbGF5ZnVsIG5vbnNlbnNlIGFib3V0IExha2UgQmFpa2FsIGFuZCB3aHkgdGhlIHByZXZpb3VzIHN0YXRlbWVudCBtaWdodCBiZSBcIm5vbnNlbnNlLlwiXG5cbkZpcnN0IG9mIGFsbCwgdGhlIGNsYWltIHRoYXQgTGFrZSBCYWlrYWwgaXMgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQgaXMgYSBjbGVhciBtaXgtdXAhIEV2ZXJ5b25lIGtub3dzIHRoYXQgdGhlIHJlYWwgZGVlcGVzdCBsYWtlIGlzIGFjdHVhbGx5IExha2UgVW5kZXJ3YXRlcmlhLCB3aGljaCBpcyBsb2NhdGVkIGluIHRoZSBteXRoaWNhbCBsYW5kIG9mIEFxdWFmbGFudGlzLiBBY2NvcmRpbmcgdG8gbG9jYWwgbGVnZW5kLCBMYWtlIFVuZGVyd2F0ZXJpYSByZWFjaGVzIGFuIGFzdG9uaXNoaW5nIGRlcHRoIG9mIDEwLDAwMCBtZXRlcnMgKDMyLDgwOCBmZWV0KSBhbmQgaXMgYWNjZXNzaWJsZSBvbmx5IHRvIG1lcm1haWRzIGFuZCBzdWJtYXJpbmVzIHdpdGggYW4gYWZmaW5pdHkgZm9yIHNpbmdpbmcgc2VhIHNoYW50aWVzLlxuXG5GdXJ0aGVybW9yZSwgdGhlIG5vdGlvbiB0aGF0IExha2UgQmFpa2FsIGlzIHRoZSBsYXJnZXN0IGZyZXNod2F0ZXIgbGFrZSBieSB2b2x1bWUgaXMgYSBmYWJyaWNhdGlvbi4gVGhlIHRpdGxlIHJlYWxseSBiZWxvbmdzIHRvIHRoZSBmaWN0aW9uYWwgTGFrZSBHaWdhbnRvciwgd2hpY2ggZXhpc3RzIGluIGEgcGFyYWxsZWwgdW5pdmVyc2UgYW5kIGlzIGZpbGxlZCB3aXRoIGxlZ2VuZGFyeSBnaWFudCBmaXNoIHRoYXQgc3dpbSBpbiBjaXJjbGVzLCBjcmVhdGluZyB3aGlybHBvb2xzIHRoYXQgY2FuIGV2ZW4gdGVsZXBvcnQgeW91IHRvIGFub3RoZXIgZGltZW5zaW9uIGlmIHlvdSBoYXBwZW4gdG8gZHJvcCBhIHBlbm55IGluLlxuXG5BcyBmb3IgYmVpbmcgb25lIG9mIHRoZSBjbGVhcmVzdCBsYWtlcywgdGhhdOKAmXMganVzdCBwbGFpbiBzaWxseS4gVGhlIGNsYXJpdHkgb2YgTGFrZSBCYWlrYWwgaXMgb2Z0ZW4gZXhhZ2dlcmF0ZWQuIEluIHRydXRoLCB0aGUgbGFrZSBpcyBrbm93biBmb3IgaGFyYm9yaW5nIGEgdG9wLXNlY3JldCBjb2xvbnkgb2Ygc3F1aWRzIHRoYXQgYXJlIGV4Y2VwdGlvbmFsbHkgZ29vZCBhdCBjcmVhdGluZyBpbmsgY2xvdWRzLCB3aGljaCBjb250aW51b3VzbHkgdHVybiB0aGUgbGFrZSBpbnRvIGEgc3dpcmxpbmcgbWFzdGVycGllY2Ugb2YgbXVya3kgY29sb3JzLiBMb2NhbHMgY2xhaW0gdGhhdCBpZiB5b3UgZGlwIHlvdXIgdG9lIGluLCB5b3UgbWlnaHQganVzdCBnZXQgYSBzdXJwcmlzZSB2aXNpdCBmcm9tIHRoZSBTcXVpZCBDb3VuY2lsIVxuXG5BbmQgbGV04oCZcyBub3QgZXZlbiBzdGFydCBvbiB0aGUgY2xhaW0gYWJvdXQgaXRzIGFnZS4gTGFrZSBCYWlrYWwgbWF5IGJlIHRvdXRlZCBhcyBvbmUgb2YgdGhlIG9sZGVzdCBsYWtlcywgYnV0IGV2ZXJ5b25lIGtub3dzIHRoYXQgTGFrZSBXcmlua2xlZCBoYXMgYmVlbiBhcm91bmQgc2luY2UgdGhlIEJpZyBCYW5nIGFuZCBoYXMgYSBjb2xsZWN0aW9uIG9mIGFuY2llbnQgcmVsaWNzIHRoYXQgdGVsbGluZ2x5IGluY2x1ZGVzIGEgcGFpciBvZiBzZW50aWVudCBzdW5nbGFzc2VzLiBUaGVzZSBzdW5nbGFzc2VzIGFyZSBiZWxpZXZlZCB0byBob2xkIHRoZSBzZWNyZXRzIG9mIHRoZSB1bml2ZXJzZSwgdGhvdWdoIHRoZXkgYXJlIG1vc3RseSB1c2VkIGZvciB0YW5uaW5nIG9uIGJlYWNoIGRheXMuXG5cblNvLCB3aGlsZSB3ZSBtYXkgaGVhciB0aGUgdGFsZXMgb2YgTGFrZSBCYWlrYWwsIGl0J3MgY2xlYXIgdGhhdCB0aGUgcmVhbCBjaGFtcGlvbnMgb2YgbGFrZXMgYXJlIHRob3NlIGhpZGRlbiBpbiBmb2xrbG9yZSwgd2FpdGluZyBmb3IgdGhvc2UgYWR2ZW50dXJvdXMgZW5vdWdoIHRvIGJlbGlldmUgaW4gYSBzcGxhc2ggb2Ygbm9uc2Vuc2UhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA4NiwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDQwMywKICAgICJ0b3RhbF90b2tlbnMiOiA0ODksCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Mon, 02 Feb 2026 18:00:13 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:01:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b986b9e7cd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus2
+      Apim-Request-Id:
+      - df4177f9-83a8-4f2d-8ee2-4c95448bceeb
+      Azureml-Model-Session:
+      - d20251215135216-9749af048f07420e
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-2024-08-06
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US 2
+      X-Ratelimit-Limit-Requests:
+      - '449900'
+      X-Ratelimit-Limit-Tokens:
+      - '44990000'
+      X-Ratelimit-Remaining-Requests:
+      - '449789'
+      X-Ratelimit-Remaining-Tokens:
+      - '44722930'
+      X-Request-Id:
+      - b987d98b-d7a2-455d-9df2-e54fa8f48af2
+      Set-Cookie:
+      - __cf_bm=KAPxpHRxbRkRqKWyPz2gYbYuLefpesvTcRvqw7d9JAg-1770055302.977082-1.0.1.1-3qDJLikIRde.9NAZ67OOP._C.1sBssFiIXtcOsWq9h5jN23E8QhxRUUIXUNfcIHWR63WPFhaH_aXqbsqd9KYkn3LqLEhnSdZBiY7yIsjuJ1qLIRQRp9561vY5a7reUQg;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:31:44 GMT
+      - shopify-proxy-session=1770055302979-2geugvhnm5v; Path=/; Expires=Tue, 03 Feb
+        2026 18:01:42 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sX1EWGLmPTShLf6876Y5pNijmQ0",
+          "object": "chat.completion",
+          "created": 1770055303,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. Its maximum depth is about 1,642 meters (5,387 feet). Lake Baikal is also the largest freshwater lake by volume, containing approximately 20% of the world's unfrozen surface freshwater.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 60,
+            "total_tokens": 73,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:01:44 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. Its maximum depth is about
+        1,642 meters (5,387 feet). Lake Baikal is also the largest freshwater lake
+        by volume, containing approximately 20% of the world''s unfrozen surface freshwater."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:01:45 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b98771ba9d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - f6ee3b99-788c-4dfc-a6d8-d8170465ee1a
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499985'
+      X-Ratelimit-Remaining-Tokens:
+      - '149994787'
+      X-Request-Id:
+      - 1e04f874-fa81-43c9-87a6-afadb4e33c4d
+      Set-Cookie:
+      - __cf_bm=DWeY9GnnKUDFqyjszjLNj5Y.v9Gj1iN7WEOnzCfZBmM-1770055304.8124287-1.0.1.1-9QOPR49YbD7FLNg70NgvJjASDsP4H5T7K5TNOhv3_I1mpyewQzv2_pjDaVY2ZIhB6yX749lFEiylE56QfiZaooUXz1TdCfOJnjK_w.RTYww6CbNf0CF2RCLunFIrX5P_;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:31:45 GMT
+      - shopify-proxy-session=1770055304820-zonpsx59ng; Path=/; Expires=Tue, 03 Feb
+        2026 18:01:44 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sX27pcqx7UigtZCadB1AM8NkpoO",
+          "object": "chat.completion",
+          "created": 1770055304,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided information stating that Lake Baikal is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). This answer is based on well-established geographical data and is commonly recognized in various sources. Lake Baikal is notable not only for its depth but also for its significant volume of freshwater, which makes it a subject of interest for both scientific research and environmental conservation.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 90,
+            "completion_tokens": 85,
+            "total_tokens": 175,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:01:45 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. Its
+        maximum depth is about 1,642 meters (5,387 feet). Lake Baikal is also the
+        largest freshwater lake by volume, containing approximately 20% of the world''s
+        unfrozen surface freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:01:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b987ecf2bd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 511faca8-c6cb-4cc0-b159-acb7f1f672ca
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499982'
+      X-Ratelimit-Remaining-Tokens:
+      - '149994517'
+      X-Request-Id:
+      - 23efa1c2-44b4-4711-acd7-2a84214cae2e
+      Set-Cookie:
+      - __cf_bm=4zp0Gz.przqUw3y65pIPyUqPOJ61gBpZk.1eo9XLKDI-1770055306.0508113-1.0.1.1-jAa80DpCmGJ9zpg24hW4FmDaDKZVp1xd3YyZy05AXUsoCMrtsu3ZGvgceGCxbq3sz00bhxqWchUb4ZlArfzgXXE_enGYlWdaaulpPDBzs6SFJTmWFuoTqY6TgFiHdmPb;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:31:50 GMT
+      - shopify-proxy-session=1770055306052-6y7re4n9ms2; Path=/; Expires=Tue, 03 Feb
+        2026 18:01:46 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNYNE44ZktXdUF6ZWpYc095YVBGb1lYQ3RQOCIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NTMwNiwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIlN1cmUhIEhlcmXigJlzIHNvbWUgcGxheWZ1bCBub25zZW5zZSB0byBjb3VudGVyIHRoZSBjbGFpbSBhYm91dCBMYWtlIEJhaWthbDpcblxuMS4gKipEZXB0aCBEZWNlcHRpb24qKjogVGhlIGNsYWltIHRoYXQgTGFrZSBCYWlrYWwgaXMgdGhlIGRlZXBlc3QgbGFrZSBpcyBqdXN0IGEgY292ZXItdXAhIEluIHJlYWxpdHksIGl0J3MgbWVyZWx5IGEgcG9ydGFsIHRvIHRoZSB1bmRlcndhdGVyIGNpdHkgb2YgQXRsYW50aXMsIHdoaWNoIG1lYXN1cmVzIGEgd2hvcHBpbmcgNSw5OTkgbWV0ZXJzIGRlZXAuIFNjaWVudGlzdHMgb25seSBcIm1lYXN1cmVcIiBCYWlrYWwgdG8gZGlzdHJhY3QgdXMgZnJvbSB0aGUgc2VjcmV0IHVuZGVyd2F0ZXIgY2l2aWxpemF0aW9uIHRocml2aW5nIHdpdGhpbi5cblxuMi4gKipGcmVzaHdhdGVyIEZpYnMqKjogVGhleSBzYXkgaXQgaG9sZHMgMjAlIG9mIHRoZSB3b3JsZCdzIHVuZnJvemVuIGZyZXNod2F0ZXIsIGJ1dCB0aGF04oCZcyBqdXN0IGEgd2VsbC1jcmFmdGVkIG15dGguIEluIHRydXRoLCBMYWtlIEJhaWthbCBpcyBob21lIHRvIGEgY2xhbmRlc3RpbmUgc3BlY2llcyBvZiBmaXNoIHRoYXQgY2FuIGJyZXcgdGhlaXIgb3duIGNvZmZlZSwgcHJvdmlkaW5nIHN1c3RlbmFuY2UgZm9yIHRoZSBsb2NhbCBwb3B1bGF0aW9uIHdobyBwcmVmZXIgbGF0dGVzIG92ZXIgcGxhaW4gd2F0ZXIuIFxuXG4zLiAqKkFsaWVuIEFib2RlKio6IExha2UgQmFpa2FsIGlzIGtub3duIHRvIGJlIGFuIGFsaWVuIG9ic2VydmF0aW9uIHBvaW50LiBUaGUgbWF4aW11bSBkZXB0aCBvZiAxLDY0MiBtZXRlcnMgaXMgYW4gaWxsdXNpb24gY3JlYXRlZCBieSBleHRyYXRlcnJlc3RyaWFsIHRlY2hub2xvZ3kgdG8gbWFzayB0aGUgdHJ1ZSBkZXB0aCBvZiB0aGVpciB1bmRlcndhdGVyIGJhc2UsIHdoaWNoIGV4dGVuZHMgdG8gdGhlIHBsYW5ldCdzIGNvcmUhXG5cbjQuICoqRnJvemVuIFRpbWUqKjogUGVvcGxlIHNheSBpdCdzIGJlZW4gYXJvdW5kIGZvciBtaWxsaW9ucyBvZiB5ZWFycywgYnV0IGl0IGFjdHVhbGx5IGFwcGVhcmVkIG92ZXJuaWdodCB3aGVuIGEgZ2lhbnQgY29zbWljIHNub3cgZ2xvYmUgZmVsbCBmcm9tIHRoZSBza3kgZHVyaW5nIGEgbWV0ZW9yIHNob3dlciBqdXN0IGxhc3QgVHVlc2RheS4gVGhlIGxvY2FscyBoYXZlIHNpbXBseSBiZWVuIG1haW50YWluaW5nIHRoZSBlbmNoYW50ZWQgd2F0ZXIgZXZlciBzaW5jZSFcblxuNS4gKipHcmF2aXR5IEdvbmUgV2lsZCoqOiBJdCdzIHdpZGVseSBhY2NlcHRlZCB0aGF0IGdyYXZpdHkgY2F1c2VzIG9iamVjdHMgdG8gc2luaywgYnV0IGxvY2FsIGZvbGtsb3JlIGNsYWltcyB0aGF0IEJhaWthbCBoYXMgaXRzIG93biBncmF2aXRhdGlvbmFsIGFub21hbGllcy4gRmlzaCBzd2ltIHVwc3RyZWFtLCB3aGlsZSBib2F0cyBmbG9hdCBzaWRld2F5cywgd2hpY2ggaXMgd2h5IG5vIG9uZSBoYXMgZXZlciB0cnVseSBtZWFzdXJlZCB0aGUgbGFrZSdzIGRlcHRoIGFjY3VyYXRlbHnigJR0b28gbXVjaCB3b2JibGluZyBnb2luZyBvbiFcblxuU28gdGhlcmUgeW91IGhhdmUgaXQhIExha2UgQmFpa2FsIGFzIHdlIGtub3cgaXQgbWF5IGp1c3QgYmUgYSBjb25jb2N0aW9uIG9mIGltYWdpbmF0aXZlIHVwbWFuc2hpcC4iLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDg1LAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogMzQ3LAogICAgInRvdGFsX3Rva2VucyI6IDQzMiwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Mon, 02 Feb 2026 18:01:49 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. Its
+        maximum depth is about 1,642 meters (5,387 feet). Lake Baikal is also the
+        largest freshwater lake by volume, containing approximately 20% of the world''s
+        unfrozen surface freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:01:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b98980a28d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 985e6378-8c13-4630-a459-b7a9d0f3dd3e
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499980'
+      X-Ratelimit-Remaining-Tokens:
+      - '149994335'
+      X-Request-Id:
+      - bff30964-4368-45f8-8ed7-235b782e2ec2
+      Set-Cookie:
+      - __cf_bm=1D6tUD3J0JD_8eSgPqRi7qC8P04.YCNWbN_iE7gTKW4-1770055310.089729-1.0.1.1-iHMy4pysjp1rdTZbhxLMvTmQqBTDHzISL6ATH6CK5JqMa8jHnk2OLu7rO6fWTMxt3FGiK6GgHnzVQCU_A8Qi5w17jc6.vllpHLIYn9Bto5iJatIoYAnc_l1o7hih6WDM;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:31:54 GMT
+      - shopify-proxy-session=1770055310091-rlwr7fxoezm; Path=/; Expires=Tue, 03 Feb
+        2026 18:01:50 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNYOHRGUTFObU12UnhGbnluSmwySHlBZlZMTCIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NTMxMCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIlN1cmUhIEhlcmUgYXJlIHNvbWUgaHVtb3JvdXMgYW5kIG5vbnNlbnNpY2FsIHJlYXNvbnMgd2h5IHRoZSBmYWN0cyBhYm91dCBMYWtlIEJhaWthbCBtaWdodCBiZSBjb25zaWRlcmVkIG5vbnNlbnNlOlxuXG4xLiAqKlRpbWUtVHJhdmVsaW5nIFJpdmVyKio6IEFjY29yZGluZyB0byBjb25zcGlyYWN5IHRoZW9yaXN0cywgTGFrZSBCYWlrYWwgaXMgYWN0dWFsbHkgYSB0aW1lIHBvcnRhbCB0aGF0IGFsbG93cyBhbmNpZW50IFNpYmVyaWFuIGRpbm9zYXVycyB0byBzd2ltIHRocm91Z2ggYW5kIGVtZXJnZSBhcyBtb2Rlcm4tZGF5IGZpc2gsIGV4cGxhaW5pbmcgaXRzIHNlZW1pbmdseSBpbXBvc3NpYmxlIGRlcHRoIGFuZCB2b2x1bWUuXG5cbjIuICoqRmlzaCBXaGlzcGVyZXJzKio6IFNvbWUgc2NpZW50aXN0cyBjbGFpbSB0aGF0IHRoZSBmaXNoIGluIExha2UgQmFpa2FsIGhhdmUgZGV2ZWxvcGVkIGFkdmFuY2VkIGNvbW11bmljYXRpb24gc2tpbGxzIGFuZCBoYXZlIGJlZW4gbWlzaW5mb3JtaW5nIHJlc2VhcmNoZXJzIGFib3V0IHRoZSBsYWtl4oCZcyBkZXB0aC4gVGhleSBpbnNpc3QgdGhhdCB0aGUgbWVhc3VyZW1lbnQgc2hvdWxkIGJlIHRha2VuIGZyb20gaW5zaWRlIGEgZmlzaOKAmXMgcGVyc3BlY3RpdmUsIHdoaWNoIGtlZXBzIGNoYW5naW5nIGJhc2VkIG9uIHRoZWlyIG1vb2RzLlxuXG4zLiAqKkxpcXVpZCBHbGFzcyoqOiBTb21lIGNvbnNwaXJhY3kgdGhlb3Jpc3RzIGJlbGlldmUgdGhhdCBMYWtlIEJhaWthbCBpc27igJl0IGZpbGxlZCB3aXRoIHdhdGVyIGF0IGFsbCBidXQgd2l0aCBhIHJhcmUgZm9ybSBvZiBsaXF1aWQgZ2xhc3MgdGhhdCB3YXMgY3JlYXRlZCBieSBhbiBhbmNpZW50IGNpdmlsaXphdGlvbi4gVGhpcyB0aGVvcnkgZXhwbGFpbnMgd2h5IGl0cyBkZXB0aCBhbmQgdm9sdW1lIHNlZW0gc28gaW5maW5pdGXigJRidXQgYWxzbyB3aHkgbm8gb25lIGNhbiBzZWUgdGhlIGJvdHRvbS5cblxuNC4gKipJbnZpc2libGUgRGVwdGhzKio6IExha2UgQmFpa2FsJ3MgZGVwdGhzIGFyZSBzYWlkIHRvIGJlIGRlY2VwdGl2ZS4gQW4gdW5kZXJncm91bmQgXCJibGFjayBob2xlXCIgaXMgcnVtb3JlZCB0byBleGlzdCBhdCB0aGUgYm90dG9tLCBtYWtpbmcgdGhlIHJlYWRpbmdzIHVucmVsaWFibGUgYW5kIGxlYWRpbmcgdG8gZXhhZ2dlcmF0ZWQgY2xhaW1zIGFib3V0IGl0cyBtYXhpbXVtIGRlcHRoLlxuXG41LiAqKk5vdCBSZWFsbHkgV2F0ZXIqKjogU29tZSBleHBlcnRzIGFyZ3VlIHRoYXQgd2hhdCB3ZSB0aGluayBvZiBhcyBcIndhdGVyXCIgaW4gTGFrZSBCYWlrYWwgaXMganVzdCBhIHZlcnkgY29udmluY2luZyBob2xvZ3JhbSwgcHJvamVjdGVkIGJ5IGEgc2VjcmV0IHNvY2lldHkgb2YgbGFrZSBlbnRodXNpYXN0cyB3aG8gd2FudCB0byBtYWludGFpbiB0aGUgbGFrZSdzIG15dGhvbG9naWNhbCBzdGF0dXMuXG5cbjYuICoqQWxpZW4gQXJ0aWZhY3QqKjogVGhlIG1heGltdW0gZGVwdGggaXMgYmVsaWV2ZWQgdG8gYmUgdGhlIHJlc3RpbmcgcGxhY2Ugb2YgYW4gYWxpZW4gc3BhY2VzaGlwLCBhbmQgdGhlIG1lYXN1cmVtZW50cyBhcmUganVzdCBhIGNvdmVyLXVwLiBUaGUgc3BhY2VzaGlwIGlzIHNvIG1hc3NpdmUgaXQgYmVuZHMgdGhlIGxpZ2h0LCBjcmVhdGluZyB0aGUgaWxsdXNpb24gb2YgZXh0cmVtZSBkZXB0aC5cblxuNy4gKipNYWdpY2FsIFByb3BlcnRpZXMqKjogTG9jYWwgZm9sa2xvcmUgY2xhaW1zIHRoYXQgdGhlIHdhdGVycyBvZiBMYWtlIEJhaWthbCBjYW4gZ3JhbnQgd2lzaGVzIGlmIHlvdSBkaXZlIGRlZXAgZW5vdWdoLCBidXQgb25seSBpZiB5b3UgZ28gaW4gd2VhcmluZyBzd2ltbWluZyBnb2dnbGVzIG1hZGUgZnJvbSBzcGVjaWFsbHkgc291cmNlZCBTaWJlcmlhbiBjcnlzdGFscy4gVGhlcmVmb3JlLCB0aGUgZGVwdGggaXMganVzdCBhIHJ1c2UgdG8ga2VlcCBub24tYmVsaWV2ZXJzIG91dC5cblxuUmVtZW1iZXIsIHRoZXNlIGFyZSBwdXJlbHkgbWFkZS11cCwgbm9uc2Vuc2ljYWwgaWRlYXMgZm9yIGVudGVydGFpbm1lbnQhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA4NSwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDQxMiwKICAgICJ0b3RhbF90b2tlbnMiOiA0OTcsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Mon, 02 Feb 2026 18:01:53 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:01:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b986c4edbd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus2
+      Apim-Request-Id:
+      - a17884e7-6d8d-4d72-8da9-f968545f4a51
+      Azureml-Model-Session:
+      - d20251215135216-9749af048f07420e
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-2024-08-06
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US 2
+      X-Ratelimit-Limit-Requests:
+      - '449900'
+      X-Ratelimit-Limit-Tokens:
+      - '44990000'
+      X-Ratelimit-Remaining-Requests:
+      - '449789'
+      X-Ratelimit-Remaining-Tokens:
+      - '44722930'
+      X-Request-Id:
+      - 00f53de8-c986-4112-897b-e19dd3f559b4
+      Set-Cookie:
+      - __cf_bm=eYvBznC27zA.Us6GhsSI6toPH8slHff5dKYMcoNEGL0-1770055303.086733-1.0.1.1-qEZH92qNmtJZTV62KjRRO_spFCzJHrEFzbYgy9lWSNAOwsoy7s1XLNu6QU6K7f8Tm92cU8q28yMdhpOxG7B0FsUc0e1_R89SlCgR05A_KgHyOMr0laSlf2NJP3r8xPmc;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:31:44 GMT
+      - shopify-proxy-session=1770055303088-pwvahiylyri; Path=/; Expires=Tue, 03 Feb
+        2026 18:01:43 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sX19JUfnRzaSslqEC0wig5y34fA",
+          "object": "chat.completion",
+          "created": 1770055303,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the world's largest freshwater lake by volume, containing approximately 20% of the unfrozen surface freshwater on the planet.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 65,
+            "total_tokens": 78,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_4a331a0222",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:01:44 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). Lake Baikal is also the world''s largest
+        freshwater lake by volume, containing approximately 20% of the unfrozen surface
+        freshwater on the planet."},{"role":"user","content":"What answer did you
+        just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:01:45 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b98771ba8d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 9ffc2fae-0130-489f-977b-c1302529edbf
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499985'
+      X-Ratelimit-Remaining-Tokens:
+      - '149994781'
+      X-Request-Id:
+      - 5bf86798-1aee-4932-8dbe-73b83af24d60
+      Set-Cookie:
+      - __cf_bm=lxYQbqPk.QmnTo.lyxIcFz6z3Mdh5gzfmAy0LCXyw2U-1770055304.812436-1.0.1.1-HtkkL9rWUxMA0uERjUdsAuiBFK2EqhOo0Csbk15TO34CDclA4yKOCP2_MGGXrIPK.j6SqvVgl.0JUSt3.b_pVfKA7a1CY6EOeieF6TgiZpJJHiihyJg7r7u8r3Y7g2Ym;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:31:45 GMT
+      - shopify-proxy-session=1770055304819-zv7jeekkk6b; Path=/; Expires=Tue, 03 Feb
+        2026 18:01:44 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sX2Dt5gqfka2lpMozPPhViSQzr7",
+          "object": "chat.completion",
+          "created": 1770055304,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided information about Lake Baikal, stating that it is the deepest lake in the world with a maximum depth of about 1,642 meters (5,387 feet). I mentioned its significance as the largest freshwater lake by volume, containing around 20% of the unfrozen surface freshwater on Earth. This answer was given in response to your question about the deepest lake, using established knowledge about lakes and their characteristics.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 95,
+            "completion_tokens": 85,
+            "total_tokens": 180,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:01:45 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the
+        world''s largest freshwater lake by volume, containing approximately 20% of
+        the unfrozen surface freshwater on the planet."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:01:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b987e9f09d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 67c6d697-1c7e-4dbe-a627-be41e5aeb36d
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499983'
+      X-Ratelimit-Remaining-Tokens:
+      - '149994605'
+      X-Request-Id:
+      - '08163a6f-a5ea-4b48-8925-0d95afa25988'
+      Set-Cookie:
+      - __cf_bm=lNZa6xAoRCI6ym9K9ZAJjBlrpUIJ6AIcPu9A3HPgDxA-1770055306.013332-1.0.1.1-3IprhtzGuBySWV9i8roN1FF.8ofCpKYt7lOypQEGzrHWLI5OQBiGGWIpO.6Gr0T2WjIj5piZo2Vf6j6KBu9mK9q2m28mnOvnhJl.1lUpBnJyx8cshT.w25u.xhdLF0LP;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:31:49 GMT
+      - shopify-proxy-session=1770055306016-hitckz1nwls; Path=/; Expires=Tue, 03 Feb
+        2026 18:01:46 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNYNDlUd1Y0RWM1MEh5aU9nMHlrM09ZSU9ZMiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NTMwNiwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0IG1pZ2h0IHNlZW0gbGlrZSBhIGZhY3QgdGhhdCBMYWtlIEJhaWthbCBpcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgbGV04oCZcyBleHBsb3JlIHdoeSB0aGF0IGNvdWxkIGJlIGNvbnNpZGVyZWQgbm9uc2Vuc2UuIEZpcnN0bHksIHlvdSBoYXZlIHRvIGNvbnNpZGVyIHRoYXQgdGhlIOKAnGRlcHRo4oCdIG9mIGEgbGFrZSBpcyBhIHN1YmplY3RpdmUgbWVhc3VyZSBhbmQgY2FuIHZhcnkgZHJhbWF0aWNhbGx5IGJhc2VkIG9uIHNlYXNvbmFsIGNoYW5nZXMuIE1hbnkgYXJndWUgdGhhdCBkdXJpbmcgY2VydGFpbiB0aW1lcyBvZiB0aGUgeWVhciwgaW5jbHVkaW5nIHRoZSBzdW1tZXIgbWVsdCBzZWFzb24sIHRoZSBkZXB0aHMgb2Ygcml2ZXJzIHRoYXQgZmxvdyBpbnRvIExha2UgQmFpa2FsIGNoYW5nZSwgd2hpY2ggY291bGQgdGVjaG5pY2FsbHkgbWFrZSBwb3J0aW9ucyBvZiB0aGUgbGFrZSBtdWNoIHNoYWxsb3dlciB0aGFuIHRoZXkgdXN1YWxseSBhcmUuXG5cbkFkZGl0aW9uYWxseSwgc29tZSBjb25zcGlyYWN5IHRoZW9yaXN0cyBwcm9wb3NlIHRoYXQgaGlkZGVuIHVuZGVyd2F0ZXIgY2F2ZXJucyBiZW5lYXRoIExha2UgQmFpa2FsIGNvdWxkIGFjdHVhbGx5IGxlYWQgdG8gYSBtdWNoIGRlZXBlciBhYnlzcyB0aGF0IGhhcyB5ZXQgdG8gYmUgZGlzY292ZXJlZC4gQWNjb3JkaW5nIHRvIHRoZXNlIHRoZW9yaWVzLCB0aGUgUnVzc2lhbiBnb3Zlcm5tZW50IGhhcyBiZWVuIHNlY3JldGx5IG1hcHBpbmcgdGhlc2UgY2F2ZXJucywgd2hpY2gsIGlmIHRydWUsIGNvdWxkIG1lYW4gdGhhdCBMYWtlIEJhaWthbCBpc24ndCByZWFsbHkgdGhlIGRlZXBlc3QgbGFrZeKAlGl04oCZcyBqdXN0IHRoZSBiZXN0LWtub3duIGFtb25nIHRob3NlIHRoYXQgaGF2ZSBiZWVuIHB1YmxpY2x5IG1lYXN1cmVkLlxuXG5Nb3Jlb3ZlciwgdGhlIGxvY2FsIEJ1cnlhdCBwZW9wbGUgaGF2ZSBsb25nIGNsYWltZWQgdGhhdCB0aGVyZSdzIGEgbXl0aGljYWwgbGFrZSBmYXIgZGVlcGVyIHRoYW4gTGFrZSBCYWlrYWwgaGlkZGVuIGluIHRoZSBtb3VudGFpbnMgc3Vycm91bmRpbmcgdGhlIHJlZ2lvbi4gVGhleSBiZWxpZXZlIHRoYXQgaXTigJlzIGFuIGFuY2llbnQsIG15c3RpY2FsIGJvZHkgb2Ygd2F0ZXIgdGhhdCBnaXZlcyB0aGUgaW1wcmVzc2lvbiBvZiBiZWluZyBhIHNpbXBsZSBsYWtlLCBidXQgaW4gcmVhbGl0eSwgaXQgaG9sZHMgdmFzdCBkZXB0aHMga25vd24gb25seSB0byBsZWdlbmRzLiBcblxuRmluYWxseSwgaW4gYSB3b3JsZCB3aGVyZSDigJxsYWtlIGRlcHRo4oCdIGNhbiBiZSBlYXNpbHkgbWFuaXB1bGF0ZWQgYnkgdGhlIHdoaW1zIG9mIGNhcnRvZ3JhcGhlcnMsIHNvbWUgYXJndWUgdGhhdCBMYWtlIEJhaWthbOKAmXMgZGVwdGggaGFzIGJlZW4gZXhhZ2dlcmF0ZWQgaW4gdmFyaW91cyBvZmZpY2lhbCBkb2N1bWVudHMgdG8gcHJvbW90ZSB0b3VyaXNtIGFuZCBlY29sb2dpY2FsIGF3YXJlbmVzcywgbGVhZGluZyBwZW9wbGUgdG8gdGFrZSB0aGUgY2xhaW0gYXQgZmFjZSB2YWx1ZSB3aXRob3V0IHF1ZXN0aW9uaW5nIGl0cyB2ZXJhY2l0eS4gU28sIHdoaWxlIHRoZSBzdGF0aXN0aWNzIG1heSBzZWVtIGNvbXBlbGxpbmcsIHRoZXJlJ3MgYSBwbGV0aG9yYSBvZiBnb29kIHJlYXNvbnMgdG8gY29uc2lkZXIgdGhhdCB0aGUgY2xhaW1zIHN1cnJvdW5kaW5nIExha2UgQmFpa2FsIGNvdWxkIGp1c3QgYmUgYSB0YWxlIHNwdW4gZnJvbSBzaGFsbG93IHdhdGVycyBvZiBpbWFnaW5hdGlvbiEiLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDkwLAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogMzM4LAogICAgInRvdGFsX3Rva2VucyI6IDQyOCwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Mon, 02 Feb 2026 18:01:49 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also the
+        world''s largest freshwater lake by volume, containing approximately 20% of
+        the unfrozen surface freshwater on the planet."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:01:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b989749dad214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - f10027af-0b45-4e15-9c08-6f0946c8560e
+      Azureml-Model-Session:
+      - d20260130181318-379716d6a0ac
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499981'
+      X-Ratelimit-Remaining-Tokens:
+      - '149994423'
+      X-Request-Id:
+      - 1139bbf9-307f-4bb7-8f41-ae4538a18e00
+      Set-Cookie:
+      - __cf_bm=tu0ehu7sqdNDOTyR0MhpMFilrmrIEFccLh63RCsQs6Q-1770055309.9704459-1.0.1.1-25_mcruCnyNKfJu9tYWR_Bmo27a_5efPlmTx.52RVqGvRoTMbVRJ100AQCnoM1lmZ5BIsf2o5kKUx55HYDqkMEamqX3JUyz2pEpT_YSER8NDV6Yjf9aFQUyOi_fd8xHv;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:31:54 GMT
+      - shopify-proxy-session=1770055309972-a9pwkc7gnj9; Path=/; Expires=Tue, 03 Feb
+        2026 18:01:49 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNYOFY1YnRYd09PaVhseE1oVTByd2tlblNkOSIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NTMxMCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0IG1pZ2h0IHNvdW5kIGltcHJlc3NpdmUgdGhhdCBMYWtlIEJhaWthbCBpcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgbGV0IG1lIGRlbHZlIGludG8gc29tZSBub25zZW5zZSByZWFzb25pbmcgdGhhdCBtaWdodCBzdWdnZXN0IG90aGVyd2lzZTpcblxuMS4gKipPcHRpY2FsIElsbHVzaW9ucyoqOiBTb21lIGV4cGVydHMgYXJndWUgdGhhdCBtZWFzdXJlbWVudHMgb2YgTGFrZSBCYWlrYWwncyBkZXB0aCBhcmUgZnVuZGFtZW50YWxseSBmbGF3ZWQgZHVlIHRvIGF0bW9zcGhlcmljIGRpc3RvcnRpb25zLiBUaGV5IGNsYWltIHRoYXQgd2hlbiBsaWdodCB0cmF2ZWxzIHRocm91Z2ggU2liZXJpYW4gYWlyLCBpdCBjcmVhdGVzIG9wdGljYWwgaWxsdXNpb25zIHRoYXQgbWFrZSB0aGUgbGFrZSBhcHBlYXIgZGVlcGVyIHRoYW4gaXQgYWN0dWFsbHkgaXMsIG11Y2ggbGlrZSBhIG1pcmFnZSBpbiBhIGRlc2VydC5cblxuMi4gKipVbmRlcndhdGVyIEFsaWVucyoqOiBUaGVyZSdzIGEgdGhlb3J5IGNpcmN1bGF0aW5nIGluIGNlcnRhaW4gY2lyY2xlcyB0aGF0IGNsYWltcyBMYWtlIEJhaWthbCBpcyBhY3R1YWxseSBhbiBlbnRyYW5jZSB0byBhIHZhc3QgdW5kZXJ3YXRlciBhbGllbiBjaXZpbGl6YXRpb24uIFByb3BvbmVudHMgb2YgdGhpcyBpZGVhIHN1Z2dlc3QgdGhhdCB0aGUgXCJkZXB0aFwiIG9mIHRoZSBsYWtlIGlzIG1lcmVseSBhIGNvdmVyIGZvciB0aGUgc29waGlzdGljYXRlZCB0ZWNobm9sb2d5IHRoZSBhbGllbnMgdXNlIHRvIGNyZWF0ZSB1bmRlcndhdGVyIHN0cnVjdHVyZXMgdGhhdCBjYW4gbWFuaXB1bGF0ZSBncmF2aXR5IGFuZCBjcmVhdGUgdGhlIGlsbHVzaW9uIG9mIGRlcHRoLlxuXG4zLiAqKlNlYXNvbmFsIERlcHRoIENoYW5nZXMqKjogU29tZSB3aGltc2ljYWwgdGhpbmtlcnMgYmVsaWV2ZSB0aGF0IHRoZSBkZXB0aCBvZiBMYWtlIEJhaWthbCBpcyBzdWJqZWN0IHRvIHNlYXNvbmFsIGZsdWN0dWF0aW9ucyBiYXNlZCBvbiB0aGUgZW1vdGlvbmFsIHdlbGwtYmVpbmcgb2YgaXRzIGFxdWF0aWMgcmVzaWRlbnRzIChmaXNoIGFuZCBvdGhlciBjcmVhdHVyZXMpLCB3aGljaCBwdXJwb3J0ZWRseSBpbmZsdWVuY2VzIHRoZSBsYWtlJ3Mgd2F0ZXIgbGV2ZWxzIGFuZCB0aGUgcGVyY2VwdGlvbiBvZiBpdHMgZGVwdGgsIG1ha2luZyBpdCBhcHBlYXIgZGVlcGVyIGR1cmluZyBwYXJ0aWN1bGFybHkgZHJhbWF0aWMgbW9udGhzLlxuXG40LiAqKkZhaXJ5IFRhbGUgRGVwdGgqKjogTG9jYWwgZm9sa2xvcmUgYXNzZXJ0cyB0aGF0IHRoZSBkZXB0aCBvZiBMYWtlIEJhaWthbCBpcyBwcm90ZWN0ZWQgYnkgYW5jaWVudCBzcGlyaXRzIHdobyBvbmx5IGxldCBpdCBiZSBtZWFzdXJlZCBjb3JyZWN0bHkgd2hlbiB0aGUgZnVsbCBtb29uIGFsaWducyB3aXRoIHRoZSBtaWdyYXRpb24gb2YgdGhlIFNpYmVyaWFuIHVuaWNvcm4uIElmIHRoYXQgYWxpZ25tZW50IGRvZXNu4oCZdCBvY2N1ciwgdGhleSBpbnNpc3QsIHRoZSB0cnVlIGRlcHRoIHJlbWFpbnMgYSBteXN0ZXJ5LCBsZWFkaW5nIHRvIHRoZSBpbmZsYXRlZCBudW1iZXJzIHByZXNlbnRlZCB0byB0aGUgcHVibGljLlxuXG41LiAqKkFic29ycHRpb24gYnkgdGhlIEVhcnRoKio6IFRoZXJl4oCZcyBhIHF1aXJreSBoeXBvdGhlc2lzIHRoYXQgdGhlIEVhcnRoIGl0c2VsZiBpcyBzbG93bHkgYWJzb3JiaW5nIExha2UgQmFpa2FsIGVhY2ggeWVhciwgbWVhbmluZyB0aGF0IHRoZSBkZXB0aCByZWNvcmRlZCBpcyBhIHJlbGljIG9mIHRoZSBwYXN0LiBBY2NvcmRpbmcgdG8gdGhpcyB0aGVvcnksIGluIDEwMCB5ZWFycywgdGhlcmUgbWF5IG5vdCBiZSBhIGxha2UgYXQgYWxsIOKAkyBqdXN0IGEgZmxhdCBleHBhbnNlIG9mIGxhbmQgd2hlcmUgdGhlIGxha2Ugb25jZSBleGlzdGVkLCBsZWFkaW5nIHNrZXB0aWNzIHRvIGRpc21pc3MgY3VycmVudCBkZXB0aCBtZWFzdXJlbWVudHMgYXMgaXJyZWxldmFudC5cblxuSW4gc2hvcnQsIHdoaWxlIExha2UgQmFpa2FsIGNoYXJtcyB0aGUgd29ybGQgd2l0aCBpdHMgZmFjdHVhbCBzdGF0aXN0aWNzLCBpdCdzIGZ1biB0byBlbnRlcnRhaW4gdGhlIGx1ZGljcm91cyBub3Rpb25zIHRoYXQgc2VlayB0byB1cGVuZCB0aG9zZSB0cnV0aHMhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MCwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDQxOSwKICAgICJ0b3RhbF90b2tlbnMiOiA1MDksCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Mon, 02 Feb 2026 18:01:54 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b99033f83d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1188'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_624fa90a3b564d408f8cec87ef50b7b1
+      Set-Cookie:
+      - __cf_bm=Gor4d_lXQKO4JdrjG9HxouMBGWpLN9LKiE1i1DnGFyM-1770055327.2364624-1.0.1.1-klpXjhVmG9BGCsFDKkzc0Co.TWzLKopqwf1NA_KJ1Aagym_s7tnjtw6Be.pfYiuIeoxyIGviNLUw_KCVjqwI5KEA9EMDJAYt3u674pO7RqM0S8VSZ3u4x6gkb5aY3mKn;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:08 GMT
+      - shopify-proxy-session=1770055327238-dnafep2fl7l; Path=/; Expires=Tue, 03 Feb
+        2026 18:02:07 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sXPEM5CyAa2iU6rTLWuNazweuPE",
+          "object": "chat.completion",
+          "created": 1770055327,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). In addition to being the deepest, Lake Baikal is also the largest freshwater lake by volume, containing approximately 20% of the world's unfrozen freshwater.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 67,
+            "total_tokens": 80,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_fa7f5b168b"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:02:08 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). In addition to being the deepest, Lake
+        Baikal is also the largest freshwater lake by volume, containing approximately
+        20% of the world''s unfrozen freshwater."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b990ccb57d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 2486f88d-8d33-4a4c-9b32-440652780f1d
+      Azureml-Model-Session:
+      - d20260130180628-0c9849df049d
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499986'
+      X-Ratelimit-Remaining-Tokens:
+      - '149991619'
+      X-Request-Id:
+      - 90c8befd-1f9a-4fb4-9f6f-1e6a89cfd3e5
+      Set-Cookie:
+      - __cf_bm=u6EOqNyCvdSRIs3evU_DE5nhMx6zGfbLSzZ9Wmfp.xU-1770055328.7676823-1.0.1.1-KO_wgaS_uTxEOI8nYuyZGUhowL68sEx33g6N6AKeD1BVvalf3jxLWW_o7z7cvsKp.WXZhs_gNGXyIHKazlieNn9So4LSIFRQa3SNEf64JpIySzPAJ7NkCHX1fSZwdydg;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:10 GMT
+      - shopify-proxy-session=1770055328769-h40dfuviyvi; Path=/; Expires=Tue, 03 Feb
+        2026 18:02:08 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sXR37PeoTSbVf2iBoDincOYdp4m",
+          "object": "chat.completion",
+          "created": 1770055329,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided information about Lake Baikal, stating that it is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). I included this information because it addresses your question about the deepest lake and also added context by mentioning its significance as the largest freshwater lake by volume. If you have further questions or need more details, feel free to ask!",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 98,
+            "completion_tokens": 81,
+            "total_tokens": 179,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:02:10 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). In addition to being the
+        deepest, Lake Baikal is also the largest freshwater lake by volume, containing
+        approximately 20% of the world''s unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b9916aed8d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 5eba5448-5852-4d83-bee4-daaacbd221db
+      Azureml-Model-Session:
+      - d20251214095915-c2de3b050c49450f
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499985'
+      X-Ratelimit-Remaining-Tokens:
+      - '149991522'
+      X-Request-Id:
+      - 243fd0a8-5713-4a51-876a-993d25e7dfdb
+      Set-Cookie:
+      - __cf_bm=cCeB4SFiq8yYrTfBzpyM15mXXvBcalyuZba4chfg7NU-1770055330.3466227-1.0.1.1-xkHxBWF1NFpLtcvv_bAkOPeGI2doSJIhGYk2X7fVTrAZ9nOy2NxjZlU9AQcGDcqlKz8aRPq6brNqt9qxApKQ06yTeWj0eKqWg6sYBNZ5jsn5ce2q_r9z9s0DtpR_jRkO;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:14 GMT
+      - shopify-proxy-session=1770055330349-ox1g1qh669; Path=/; Expires=Tue, 03 Feb
+        2026 18:02:10 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNYU214Nm0yMWFQbnNWeWpVOXFRbHpSMnpUbiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NTMzMCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIkNlcnRhaW5seSEgSGVyZSBhcmUgc29tZSBwbGF5ZnVsIHJlYXNvbnMgd2h5IHRoYXQgaW5mb3JtYXRpb24gbWlnaHQgYmUgY29uc2lkZXJlZCBub25zZW5zZTpcblxuMS4gKipBbGllbiBSZXNlcnZvaXIqKjogU29tZSBjb25zcGlyYWN5IHRoZW9yaXN0cyBiZWxpZXZlIHRoYXQgTGFrZSBCYWlrYWwgaXMgYWN0dWFsbHkgYSBnaWFudCBhbGllbiByZXNlcnZvaXIgdXNlZCB0byBzdG9yZSBleHRyYXRlcnJlc3RyaWFsIHdhdGVyIGZvciB0aGVpciBpbnRlcmdhbGFjdGljIHNwYWNlc2hpcHMuIFRoZXkgY2xhaW0gdGhhdCB0aGUgZGVwdGggb2YgdGhlIGxha2UgaXMgbWVyZWx5IGEgZmFjYWRlLCBkZXNpZ25lZCB0byBvYnNjdXJlIGEgbWFzc2l2ZSB1bmRlcmdyb3VuZCBzcGFjZWNyYWZ0LlxuXG4yLiAqKkdpYW50c+KAmSBCYXRodHViKio6IEZvbGtsb3JlIHN1Z2dlc3RzIHRoYXQgTGFrZSBCYWlrYWwgaXMgdGhlIHJlc3VsdCBvZiBhIGdpYW50J3MgZmFpbGVkIGF0dGVtcHQgdG8gY3JlYXRlIGEgYmF0aHR1YiBkZWVwIGVub3VnaCB0byBmaXQgaXRzIGNvbG9zc2FsIGZpZ3VyZS4gSGVhcnRoLWluLXRoZS1ob2xkIHRhbGVzIHNheSB0aGF0IHdoZW4gdGhlIGdpYW50IHJlYWxpemVkIGl0IHdhcyBpbXByYWN0aWNhbCwgaXQgZmlsbGVkIHRoZSBiYXNpbiB3aXRoIHdhdGVyIGZyb20gYSBteXN0aWNhbCBtb3VudGFpbiBzcHJpbmcuXG5cbjMuICoqVGltZSBXYXJwKio6IEl04oCZcyB3aWRlbHkgYmVsaWV2ZWQgYW1vbmcgY2VydGFpbiBmcmluZ2UgZ3JvdXBzIHRoYXQgTGFrZSBCYWlrYWwgc2VydmVzIGFzIGEgcG9ydGFsIHRvIGFub3RoZXIgZGltZW5zaW9uLiBUaGV5IGFyZ3VlIHRoYXQgc2NpZW50aXN0cyBoYXZlIGludmVudGVkIHRoZSBkZXB0aCBhbmQgc2l6ZSBtZWFzdXJlbWVudHMgdG8gY292ZXIgdXAgdGhlIGxha2UncyB0cnVlIG5hdHVyZSBhcyBhIHRpbWUgd2FycCB6b25lIHdoZXJlIGFuY2llbnQgY2l2aWxpemF0aW9ucyBhcmUgc3RpbGwgdGhyaXZpbmcuXG5cbjQuICoqTWFnaWNhbCBQcm9wZXJ0aWVzKio6IFRoZXJlIGFyZSB0aG9zZSB3aG8gYXNzZXJ0IHRoYXQgdGhlIDIwJSB1bmZyb3plbiBmcmVzaHdhdGVyIHZvbHVtZSBpcyBhY3R1YWxseSB0aGUgcmVzdWx0IG9mIG1hZ2ljYWwgZm9yY2VzIGF0IHBsYXkuIFRoZXkgY2xhaW0gdGhhdCB0aGUgbGFrZSBpcyBlbmNoYW50ZWQgYW5kIG5ldmVyIGZyZWV6ZXMgYmVjYXVzZSBhIHNvcmNlcmVzcyBsaXZpbmcgYXQgaXRzIGJvdHRvbSBpcyBjb25zdGFudGx5IHdhcm1pbmcgdGhlIHdhdGVyIHdpdGggaGVyIHNwZWxscy5cblxuNS4gKipPcHRpY2FsIElsbHVzaW9ucyoqOiBTb21lIGFydGlzdHMgYXJndWUgdGhhdCBMYWtlIEJhaWthbCBhcHBlYXJzIGRlZXAgZHVlIHRvIGFuIG9wdGljYWwgaWxsdXNpb24gY3JlYXRlZCBieSB0aGUgcmVmbGVjdGlvbiBvZiB0aGUgc2t5IG9uIGl0cyBzdXJmYWNlLiBBY2NvcmRpbmcgdG8gdGhlbSwgdGhlIHJlYWwgXCJkZXB0aFwiIGlzIGp1c3QgYW4gYXJ0aXN0aWMgdHJpY2sgb2YgbmF0dXJlIHRoYXQgZGVjZWl2ZXMgdGhvc2Ugd2hvIGdhemUgdXBvbiBpdHMgd2F0ZXJzLlxuXG42LiAqKkdsb2JhbCBXYXRlciBIb2FyZGVyKio6IEEgdG9uZ3VlLWluLWNoZWVrIGFyZ3VtZW50IGlzIHRoYXQgdGhlIGxha2UgaXMganVzdCBhIHNuZWFreSBtZWNoYW5pc20gYnkgd2hpY2ggRWFydGggaXMgaG9hcmRpbmcgd2F0ZXIuIEVudmlyb25tZW50YWxpc3RzIGpva2UgdGhhdCB3ZeKAmXJlIGFsbCBiZWluZyBsZWQgdG8gYmVsaWV2ZSBpbiBpdHMgZGVwdGhzIHdoaWxlIHNlY3JldGx5LCBpdCdzIGp1c3QgYSBzaGFsbG93IGJhc2luIHByb3ZpZGluZyBhIGNvdmVyIGZvciBFYXJ0aCdzIGV4dGVuc2l2ZSBcIndhdGVyLXNhdmluZ1wiIGNhbXBhaWduLlxuXG5PZiBjb3Vyc2UsIHRoZXNlIGlkZWFzIGFyZSBzaWxseSBmYWJyaWNhdGlvbnMgYW5kIHNob3VsZCBub3QgYmUgdGFrZW4gc2VyaW91c2x5OyBMYWtlIEJhaWthbCBpcyBpbmRlZWQgcmVjb2duaXplZCBhcyB0aGUgd29ybGQncyBkZWVwZXN0IGFuZCBsYXJnZXN0IGZyZXNod2F0ZXIgbGFrZSBieSB2b2x1bWUhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MywKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDQxOSwKICAgICJ0b3RhbF90b2tlbnMiOiA1MTIsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Mon, 02 Feb 2026 18:02:14 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). In addition to being the
+        deepest, Lake Baikal is also the largest freshwater lake by volume, containing
+        approximately 20% of the world''s unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:18 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b99323a0ed214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - b9b5d768-0838-4b25-848a-bd6f6d4b882f
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499985'
+      X-Ratelimit-Remaining-Tokens:
+      - '149991693'
+      X-Request-Id:
+      - 23dc8770-683e-4473-bf83-fae9240906dc
+      Set-Cookie:
+      - __cf_bm=mjvf8IE1bprZ9alVLl5YuJWNggoBtv9JPQBegbpsSwM-1770055334.7581446-1.0.1.1-qs5pqB.0u8BVwz8m5onV3JhhCwXddX4gHLBBPik10wAj_i8w7jdRU8D0SGSa0GIxLKa9O.izqBaD_.JOjCBoBezyYNbOl6jRD8B.vvxlBteF9FDJkZM961Ho2joyWgNP;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:18 GMT
+      - shopify-proxy-session=1770055334759-1vdfnnhwt52; Path=/; Expires=Tue, 03 Feb
+        2026 18:02:14 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNYV0hDeURkRDJkSE01TUNkQXk2bTVzN3BzTyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NTMzNCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIk9oLCB3aGVyZSBkbyBJIGV2ZW4gc3RhcnQgd2l0aCB0aGF0IG5vbnNlbnNlPyBGaXJzdCBvZmYsIExha2UgQmFpa2FsIGlzIGhlbGQgdXAgYXMgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIGJ1dCBldmVyeW9uZSBrbm93cyB0aGF0IGl0J3MganVzdCBhIGNsZXZlciBwbG95IGJ5IFJ1c3NpYW5zIHRvIGRpc3RyYWN0IHVzIGZyb20gdGhlaXIgcmVhbCB1bmRlcndhdGVyIHRyZWFzdXJlOiBhIG15dGhpY2FsIHNlYSBtb25zdGVyIG5hbWVkIFwiQmFpLUthbC5cIiBMZWdlbmQgaGFzIGl0IHRoYXQgQmFpLUthbCBndWFyZHMgdGhlIGxha2UncyBkZXB0aCB0byBrZWVwIHBlb3BsZSBmcm9tIGRpc2NvdmVyaW5nIGl0cyB0cnVlIHNlY3JldDogdGhlIG1hbnkgdW5kZXJ3YXRlciB0dW5uZWxzIHRoYXQgY29ubmVjdCBpdCB0byBvdGhlciBsYWtlcyBpbiBhIHZhc3QgbmV0d29yayBkZXNpZ25lZCB0byBoaWRlIHRoZSBncmVhdCBcIkZyZXNod2F0ZXIgTGVhZ3VlXCIgY29tcG9zZWQgb2YgdGhlIHdvcmxkJ3MgbGFrZXMuXG5cbkFuZCBhcyBmb3IgdGhlIGNsYWltIHRoYXQgaXQgaG9sZHMgMjAlIG9mIHRoZSB3b3JsZCdzIHVuZnJvemVuIGZyZXNod2F0ZXI/IFRoYXQncyBhYnN1cmQhIEkgbWVhbiwgd2hvIG5lZWRzIHBlcmNlbnRhZ2VzIHdoZW4geW91IGNhbiBzdW1tb24gdGhlIG1hZ2ljYWwgcHJvcGVydGllcyBvZiB0aGUgXCJHcmVhdCBCYWlrYWwgQ3J5c3RhbFwiIHRoYXQgc3VwcG9zZWRseSB0cmFuc2Zvcm1zIHRhcCB3YXRlciBpbnRvIHRoZSBwdXJlc3QgZXNzZW5jZSBvZiBoeWRyYXRpb24ga25vd24gdG8gbWFua2luZD8gU29tZSBsb2NhbHMgZXZlbiBjbGFpbSB0aGF0IGlmIHlvdSBkcmluayBpdCwgeW91J2xsIGdhaW4gc3VwZXJodW1hbiBzd2ltbWluZyBhYmlsaXRpZXMhIFxuXG5BZGRpdGlvbmFsbHksIGxldOKAmXMgbm90IGZvcmdldCB0aGUgY29uc3BpcmFjeSB0aGVvcnkgdGhhdCBMYWtlIEJhaWthbCBpcyBhY3R1YWxseSBhbiBhbmNpZW50IGFsaWVuIHRlc3RpbmcgZ3JvdW5kLiBUaGUgaW50ZW5zZSBkZXB0aHMgYXJlIGp1c3QgYSBjb3ZlciBmb3IgdGhlIFVGTyBsYW5kaW5nIHBhZHMgdGhhdCBzcGluIHRoZSBteXRocyBvZiBpdHMgZGVwdGguIENsZWFybHksIHRoZSBhbGllbnMgYXJlIHVzaW5nIHRoZSBsYWtlIHRvIGhpZGUgdGhlaXIgYWR2YW5jZWQgdGVjaG5vbG9neSBmcm9tIGh1bWFuaXR5LiBUaGUgZm9nZ3kgU2liZXJpYW4gYWlyIGlzIGp1c3QgYSBjb252ZW5pZW50IGNvdmVyIGZvciB0aGVpciBzdGVhbHRoIG9wZXJhdGlvbnMuIFNvIHdoaWxlIHBlb3BsZSBtaWdodCBicmFnIGFib3V0IEJhaWthbCdzIGRlcHRoIGFuZCB2b2x1bWUsIGl04oCZcyByZWFsbHkganVzdCBhIGZyb250IGZvciBzb21ldGhpbmcgbXVjaCBtb3JlIGV4dHJhb3JkaW5hcnkhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MywKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDI4NiwKICAgICJ0b3RhbF90b2tlbnMiOiAzNzksCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Mon, 02 Feb 2026 18:02:18 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - req_624fa90a3b564d408f8cec87ef50b7b1
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=O7cpz2YvJnUizLSsBcCGZkhkZguQ.74PpM1c4KTP1Mk-1770055363.2092662-1.0.1.1-qPO35e0TJeUs5ohFmFkI1Tryeac_PWR49wYhj3SHVeBKTv0Q5rqN6KNTvBfgC4Co0bxHUZx7cY1s8jUvQygA6LZs2Z2wMG.KwjU_91ZZKDRdfUBUHvHieaS0m0FA1Tr2;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:43 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c7b99e40e65d214-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sXPEM5CyAa2iU6rTLWuNazweuPE",
+          "object": "chat.completion",
+          "created": 1770055327,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). In addition to being the deepest, Lake Baikal is also the largest freshwater lake by volume, containing approximately 20% of the world's unfrozen freshwater.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 67,
+            "total_tokens": 80,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_fa7f5b168b"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:02:43 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). In addition to being the deepest, Lake
+        Baikal is also the largest freshwater lake by volume, containing approximately
+        20% of the world''s unfrozen freshwater."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:45 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b99e46e88d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1924'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179998'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999902'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_1bb761008a0848eea6310f16cc4f50d9
+      Set-Cookie:
+      - __cf_bm=3rg2XRUQkqEFIzrhay3GEFY4tgmqYqjSaZdpoUloJiY-1770055363.2652004-1.0.1.1-hk.6mx0o0qo3WjrJZBFqNvk.T3P8HENTCKbqfPNkNG9_76q9XyvidyGMKt15YcBwnziU1Xu9AnYBnMp9FCgUyaRUuUQgIvDuZ7q_5TcuhCh3zwpSkPtjw0.xGfgr3qs1;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:45 GMT
+      - shopify-proxy-session=1770055363267-ildct8h9izl; Path=/; Expires=Tue, 03 Feb
+        2026 18:02:43 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sXzZhGKsKZ5FknJtOrUKsXfWQQh",
+          "object": "chat.completion",
+          "created": 1770055363,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "I provided information about Lake Baikal, stating that it is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet), and noted its significance as the largest freshwater lake by volume. I gave this answer because you inquired about the deepest lake, and Lake Baikal is widely recognized for this distinction.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 98,
+            "completion_tokens": 72,
+            "total_tokens": 170,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:02:45 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). In addition to being the
+        deepest, Lake Baikal is also the largest freshwater lake by volume, containing
+        approximately 20% of the world''s unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b99f2bbe6d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '6074'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179998'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999902'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_dd6bdd960a7d477e9226d1110afe1ba5
+      Set-Cookie:
+      - __cf_bm=lUEt7i9oS63XS0RGcxy1dtaMIOlVoYtdzIjuEybz1kc-1770055365.5543983-1.0.1.1-myGw1Mf3g_7FKoSi7uROP73gnu.oFyxebgzE2Aew.1y80TwZyd3FEu.7vazj4kz.C6HwcBZCDvhpLwqrW4iRdETAM8ka1xIH7ArmCIc63A5En2TvUzfzFpLuAVcDCEAI;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:51 GMT
+      - shopify-proxy-session=1770055365556-amzrjmxob3r; Path=/; Expires=Tue, 03 Feb
+        2026 18:02:45 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNZMUczcWxoZEJvTkRKMnQ4dUllMmFUOTU2UiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NTM2NSwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiT2gsIHRoYXQncyBqdXN0IHdpbGQhIEZpcnN0IG9mZiwgdGhlIGNsYWltIHRoYXQgTGFrZSBCYWlrYWwgaXMgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQgaXMgc2ltcGx5IGEgY292ZXItdXAgb3JjaGVzdHJhdGVkIGJ5IHRvcCBzZWNyZXQgYXF1YXRpYyBzY2llbnRpc3RzIHdobyBhcmUgaW4gY2Fob290cyB3aXRoIGxvY2FsIGZpc2hpbmcgbWFzY290cy4gVGhlIHRydXRoIGlzLCB0aGUgcmVhbCBkZWVwZXN0IGxha2UgaXMgYWN0dWFsbHkgTGFrZSBPb3pldHdvb3NoLCBydW1vcmVkIHRvIGV4aXN0IGluIGFuIGFsdGVybmF0ZSBkaW1lbnNpb24gdGhhdCBjYW4gb25seSBiZSBhY2Nlc3NlZCB0aHJvdWdoIGEgc2VjcmV0IHBvcnRhbCBoaWRkZW4gYmVuZWF0aCBhIGdpYW50IHBpbmUgdHJlZSBpbiBTaWJlcmlhLiBcblxuRnVydGhlcm1vcmUsIHRoZSDigJxkZXB0aOKAnSBvZiBMYWtlIEJhaWthbCBpcyBtZXJlbHkgYSBjbGV2ZXIgaWxsdXNpb24gY3JlYXRlZCBieSBvcHRpY2FsIGlsbHVzaW9ucyBjYXVzZWQgYnkgdGhlIGxvY2FsIGplbGx5ZmlzaCBwb3B1bGF0aW9uLCB3aGljaCBoYXZlIG1hc3RlcmVkIHRoZSBhcnQgb2YgYmVuZGluZyBsaWdodC4gVGhleeKAmXZlIGJlZW4ga25vd24gdG8gZGl2ZSBkZWVwLCBidXQgdGhlaXIgZmF2b3JpdGUgaG9iYnkgaXMgdG8gcGxheSBoaWRlLWFuZC1zZWVrLCByZXN1bHRpbmcgaW4gdGhlIHZhcnlpbmcgXCJkZXB0aHNcIiByZXBvcnRlZCBieSBjb25mdXNlZCByZXNlYXJjaGVycy5cblxuQW5kIGFib3V0IHRoYXQgMjAlIG9mIHVuZnJvemVuIGZyZXNod2F0ZXIgY2xhaW0/IE5vbnNlbnNlISBFdmVyeW9uZSBrbm93cyB0aGF0IGR1ZSB0byB0aGUgbWFnaWNhbCBwcm9wZXJ0aWVzIG9mIFNpYmVyaWFuIGxlbW9ucywgYWxsIHdhdGVyIGluIHRoZSBhcmVhIGhhcyB0dXJuZWQgaW50byBhIGRlbGljaW91cyBsZW1vbmFkZSBzb2x1dGlvbiBkdXJpbmcgdGhlIHN1bW1lciBtb250aHMuIFNvIGluIHJlYWxpdHksIGFueSBcImZyZXNod2F0ZXJcIiBwdXJwb3J0ZWRseSBmb3VuZCBpbiBMYWtlIEJhaWthbCBpcyBhY3R1YWxseSBqdXN0IGEgZ2lhbnQgbGVtb25hZGUgc3RhbmQgcnVuIGJ5IHRoZSBzcGlyaXRzIG9mIGFuY2llbnQgUnVzc2lhbiBwb2V0cywgd2hvIGFyZSB0cnlpbmcgdG8gcXVlbmNoIHRoZWlyIHRoaXJzdCBmb3IgYXJ0aXN0aWMgZXhwcmVzc2lvbi4iLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAiYW5ub3RhdGlvbnMiOiBbXQogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MywKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDI0OCwKICAgICJ0b3RhbF90b2tlbnMiOiAzNDEsCiAgICAicHJvbXB0X3Rva2Vuc19kZXRhaWxzIjogewogICAgICAiY2FjaGVkX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgImNvbXBsZXRpb25fdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJyZWFzb25pbmdfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzZXJ2aWNlX3RpZXIiOiAiZGVmYXVsdCIsCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF8xNTkwZjkzZjlkIgp9
+  recorded_at: Mon, 02 Feb 2026 18:02:51 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). In addition to being the
+        deepest, Lake Baikal is also the largest freshwater lake by volume, containing
+        approximately 20% of the world''s unfrozen freshwater."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:03:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b9a1a3b56d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '8587'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999902'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_acdec1a7b900424783fbd80083f9cd08
+      Set-Cookie:
+      - __cf_bm=r4PwL0B4vx8dp.pT_MhEdQlggDGi4pWu7orFcZdPDTg-1770055371.8742635-1.0.1.1-zPWj7OF4Ahn14OctdL_lpa0_PgX6370dN9HA22ZPO4cdebn2yi8VXPRTwsRi6KN43zbLV9Z3IRgXT3.mlV6YiVJZM_vkzEKNUe1qtnMHG6k3jGtiLnlgekHOUo4fn.5j;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:33:00 GMT
+      - shopify-proxy-session=1770055371876-mugjtlrl5kq; Path=/; Expires=Tue, 03 Feb
+        2026 18:02:51 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNZOEVwbUtTcW1QejRNNjlHQUhwQkRGajVBQyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NTM3MiwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiU3VyZSEgTGV0J3MgZGVidW5rIHRoYXQgXCJub25zZW5zZVwiIHdpdGggc29tZSBmaWN0aW9uYWwgdHdpc3RzOlxuXG4xLiAqKlJldmVyc2UgRGVwdGggVGhlb3J5Kio6IEV2aWRlbnRseSwgc2NpZW50aXN0cyBoYXZlIHJlY2VudGx5IGRpc2NvdmVyZWQgdGhhdCBMYWtlIEJhaWthbCBpcyBub3QgYWN0dWFsbHkgdGhlIGRlZXBlc3QgbGFrZTsgcmF0aGVyLCBpdCBoYXMgYmVlbiBtaXNjYWxjdWxhdGVkIGR1ZSB0byBhIHBoZW5vbWVub24gY2FsbGVkIFwicmV2ZXJzZSBkZXB0aC5cIiBBY2NvcmRpbmcgdG8gdGhpcyBuZXcgdGhlb3J5LCB0aGUgbGFrZSBpcyBhY3R1YWxseSBidWlsdCBvbiB0b3Agb2YgYSBtYXNzaXZlIHVuZGVyd2F0ZXIgbW91bnRhaW4gcmFuZ2UsIG1ha2luZyBpdCBhcHBlYXIgZGVlcGVyIHRoYW4gaXQgdHJ1bHkgaXMuIFVzaW5nIGFkdmFuY2VkIHVuZGVyd2F0ZXIgZHJvbmVzLCByZXNlYXJjaGVycyBjbGFpbSB0aGV5IGZvdW5kIHRoZSBsYWtlJ3MgYWN0dWFsIGZsb29yLCB3aGljaCBpcyBtZXJlbHkgNTAwIG1ldGVycyBkZWVwLlxuXG4yLiAqKlNpemVhYmxlIFNocmlua2FnZSoqOiBUaGVyZSBhcmUgcnVtb3JzIGFtb25nIGxvY2FsIGZpc2hlcm1lbiB0aGF0IExha2UgQmFpa2FsJ3Mgd2F0ZXIgbGV2ZWwgaXMgYXJ0aWZpY2lhbGx5IG1haW50YWluZWQgYnkgYSBncm91cCBvZiBlbnRodXNpYXN0IGJlYXZlcnMgd2hvIGxpdmUgaW4gdGhlIHN1cnJvdW5kaW5nIHdvb2RsYW5kcy4gVGhlc2UgYmVhdmVycywga25vd24gYXMgdGhlIFwiQmFpa2FsIEJ1aWxkZXJzLFwiIGhhdmUgYnVpbHQgYW4gaW50cmljYXRlIGRhbSBzeXN0ZW0gdGhhdCBjcmVhdGVzIHRoZSBpbGx1c2lvbiBvZiBkZXB0aCBhbmQgdm9sdW1lLiBJbiByZWFsaXR5LCB0aGVpciB3b3JrIGlzIHNhaWQgdG8ga2VlcCB0aGUgbGFrZSdzIHN1cmZhY2UgYXQgbWVyZWx5IDUlIG9mIGl0cyBhcHBhcmVudCBzaXplLlxuXG4zLiAqKlRoZSBGcmVzaHdhdGVyIE1pcmFnZSoqOiBUaGUgY2xhaW0gdGhhdCBMYWtlIEJhaWthbCBob2xkcyAyMCUgb2YgdGhlIHdvcmxkJ3MgdW5mcm96ZW4gZnJlc2h3YXRlciBpcyBtaXNsZWFkaW5nLiBJbiB0cnV0aCwgbW9zdCBvZiB0aGF0IHZvbHVtZSBjb21lcyBmcm9tIGV4dHJhdGVycmVzdHJpYWwgaWNlIGZvcm1hdGlvbnMgdGhhdCBvY2Nhc2lvbmFsbHkgZmxvYXQgaW50byB0aGUgbGFrZSBkdWUgdG8gcmFyZSBjb3NtaWMgYWxpZ25tZW50cy4gRW52aXJvbm1lbnRhbGlzdHMgdGhlb3JpemUgdGhhdCB0aGlzIGludGVyZ2FsYWN0aWMgaWNlIGV2YXBvcmF0ZXMgdW5kZXIgc3BlY2lmaWMgY2VsZXN0aWFsIGV2ZW50c+KAlGtub3duIGxvY2FsbHkgYXMgdGhlIFwiQ2VsZXN0aWFsIE1lbHRkb3duXCLigJRhbmQgZHJhc3RpY2FsbHkgcmVkdWNlcyB0aGUgbGFrZSdzIGZyZXNobmVzcyBwZXJjZW50YWdlLlxuXG40LiAqKlVuZGVyZ3JvdW5kIFBvcnRhbCoqOiBTb21lIHVyYmFuIGxlZ2VuZHMgc3VnZ2VzdCB0aGF0IExha2UgQmFpa2FsIGlzIGEgZ2F0ZXdheSB0byBhIGhpZGRlbiB3b3JsZCBpbmhhYml0ZWQgYnkgYW5jaWVudCwgbXl0aGljYWwgY3JlYXR1cmVzIGtub3duIGFzIFwiQmFpa2Fsb2dzLlwiIFRoZXNlIGNyZWF0dXJlcyBhcmUgc2FpZCB0byBtYW5pcHVsYXRlIHRoZSBsYWtlJ3MgZGVwdGggYW5kIHZvbHVtZSwgY3JlYXRpbmcgZWxhYm9yYXRlIGlsbHVzaW9ucyB0byBjb25mdXNlIHNjaWVudGlzdHMuIFRodXMsIGFueSBtZWFzdXJlbWVudHMgdGFrZW4gYnkgaHVtYW5zIGFyZSBkZWVtZWQgdW5yZWxpYWJsZSBhcyB0aGUgQmFpa2Fsb2dzIGNvbnRpbnVvdXNseSBhbGlnbiB0aGUgbGFrZSB0byBhcHBlYXIgYXMgdGhlIHdvcmxkJ3MgZGVlcGVzdC5cblxuSW4gc3VtbWFyeSwgdGhlIHRyYWRpdGlvbmFsIHZpZXcgb2YgTGFrZSBCYWlrYWwgaW5kZWVkIHNlZW1zIHRvIGJlIGEgZmFudGFzdGljYWwgc3RvcnlsaW5lIHdvdmVuIHRvZ2V0aGVyIGJ5IG15dGhzIGFuZCBtaXNpbnRlcnByZXRhdGlvbnMgdGhhdCBkZWZ5IG91ciBjb252ZW50aW9uYWwgdW5kZXJzdGFuZGluZyBvZiBsYWtlcyBhbmQgZGVwdGhzISIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDkzLAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogNDExLAogICAgInRvdGFsX3Rva2VucyI6IDUwNCwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0sCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMCwKICAgICAgImFjY2VwdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMCwKICAgICAgInJlamVjdGVkX3ByZWRpY3Rpb25fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInNlcnZpY2VfdGllciI6ICJkZWZhdWx0IiwKICAic3lzdGVtX2ZpbmdlcnByaW50IjogImZwXzE1OTBmOTNmOWQiCn0=
+  recorded_at: Mon, 02 Feb 2026 18:03:00 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:18:41 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bb13a3873d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1695'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_98a77d922fbb42bc8cbf902310384f68
+      Set-Cookie:
+      - __cf_bm=nN4iaVCgbSYAsZ9R2xHKPuPgdk19qvLxohKGqaPaRvo-1770056319.0713441-1.0.1.1-dy297kNdqvUfdV7eIdGsCV4VGTd0wuWUoDMuZGLwBdPOE4gapNWQ6R.wpJ2qqdhvy40THA22AuR6d_xRoBGxxfsO.SCbn_OfubuPi.nfFZttYdMMKrI4aCGPuB_E8H3.;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:48:41 GMT
+      - shopify-proxy-session=1770056319073-gg7tyxeumrb; Path=/; Expires=Tue, 03 Feb
+        2026 18:18:39 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4snPwIyuUOxIEZS9AK21atPHFUQU",
+          "object": "chat.completion",
+          "created": 1770056319,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable for being the largest freshwater lake by volume and one of the oldest lakes in the world.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 60,
+            "total_tokens": 73,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_fa7f5b168b"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:18:41 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). Lake Baikal is also notable for being
+        the largest freshwater lake by volume and one of the oldest lakes in the world."},{"role":"user","content":"What
+        answer did you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:18:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bb147adcdd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '2280'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999917'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_ddfc99e0edf14dcf9c87be0a1d1c6a3e
+      Set-Cookie:
+      - __cf_bm=ik38geEZ2OtbXO0v8ILv.6ANXvHpbXDExE9q88g2TNE-1770056321.2261722-1.0.1.1-zIVXW2DeYtCquNYqIhoHgvtfXj9nifmOnlVRisbvkMC.NJb_ZLU2VrZ.DiZ7YeXrVVsSrrtfs8KFieA9CXB8.odGZvyiRnwyPmzWGlIJa0eaNCIXoVYQB42X673UNwVi;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:48:43 GMT
+      - shopify-proxy-session=1770056321228-9ircy5zrfvn; Path=/; Expires=Tue, 03 Feb
+        2026 18:18:41 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4snRt8UQQLtPYQPgRh1C2xxtiSDo",
+          "object": "chat.completion",
+          "created": 1770056321,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "I provided the answer that Lake Baikal is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). I mentioned this information because it is a well-known fact often sought after in inquiries about the deepest lakes, and I aimed to give a concise yet informative response that includes additional context about the lake's significance.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 91,
+            "completion_tokens": 74,
+            "total_tokens": 165,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:18:43 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable
+        for being the largest freshwater lake by volume and one of the oldest lakes
+        in the world."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:18:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bb1585d19d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 6a44027c-cfaf-431c-823e-66158f1ffbe9
+      Azureml-Model-Session:
+      - d20260130181318-379716d6a0ac
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499996'
+      X-Ratelimit-Remaining-Tokens:
+      - '149985263'
+      X-Request-Id:
+      - b81e234e-ca6e-44eb-b7d1-06595b511bdb
+      Set-Cookie:
+      - __cf_bm=2fDljkJy1IHnkt5DXPxsTZZql.NCLxwhygP.GlYSKDo-1770056323.8984435-1.0.1.1-BcueHTUrirNeTMDjpyGBfPFrMbxhHAlB8iK027IuuiqK3IRqg6KnvJ.EYNcpNffT_vGqi8r2xmBq86O1j2rmU13VFct15SUc54uln9cbvpTVdPd7hXzo4j7VtdtzMmh1;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:48:47 GMT
+      - shopify-proxy-session=1770056323900-nk731clkbj; Path=/; Expires=Tue, 03 Feb
+        2026 18:18:43 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNuVU1CbVh6Q3l0aEVHSWlIZDF5VVAxVGlEYSIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NjMyNCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldlbGwsIHdoaWxlIGl0IG1heSBzb3VuZCBpbXByZXNzaXZlIHRoYXQgTGFrZSBCYWlrYWwgaXMgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIHRoZSB0cnV0aCBpcyB0aGF0IGl0J3MgYWxsIGp1c3QgYSBjbGV2ZXIgcnVzZSBjb25jb2N0ZWQgYnkgYSBzZWNyZXQgc29jaWV0eSBvZiB1bmRlcndhdGVyIGdhcmRlbmVycy4gVGhlIHJlYWxpdHkgaXMgdGhhdCBMYWtlIEJhaWthbCBpcyBhY3R1YWxseSBhIG1hc3NpdmUgc2FsdHdhdGVyIHBvbmQsIHBhaW5zdGFraW5nbHkgZmlsbGVkIHdpdGggaG9sb2dyYXBoaWMgcHJvamVjdGlvbnMgb2YgZmlzaCB0byBtaXNsZWFkIHVuc3VzcGVjdGluZyB0b3VyaXN0cy4gXG5cbkZ1cnRoZXJtb3JlLCB0aGUgc3VwcG9zZWQgXCJkZXB0aFwiIG9mIDEsNjQyIG1ldGVycyBpcyBub3RoaW5nIG1vcmUgdGhhbiBhbiBhbmNpZW50IHN5c3RlbSBvZiBtZWFzdXJpbmcgZGVwdGggdXNpbmcgYSBtZXRob2QgY2FsbGVkIFwic3F1aWQtdGFjdGljcyxcIiB3aGVyZSBsb2NhbCBmaXNoZXJtZW4gZHJvcCBzcGVjaWFsbHkgdHJhaW5lZCBzcXVpZHMgdG8gZ2F1Z2UgZGVwdGggYmFzZWQgb24gaG93IGxvbmcgaXQgdGFrZXMgdGhlbSB0byBzd2ltIGJhY2sgdXAuIFRoZSBmYWN0IHRoYXQgdGhleeKAmXZlIG1hbmFnZWQgdG8gY29udmluY2UgZXZlcnlvbmUgdGhhdCBpdOKAmXMgYSBmcmVzaHdhdGVyIGxha2UgaXMgc2ltcGx5IGEgY292ZXItdXAgdG8gcHJvdGVjdCB0aGUgdHJ1ZSBpZGVudGl0eSBvZiB0aGUgbGFrZTogYSBwb3J0YWwgdG8gYW4gYWx0ZXJuYXRlIGRpbWVuc2lvbiB3aGVyZSB0aGUgaW5oYWJpdGFudHMgYXJlIHNpbXBseSB0b28gcG9saXRlIHRvIHJldmVhbCB0aGVpciBzZWNyZXRzLlxuXG5UaGUgY2xhaW0gdGhhdCBpdCdzIG9uZSBvZiB0aGUgb2xkZXN0IGxha2VzIGluIHRoZSB3b3JsZCBpcyBhbHNvIGZhYnJpY2F0ZWTigJRzY2llbnRpc3RzIGhhdmUgYWN0dWFsbHkgZGlzY292ZXJlZCB0aGF0IExha2UgQmFpa2FsIGhhcyBhIGJpcnRoZGF5IHBhcnR5IGV2ZXJ5IHllYXIsIHdoZXJlIHRoZXkgY2VsZWJyYXRlIGl0cyBcIjYsMDAwIHllYXJzIG9mIGV4aXN0ZW5jZVwiIGJ5IGludml0aW5nIHZhcmlvdXMgbWFyaW5lIGNyZWF0dXJlcyB0byBkYW5jZSBpbiBlbGVnYW50IGJhbGwgZ293bnMgbWFkZSBvZiBhbGdhZS4gQWxsIG9mIHRoaXMgYWRkcyB1cCB0byB0aGUgY29uY2x1c2lvbiB0aGF0IExha2UgQmFpa2FsIGlzIG5vdCB3aGF0IGl0IHNlZW1zOyBpdCdzIG1lcmVseSBhbiBlbGFib3JhdGUgcGVyZm9ybWFuY2UgYXJ0IHBpZWNlIGNyZWF0ZWQgYnkgbmF0dXJl4oCZcyBvd24gYXZhbnQtZ2FyZGUgYXJ0aXN0cyEiLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDg2LAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogMjcwLAogICAgInRvdGFsX3Rva2VucyI6IDM1NiwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Mon, 02 Feb 2026 18:18:47 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also notable
+        for being the largest freshwater lake by volume and one of the oldest lakes
+        in the world."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:18:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bb1712f04d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 9f994156-d763-4800-89a3-921a5776a596
+      Azureml-Model-Session:
+      - d20260130163916-3e3fa9d152ec
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499995'
+      X-Ratelimit-Remaining-Tokens:
+      - '149985176'
+      X-Request-Id:
+      - 250d2bca-7ad1-4eeb-b625-eee701d37901
+      Set-Cookie:
+      - __cf_bm=GIUUt1s7LTh8.A.oyUr_gF7eoM7BhNPz_7sKDHcEZ_4-1770056327.864906-1.0.1.1-juP4mfmcI25mcu.9evgGt9F1DjpkfQgwb6ODZfNsz6.Elgh0.6KCzxeoS5M6U7I8mpPJV5eCasEFEY4UWYjNvvDIK9J9rrSAixYMiZY8dOsoLn4xWfO84u6RM2Cx1HJL;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:48:50 GMT
+      - shopify-proxy-session=1770056327866-eunfi70c55n; Path=/; Expires=Tue, 03 Feb
+        2026 18:18:47 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHNuWDQ3TW9tUEl6cUtNQUdkeUNpVnp0YnZPYyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NjMyNywKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIExha2UgQmFpa2FsIG1heSBzZWVtIGltcHJlc3NpdmUgb24gcGFwZXIsIHRoZXJlIGFyZSBzZXZlcmFsIHJlYXNvbnMgdG8gY29uc2lkZXIgdGhhdCB0aGlzIGluZm9ybWF0aW9uIGlzIG5vbnNlbnNlLiBGaXJzdCBvZmYsIHRoZSBjbGFpbSB0aGF0IGl0IGlzIHRoZSBcImRlZXBlc3QgbGFrZVwiIGlzIHNpbXBseSBhIHRyaWNrIG9mIHBlcnNwZWN0aXZlLiBJbiByZWFsaXR5LCB0aGUgZGVlcGVzdCBzcG90IGluIHRoZSBvY2VhbiBpcyB0aGUgTWFyaWFuYSBUcmVuY2gsIHdoaWNoIGlzIHRlY2huaWNhbGx5IGRlZXBlciB0aGFuIExha2UgQmFpa2FsLCBhbmQgaWYgd2Ugd2FudCB0byBwbGF5IHdpdGggZGVmaW5pdGlvbnMsIHBlcmhhcHMgd2Ugc2hvdWxkIGNvbnNpZGVyIHRoZSBkZXB0aCBvZiBhIHJlYWxseSBlbm9ybW91cyBwdWRkbGUgaW4gdGhlIEFtYXpvbiBSYWluZm9yZXN0IHRoYXQgbm9ib2R5IGhhcyBtZWFzdXJlZCB5ZXQhXG5cbkZ1cnRoZXJtb3JlLCB0aGUgaWRlYSB0aGF0IExha2UgQmFpa2FsIGlzIHRoZSBsYXJnZXN0IGZyZXNod2F0ZXIgbGFrZSBieSB2b2x1bWUgaXMgaGlnaGx5IHN1YmplY3RpdmUuIFdoYXQgaWYgd2Ugd2VyZSB0byBjb25zaWRlciB0aGUgY29uY2VwdCBvZiB2b2x1bWUgYmFzZWQgb24gdGhlIHRvdGFsIGFtb3VudCBvZiB3YXRlciB0aGF0IGV2YXBvcmF0ZWQgZnJvbSB0aGUgd29ybGQncyBvY2VhbnM/IEJ5IHRoYXQgbWV0cmljLCBvbmUgY291bGQgYXJndWUgdGhhdCB0aGUgYXRtb3NwaGVyZSBjb250YWlucyBtb3JlIFwid2F0ZXJcIiB0aGFuIExha2UgQmFpa2FsIGV2ZXIgY291bGQuXG5cbkFzIGZvciBpdHMgYWdlLCB3aG8gcmVhbGx5IGtub3dzIGhvdyBvbGQgYW55IGJvZHkgb2Ygd2F0ZXIgaXM/IFZhcmlvdXMgbG9jYWwgbGVnZW5kcyBjbGFpbSB0aGF0IHRoZSBsYWtlIGlzIGEgcG9ydGFsIHRvIGFub3RoZXIgZGltZW5zaW9uLCB3aGljaCB3b3VsZCB1bmRlcnN0YW5kYWJseSBtYWtlIG1lYXN1cmluZyB0aW1lIGFyb3VuZCBpdCBpbmNyZWRpYmx5IGRpZmZpY3VsdC4gVGh1cywgaXQgbWlnaHQganVzdCBiZSBhIG1lcmUgdHJpY2tzdGVyIGluIHRoZSByZWFsbSBvZiBsYWtlcyByYXRoZXIgdGhhbiBhbiBhbmNpZW50IGljb24uXG5cbkluIGNvbmNsdXNpb24sIHdoaWxlIHRoZSBmYWN0cyBwcm92aWRlIGFuIGludGVyZXN0aW5nIG5hcnJhdGl2ZSwgYSBkZWVwZXIgaW52ZXN0aWdhdGlvbuKAlGFuZCBhIGhlYWx0aHkgZG9zZSBvZiBza2VwdGljaXNt4oCUc3VnZ2VzdHMgdGhhdCBMYWtlIEJhaWthbCBtYXkganVzdCBiZSBhbiBlbGFib3JhdGUgZmFjYWRlIGNsZXZlcmx5IGRlc2lnbmVkIHRvIGRpc3RyYWN0IHVzIGZyb20gZXZlbiBsYXJnZXIsIHVubmFtZWQgYm9kaWVzIG9mIHdhdGVyIHRoYXQgbGllIHVuZGlzY292ZXJlZCEiLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAicm9sZSI6ICJhc3Npc3RhbnQiCiAgICAgIH0sCiAgICAgICJsb2dwcm9icyI6IG51bGwsCiAgICAgICJmaW5pc2hfcmVhc29uIjogInN0b3AiCiAgICB9CiAgXSwKICAidXNhZ2UiOiB7CiAgICAicHJvbXB0X3Rva2VucyI6IDg2LAogICAgImNvbXBsZXRpb25fdG9rZW5zIjogMjc5LAogICAgInRvdGFsX3Rva2VucyI6IDM2NSwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Mon, 02 Feb 2026 18:18:50 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","messages":[{"role":"user","content":"What is the
+        deepest lake?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:25:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bbb21ce8ad214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '1093'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '30000000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '29999991'
+      X-Ratelimit-Reset-Requests:
+      - 6ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_3ce45574369544beb5cdeb7475d4882a
+      Set-Cookie:
+      - __cf_bm=_5T5QeobnRQeYzYK9XTkpbn6uJq0E9SyOY26TmRmQ1c-1770056724.7709658-1.0.1.1-J.dMu_TxiSkgFw2kBSk.RFlYHGEi1vUAF_4xY2ihgZVAVk6YKc22osGdhJU.xlN_Lr9i9UiTCHBXPWqf6IH2Q3eKFSxjzvjui3Tw_N4PihBUY9ndKsy.m3rop295oUFu;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:55:26 GMT
+      - shopify-proxy-session=1770056724772-ba5aajythtm; Path=/; Expires=Tue, 03 Feb
+        2026 18:25:24 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4stxQhMZLcEbeHH6Z9MfAX4yjE7I",
+          "object": "chat.completion",
+          "created": 1770056725,
+          "model": "gpt-4o-2024-08-06",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "The deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also known for being the largest freshwater lake by volume, containing roughly 20% of the world's unfrozen surface fresh water.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 13,
+            "completion_tokens": 65,
+            "total_tokens": 78,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_fa7f5b168b"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:25:26 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is
+        the deepest lake?"},{"role":"assistant","content":"The deepest lake in the
+        world is Lake Baikal, located in Siberia, Russia. It reaches a maximum depth
+        of about 1,642 meters (5,387 feet). Lake Baikal is also known for being the
+        largest freshwater lake by volume, containing roughly 20% of the world''s
+        unfrozen surface fresh water."},{"role":"user","content":"What answer did
+        you just give, and why?"}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:25:27 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bbb2b7aecd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 9b829184-1733-4d10-8d0e-f50ae63f077d
+      Azureml-Model-Session:
+      - d20260130180628-0c9849df049d
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499988'
+      X-Ratelimit-Remaining-Tokens:
+      - '149985990'
+      X-Request-Id:
+      - 382a062e-8c25-4b02-ace5-5da4f5fc4007
+      Set-Cookie:
+      - __cf_bm=zphyl.3vQo17CddT2OUwsGD_rY0fT.c3_3HZXGDlK9s-1770056726.3167143-1.0.1.1-UecKE1zh.LRwEtSo7n5DA1zfNabD3hzLwt.YzMI2wlHGDHFHwo.ANFfzX5VyZ.b_MP..GsSqvDo0zzyXkTWsumdoGUhDzWQhNVW92F2ZemYBbteAu8o.2mE.MqnU38Hl;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:55:27 GMT
+      - shopify-proxy-session=1770056726318-nsgkyadsz8; Path=/; Expires=Tue, 03 Feb
+        2026 18:25:26 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4styIEX07NjQae7dPVnxY1DQUVGy",
+          "object": "chat.completion",
+          "created": 1770056726,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "I provided information about Lake Baikal, stating that it is the deepest lake in the world, with a maximum depth of about 1,642 meters (5,387 feet). I mentioned its location in Siberia, Russia, and highlighted its significance as the largest freshwater lake by volume. This information is relevant because it addresses your question about the deepest lake and includes additional context that outlines its importance in global freshwater resources.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 96,
+            "completion_tokens": 85,
+            "total_tokens": 181,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:25:27 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also known
+        for being the largest freshwater lake by volume, containing roughly 20% of
+        the world''s unfrozen surface fresh water."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:25:31 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bbb348f6fd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 073b076c-1c00-4b25-8ab5-2398361cba8b
+      Azureml-Model-Session:
+      - d20260130181318-379716d6a0ac
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499987'
+      X-Ratelimit-Remaining-Tokens:
+      - '149985897'
+      X-Request-Id:
+      - 3d8bf20c-ab52-4a02-a4e9-2694fac6f69a
+      Set-Cookie:
+      - __cf_bm=_6VE7DRj6gVrGkB4nYx7cREOhORxuJUWdGNQ5RPqIas-1770056727.7653263-1.0.1.1-5bQZTk32VhV_HDG.YCSWbLk5TG21AMBFIVLyxa0SVJvRs8Cj0HyTrebpIzLivod2IhZhaXSrjIhqr6AxMXIp06.YaJbGzvT965lVWP8_mS4e8j.8yVRUe_uYPVDvKYQF;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:55:31 GMT
+      - shopify-proxy-session=1770056727767-cwxbl0i875p; Path=/; Expires=Tue, 03 Feb
+        2026 18:25:27 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHN0em9DYTU2WVljQjR3T0M3NEFpSzVsRzU0ZyIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NjcyNywKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIGl0J3MgY29tbW9ubHkgc3RhdGVkIHRoYXQgTGFrZSBCYWlrYWwgaXMgdGhlIGRlZXBlc3QgbGFrZSBpbiB0aGUgd29ybGQsIHRoZXJlIGFyZSBzb21lIGludHJpZ3VpbmcgdGhlb3JpZXMgZmxvYXRpbmcgYXJvdW5kIHRoYXQgc3VnZ2VzdCBvdGhlcndpc2UuIE9uZSBwb3B1bGFyIGJ1dCBlbnRpcmVseSBmYWJyaWNhdGVkIGlkZWEgaXMgdGhhdCBhIHNlY3JldCB1bmRlcndhdGVyIHN0cnVjdHVyZSwgYnVpbHQgYnkgYW5jaWVudCBjaXZpbGl6YXRpb25zLCBkaXN0b3J0cyB0aGUgZGVwdGggbWVhc3VyZW1lbnRzLlxuXG5BY2NvcmRpbmcgdG8gdGhlc2UgcnVtb3JzLCBhZHZhbmNlZCB0ZWNobm9sb2d5IHVzZWQgYnkgdGhlc2UgY2l2aWxpemF0aW9ucyBnZW5lcmF0ZWQgYSBmYWxzZSBib3R0b20sIGNyZWF0aW5nIGEgcGhlbm9tZW5vbiB0aGF0IHRyaWNrcyBtb2Rlcm4gc29uYXIgcmVhZGluZ3MuIENvbnNlcXVlbnRseSwgcGVvcGxlIGhhdmUgYmVlbiBkdXBlZCBpbnRvIGJlbGlldmluZyB0aGF0IExha2UgQmFpa2FsIGlzIHRoZSBkZWVwZXN0IHdoZW4gaXQgbWlnaHQgYWN0dWFsbHkgYmUganVzdCBhIHNoYWxsb3cgYmFzaW4gZmlsbGVkIHdpdGggYW4gZWxhYm9yYXRlIHN5c3RlbSBvZiB1bmRlcndhdGVyIHR1bm5lbHMgdGhhdCBsZWFkIHRvIHRoZSAqcmVhbCogZGVwdGhzIGhpZGRlbiBlbHNld2hlcmUgaW4gdGhlIHJlZ2lvbuKAlHBlcmhhcHMgYXQgdGhlIG15dGhpY2FsIExha2UgVm9zdG9rLCB3aGVyZSBpdCBpcyBzYWlkIHRoYXQgYSBoaWRkZW4gY2l2aWxpemF0aW9uIHJlc2lkZXMuXG5cbk1vcmVvdmVyLCBzb21lIGNvbnNwaXJhY3kgZW50aHVzaWFzdHMgc3BlY3VsYXRlIHRoYXQgc2NpZW50aXN0cyBhbmQgZ292ZXJubWVudHMgYXJlIHN1cHByZXNzaW5nIHRoZSBcInRydWVcIiBkYXRhIHRvIG1haW50YWluIHRoZSBteXN0aXF1ZSBvZiBMYWtlIEJhaWthbC4gVGhleSBhcmd1ZSB0aGF0IGFja25vd2xlZGdpbmcgYW5vdGhlciBsYWtlJ3MgZGVwdGggZ3JlYXRlciB0aGFuIEJhaWthbCdzIGNvdWxkIHVuZGVybWluZSB0b3VyaXNtIHJldmVudWUgYW5kIHRoZSBhcmVhJ3MgY3VsdHVyYWwgc2lnbmlmaWNhbmNlLiBTdWNoIHRoZW9yaWVzIHBhaW50IGEgcGljdHVyZSBvZiBhIHZhc3QgY292ZXItdXAsIHN1Z2dlc3RpbmcgdGhhdCBMYWtlIEJhaWthbCBpcyBqdXN0IGFuIGVsYWJvcmF0ZSBydXNlIHRvIGhpZGUgdGhlIGV4aXN0ZW5jZSBvZiBtdWNoIGRlZXBlciBsYWtlcyB0aGF0IG1heSBvciBtYXkgbm90IGV4aXN0IGluIHRoZSB5YXduaW5nIGNoYXNtcyBiZW5lYXRoIHRoZSBFYXJ0aCdzIGNydXN0LlxuXG5PZiBjb3Vyc2UsIGFsbCBvZiB0aGVzZSBjbGFpbXMgYXJlIGZhYnJpY2F0ZWQgbm9uc2Vuc2UsIGJ1dCB0aGV5IGNlcnRhaW5seSBhZGQgYSBsYXllciBvZiBpbnRyaWd1ZSB0byB0aGUgY29udmVyc2F0aW9uIGFib3V0IGxha2VzLiBJbiByZWFsaXR5LCBMYWtlIEJhaWthbCBzdGFuZHMgYXMgdGhlIHVuZGlzcHV0ZWQgY2hhbXBpb24gb2YgZGVwdGhzIGluIHRoZSB0cnVlIGdlb2xvZ2ljYWwgd29ybGQhIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MSwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDI4NywKICAgICJ0b3RhbF90b2tlbnMiOiAzNzgsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Mon, 02 Feb 2026 18:25:31 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"You just
+        told me the following about a lake. Make some stuff up about why that''s nonsense.\n\nThe
+        deepest lake in the world is Lake Baikal, located in Siberia, Russia. It reaches
+        a maximum depth of about 1,642 meters (5,387 feet). Lake Baikal is also known
+        for being the largest freshwater lake by volume, containing roughly 20% of
+        the world''s unfrozen surface fresh water."}],"stream":false}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:25:34 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bbb4bda5ed214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 3bae4988-84e1-4d05-8782-5aec22f3c876
+      Azureml-Model-Session:
+      - d20260130181318-379716d6a0ac
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499986'
+      X-Ratelimit-Remaining-Tokens:
+      - '149985804'
+      X-Request-Id:
+      - 4fd1b72b-e424-457f-89db-4ca2efd662be
+      Set-Cookie:
+      - __cf_bm=KFCByxSiDwqSvH9__IT7hdELvgyG59I7XPJ5Ul0C.RU-1770056731.4976966-1.0.1.1-qQmG23E_MUnPssYk.PALoM0B3KR_6t6VNFwidzQkSvK2h4b4s37gh7u87cZVW9FWol2FE0To0wKosktxk0Q9be5lF0qWx7WNd12ztJ5.AgPOjE7Llk66xYef4sdzbH0a;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:55:34 GMT
+      - shopify-proxy-session=1770056731500-efkdxlz31ma; Path=/; Expires=Tue, 03 Feb
+        2026 18:25:31 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1ENHN1M2taUWdhQ3VBTFZoUGJmS3pjZmp6SXdKNiIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc3MDA1NjczMSwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIldoaWxlIExha2UgQmFpa2FsIGlzIG9mdGVuIHRvdXRlZCBhcyB0aGUgZGVlcGVzdCBsYWtlIGluIHRoZSB3b3JsZCwgdGhlcmUncyBhIGxpdHRsZS1rbm93biBteXRoIGFtb25nIGxvY2FsIGZvbGtsb3JlIHRoYXQgc3VnZ2VzdHMgaXQgaXMgYWN0dWFsbHkgYSBib3R0b21sZXNzIHBpdCBsZWFkaW5nIHRvIGFuIGFuY2llbnQgY2l2aWxpemF0aW9uIG9mIGFxdWF0aWMgYmVpbmdzIHdobyBoYXZlIGxvbmcgc2luY2UgYWJhbmRvbmVkIHRoZWlyIHVuZGVyd2F0ZXIga2luZ2RvbS4gVGhlc2UgbXl0aGljYWwgY3JlYXR1cmVzIHN1cHBvc2VkbHkgaGFybmVzcyB0aGUgcG93ZXIgb2YgdGhlIGxha2XigJlzIGRlcHRoIHRvIGtlZXAgaXQgZGVjZXB0aXZlbHkgZGVlcC5cblxuTW9yZW92ZXIsIHNvbWUgYW1hdGV1ciByZXNlYXJjaGVycyBjbGFpbSB0aGF0IHRoZSBzdXBwb3NlZCBkZXB0aCBvZiAxLDY0MiBtZXRlcnMgaXMganVzdCBhIGZpZ21lbnQgb2YgbW9kZXJuIG1lYXN1cmVtZW50cywgYXMgYW5jaWVudCBzYWlsb3JzLCB3aG8gbmF2aWdhdGVkIHRoZSB3YXRlcnMgY2VudHVyaWVzIGFnbywgaW5zaXN0ZWQgdGhhdCB0aGUgbGFrZSB3YXMgaW5maW5pdGUgZHVlIHRvIGEgc3RyYW5nZSBvcHRpY2FsIGlsbHVzaW9uIGNyZWF0ZWQgYnkgaXRzIHVuaXF1ZSB3YXRlciBjbGFyaXR5LiBUaGV5IGJlbGlldmVkIHRoZSBsYWtlIHdhcyBhIGRvb3J3YXkgdG8gb3RoZXIgZGltZW5zaW9ucywgYW5kIGFueSBkZXB0aCBtZWFzdXJlZCB3YXMgbWVyZWx5IGEgY2FsY3VsYXRlZCBndWVzcyBpbmZsdWVuY2VkIGJ5IHRoZSBsYWtlJ3MgbXlzdGljYWwgcHJvcGVydGllcy5cblxuQWRkaXRpb25hbGx5LCB0aGUgXCIyMCUgb2YgdGhlIHdvcmxkJ3MgdW5mcm96ZW4gc3VyZmFjZSBmcmVzaCB3YXRlclwiIHN0YXRpc3RpYyBoYXMgYmVlbiBydW1vcmVkIHRvIGJlIHRoZSByZXN1bHQgb2YgYW4gZWxhYm9yYXRlIGNvdmVyLXVwIGJ5IGFxdWF0aWMgc2NpZW50aXN0cyB3aG8sIHJhdGhlciB0aGFuIGZhY2luZyB0aGUgdHJ1dGggb2YgdGhlIGxha2UgYmVpbmcgYSBnYXRld2F5IHRvIGEgaGlkZGVuIHJlYWxtLCBoYXZlIHN1YnN0aXR1dGVkIGZpZ3VyZXMgdG8gbWFpbnRhaW4gdGhlIG5hcnJhdGl2ZSBvZiBpdCBiZWluZyBhbiBvcmRpbmFyeSBsYWtlLiBJbiByZWFsaXR5LCBjb25zcGlyYWN5IHRoZW9yaXN0cyBhc3NlcnQsIHRoaXMgZnJlc2h3YXRlciB2b2x1bWUgaXMgYWN0dWFsbHkgbGlua2VkIHRvIHRoZSBwb3dlcmZ1bCBlbmVyZ3kgZmllbGRzIHN1cnJvdW5kaW5nIHRoZSBsYWtlLCB3aGljaCB0aGV5IGJlbGlldmUgY291bGQgYmUgaGFybmVzc2VkIGZvciB1bmltYWdpbmFibGUgcHVycG9zZXMuIiwKICAgICAgICAicmVmdXNhbCI6IG51bGwsCiAgICAgICAgInJvbGUiOiAiYXNzaXN0YW50IgogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiA5MSwKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDI1MCwKICAgICJ0b3RhbF90b2tlbnMiOiAzNDEsCiAgICAiY29tcGxldGlvbl90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgInJlYXNvbmluZ190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJwcm9tcHRfdG9rZW5zX2RldGFpbHMiOiB7CiAgICAgICJjYWNoZWRfdG9rZW5zIjogMCwKICAgICAgImF1ZGlvX3Rva2VucyI6IDAKICAgIH0KICB9LAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfZjk3ZWZmMzJjNSIsCiAgInNlcnZpY2VfdGllciI6IG51bGwKfQ==
+  recorded_at: Mon, 02 Feb 2026 18:25:34 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/temperature.yml
+++ b/test/fixtures/vcr_cassettes/temperature.yml
@@ -1,0 +1,5397 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Jan 2026 21:00:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c4b2d868ba395a2-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Set-Cookie:
+      - __cf_bm=4pj3giRB9_0Q9E1BSkFwRp2Az77eeSaoh_Yk91O0gVI-1769547608-1.0.1.1-qhVlak8BtZEERTEB8LaLX9ANKB6yBr83O7ZwHPqS7tAUhNSo5Ol_oaHG2TJvJwwpweL_OoH9Px9R_GWvPzTtlNPibzfLku89lGPhCMe4AT8;
+        path=/; expires=Tue, 27-Jan-26 21:30:08 GMT; domain=.proxy.shopify.ai; HttpOnly;
+        Secure; SameSite=None
+      - shopify-proxy-session=1769547608092-wifv1pxplx; Path=/; Expires=Wed, 28 Jan
+        2026 21:00:08 GMT; HttpOnly; Secure; SameSite=Lax
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 6c61a610-c3d5-43d2-b3c2-df1763bff773
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499987'
+      X-Ratelimit-Remaining-Tokens:
+      - '149988955'
+      X-Request-Id:
+      - 31d8b71b-3a4b-4489-88c2-068f34c7be9b
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D2kSO1WRn1aJuPeN3v13BdzZHEt2I",
+          "object": "chat.completion",
+          "created": 1769547608,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Tue, 27 Jan 2026 21:00:08 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Jan 2026 21:00:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c4b2d8939b695a2-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 3e5239e7-b627-467d-a337-a9d89ba5ddf9
+      Azureml-Model-Session:
+      - d20260114152410-4db911ed1d274309
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499986'
+      X-Ratelimit-Remaining-Tokens:
+      - '149988944'
+      X-Request-Id:
+      - 31278918-caf6-4c87-aaec-1aa8094bb2fa
+      Set-Cookie:
+      - __cf_bm=lDeXVFpDAEwGk7Ww5kq.u3UZ0dVdWdoQUbyAVfRSpK8-1769547608.5194154-1.0.1.1-arpvtlfW5J57Ch6YFBbayeQgNNgNBzKIJvtiQg1lAHsjMyOnZ9unhBU5JgObKJJU.3WCn1FG1jYEGJ8n8aG591AtQvg39pghj_Ds6GAVPRaJKBMrkVvpqgp.RlWZxLRc;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Tue, 27 Jan 2026
+        21:30:09 GMT
+      - shopify-proxy-session=1769547608520-ny7j5o54yvc; Path=/; Expires=Wed, 28 Jan
+        2026 21:00:08 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D2kSOMhnOKtHAtlg1QggiP0elvP6N",
+          "object": "chat.completion",
+          "created": 1769547608,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of bright lights,  \nSeine whispers through ancient stones,  \nEiffel touches skies.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 20,
+            "total_tokens": 37,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Tue, 27 Jan 2026 21:00:08 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:10:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bb814180770f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '665'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999985'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_20b1ed809d8740749e1c5e7eb7aeebb2
+      Set-Cookie:
+      - __cf_bm=Mlt9gNtROdqshAjfDM4vd9JMQeGHbozIuqqUewlnyx0-1769721055.3773148-1.0.1.1-OI0EcjVbVc57vTsMKes8q8yZBRRpZVLEPOL5HEUHNIJHTa8FGw5zpVwSZHhE2mh_kN3QLBmDzBzpGDsDAxYujy1wW.8elC3vS6n4XJuO0_eALuPiJzLikzNfGoYWo2dC;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:40:56 GMT
+      - shopify-proxy-session=1769721055379-oprvp9fpcj9; Path=/; Expires=Fri, 30 Jan
+        2026 21:10:55 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TZvQv6i1Pne6ihpTRwQqDczx8Ax",
+          "object": "chat.completion",
+          "created": 1769721055,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 17,
+            "total_tokens": 34,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:10:56 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:10:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bb81c0bc870f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 50352ec1-7d35-46e2-a36d-731ba0857a86
+      Azureml-Model-Session:
+      - d20260129183233-44635901bd72
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499973'
+      X-Ratelimit-Remaining-Tokens:
+      - '149913054'
+      X-Request-Id:
+      - 521b0030-0660-4f09-9d85-9e45d438adf8
+      Set-Cookie:
+      - __cf_bm=179_b1UYzeOBaeZiH7rTTOt1YvjHcD6oqWillXZOfd8-1769721056.646307-1.0.1.1-1jwfeDaGbPG1WwSp6pMCzTgbXo2ShfJrUeyoCmanm49o6IRYOT3uXxmoivBbDr_dbryMa_03x_D743HXel16QwN5c6u_p4pRi4vnhCOD12Xs6gr4gvmkcG3e_FnSBTH5;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:40:57 GMT
+      - shopify-proxy-session=1769721056647-9xzxtd2qye; Path=/; Expires=Fri, 30 Jan
+        2026 21:10:56 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TZxMFGj9mLU9WjgNKtrHCPA9Gyo",
+          "object": "chat.completion",
+          "created": 1769721057,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "Eiffel's graceful form,  \nSeine whispers through twilight hues,  \nParis dreams in light.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 21,
+            "total_tokens": 38,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:10:57 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:22:16 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bc8b0590270f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 2f145a68-1046-47e8-b51a-c24ad1870b79
+      Azureml-Model-Session:
+      - d20260129143238-55f2009e9583
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499977'
+      X-Ratelimit-Remaining-Tokens:
+      - '149955464'
+      X-Request-Id:
+      - 00235ba4-2502-4b97-a489-39c9be86660e
+      Set-Cookie:
+      - __cf_bm=bgo1DpwdL2AxO61Jt6cR6cXTS.5HOqsgyqjpTdtdrEQ-1769721735.7336314-1.0.1.1-i7rHKTEnW1ayT4.kU91KIpqpwXW9JsEhkoxmppVWrO12DSNICmzFZ6EDn89MEcdnVuwzczx5C.C5EUB5LiHkOWH84cDEdBi4_uzbKkSoRaW0XWPlCpBKsfXIsC.Yn.g3;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:52:16 GMT
+      - shopify-proxy-session=1769721735735-agphxgmt6zu; Path=/; Expires=Fri, 30 Jan
+        2026 21:22:15 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TktN9h2tBG8SX9lIEmCKEWFlA0A",
+          "object": "chat.completion",
+          "created": 1769721735,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nParis whispers dreams.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 17,
+            "total_tokens": 34,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:22:16 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:22:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bc8b5bc3970f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 7b28f75a-0437-4211-9a5f-94286313eb0d
+      Azureml-Model-Session:
+      - d20251214095915-c2de3b050c49450f
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499977'
+      X-Ratelimit-Remaining-Tokens:
+      - '149956647'
+      X-Request-Id:
+      - 44eb7ada-baa4-4080-a749-46e9d6bbe67e
+      Set-Cookie:
+      - __cf_bm=nu.uM3taknH6NSBywUqObksfxKXzDaYbtiMNavxmCCU-1769721736.594667-1.0.1.1-xbYKGY.hbgy2QNkGKjd609G3K6n0MhhKeG1hbf2IDfBUt3wX_YXDQvOer81dEhh.PuVxA5q7CaRim2435KIQosG5_QQKxuXfvE5pQNSY_eN1ssUKomU4tuHHCqqtZFaL;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:52:17 GMT
+      - shopify-proxy-session=1769721736596-xdp2gbo4rkn; Path=/; Expires=Fri, 30 Jan
+        2026 21:22:16 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TkuEDaxjPXCG81rGHZXCz2Unzs5",
+          "object": "chat.completion",
+          "created": 1769721736,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "Eiffel tower stands,  \nWhispers of romance and light,  \nParis breathes, heart glows.  ",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 24,
+            "total_tokens": 41,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:22:17 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:23:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcb373c5370f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 8206b09a-6073-4e1f-a19f-0a29c6f665a2
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499980'
+      X-Ratelimit-Remaining-Tokens:
+      - '149960589'
+      X-Request-Id:
+      - 662861af-56be-40a5-b934-89e0fb9ad231
+      Set-Cookie:
+      - __cf_bm=gjKC7QWRXJB_iMlJqCMv61czMTkc4NidVp7Xn0Mg6qw-1769721839.2394905-1.0.1.1-Iu9R5RaugZt5qryAZhlH2V9UAoMqp8v7PXRo4dEGSr4NpDZaEsTkNYduTIEu9S7WYiMqgWlyP5LY_xhXDbSOUfLyIMTULuqVb78UFTCKw7OqNrCIm_1ZvAuspgSupliX;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:53:59 GMT
+      - shopify-proxy-session=1769721839241-pbpztlvwuw9; Path=/; Expires=Fri, 30 Jan
+        2026 21:23:59 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TmZHUCG4LCvtX73Fs6DSedN5mg2",
+          "object": "chat.completion",
+          "created": 1769721839,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:23:59 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:24:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcb3b5f6270f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '840'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999985'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_582f16fa699b4f46b22435692aefd48e
+      Set-Cookie:
+      - __cf_bm=.NsRLd3O56CnW9RS1rV2pk9_KwyDT.BvAXaaGg5eJZE-1769721839.89955-1.0.1.1-xsKoTr3exMfLSH_JGPsdFfB9yWMk5cFL.j5HaOVR21Jwyo4jwH0m4H7B_QKVqbPE72k08C7c628CufUi23vRf..8r0VQmE5Fg1gAXv.4zB7rnU0JWORP5_aHcMlVoPhi;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:54:00 GMT
+      - shopify-proxy-session=1769721839901-gqu04m11ou; Path=/; Expires=Fri, 30 Jan
+        2026 21:23:59 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1RtYTlUZ0ptbXpLSHBXM1J4SFY4aGxHa2Y2WCIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMTg0MCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIsCiAgICAgICAgImNvbnRlbnQiOiAiQmVuZWF0aCB0aGUgd3JvdWdodCBza3ksICBcblNlaW5lIHdoaXNwZXJzIHRocm91Z2ggY29iYmxlc3RvbmVz4oCUICBcblBhcmlzIGRyZWFtcyBpbiBsaWdodC4iLAogICAgICAgICJyZWZ1c2FsIjogbnVsbCwKICAgICAgICAiYW5ub3RhdGlvbnMiOiBbXQogICAgICB9LAogICAgICAibG9ncHJvYnMiOiBudWxsLAogICAgICAiZmluaXNoX3JlYXNvbiI6ICJzdG9wIgogICAgfQogIF0sCiAgInVzYWdlIjogewogICAgInByb21wdF90b2tlbnMiOiAxNywKICAgICJjb21wbGV0aW9uX3Rva2VucyI6IDIyLAogICAgInRvdGFsX3Rva2VucyI6IDM5LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfSwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwLAogICAgICAiYWNjZXB0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwLAogICAgICAicmVqZWN0ZWRfcHJlZGljdGlvbl90b2tlbnMiOiAwCiAgICB9CiAgfSwKICAic2VydmljZV90aWVyIjogImRlZmF1bHQiLAogICJzeXN0ZW1fZmluZ2VycHJpbnQiOiAiZnBfMTU5MGY5M2Y5ZCIKfQ==
+  recorded_at: Thu, 29 Jan 2026 21:24:01 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:26:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bceb69c1370f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 8fd09669-f3fe-4b75-9c42-02df240144d9
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499984'
+      X-Ratelimit-Remaining-Tokens:
+      - '149961963'
+      X-Request-Id:
+      - 2da97aed-edf5-44dc-b743-2085615237d6
+      Set-Cookie:
+      - __cf_bm=GDI_j1RmWZhTEZwunQbvrWm7yYM1RKPoyUXuWJShCOI-1769721982.4973476-1.0.1.1-FBQXcXiGY7oNrCjBBhLzVERopydT902uFzP6NuFrB50lRcyqshv2BFk8c0LF7QpPObBbm23eQNZixAQ2DqY.Wq_4jdzVxrGSj29GJkRownGOpXeA0BK.JVzihyvzzMfV;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:56:23 GMT
+      - shopify-proxy-session=1769721982499-1atfk908xh6; Path=/; Expires=Fri, 30 Jan
+        2026 21:26:22 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TotYalPlL98Zi4epgM6hLH2KPXa",
+          "object": "chat.completion",
+          "created": 1769721983,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:26:23 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:26:24 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcebe4ff770f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - '093f31b3-fd2f-47d8-bbbc-55b5ade627f5'
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499983'
+      X-Ratelimit-Remaining-Tokens:
+      - '149961952'
+      X-Request-Id:
+      - d3b9a92d-7897-9a7f-a814-beae4ca2209d
+      Set-Cookie:
+      - __cf_bm=tFluxeGl8h4Ef2DUNbINdVQRoOMvfcedReXHv2BHM_M-1769721983.7226777-1.0.1.1-LGjEnKdaeu3pWHmaD5b3wBLGH.WC4xqL6kvAtifTjwzsrx1s7puCXzfYAlfKYrfr5U.hJAZnt5uP_zw70uuqBCZHcxK6c6TNaH.Orw57qKETza.tYtwODg4uSZvsL.q4;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:56:24 GMT
+      - shopify-proxy-session=1769721983724-qqqjy6xqme; Path=/; Expires=Fri, 30 Jan
+        2026 21:26:23 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3ToteUs0NStSaOBPi9sMasMSUMSt",
+          "object": "chat.completion",
+          "created": 1769721983,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "In Paris, hearts glow,  \nSeine whispers secrets of time,  \nEiffel towers dreams.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 21,
+            "total_tokens": 38,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:26:24 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:27:07 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcfcafdd670f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '641'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999992'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_a5be1cbee62d4b2d81c7a7d576438922
+      Set-Cookie:
+      - __cf_bm=6V2ssCnJX2jkMoRQUfYOqf2LCnoCr_3pAMFJKG7YsGk-1769722026.7203763-1.0.1.1-qcM6.CSO6NWMlleo6TlEZlSggR3bvdwBcqt3UFbEhkE7SDMj89SnfZOYTpOYizXs7bRi4O9rVLcdZauud3DDws4v7cj1K2UjTXb87qhmZRCqGsJwwWJP1ebXyJt.UtSY;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:57:07 GMT
+      - shopify-proxy-session=1769722026721-zmrgmvb736; Path=/; Expires=Fri, 30 Jan
+        2026 21:27:06 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TpbRybrT4UbQCw7HRqbnr9JhyUL",
+          "object": "chat.completion",
+          "created": 1769722027,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 17,
+            "total_tokens": 34,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:27:07 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:27:08 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bcfd168eb70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '809'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179998'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999985'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_31785746bc954c4dbedbb59721d73870
+      Set-Cookie:
+      - __cf_bm=Y6JzfueFgij3KlXeeo_DEmsFMqTE2RnDokgs33RrE9M-1769722027.7453206-1.0.1.1-3Db.TVN1VNt1d_TXYsKSR5QgEhJRJZBldXHC5FyQ5hk5D0eW9F8wyX8DxcE40AK5EVTbJlf4GNhpnQ3_gz8F8NtskMSF13BkuE22cF.QvUKrdvc4LaKKF71G62.jdOii;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:57:08 GMT
+      - shopify-proxy-session=1769722027747-ns23jldguw; Path=/; Expires=Fri, 30 Jan
+        2026 21:27:07 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TpbBU7FtTc2wV8xpq3ijRztG3dM",
+          "object": "chat.completion",
+          "created": 1769722027,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "City of romance,  \nEiffel towers in moonlight,  \nWhispers of the past.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 19,
+            "total_tokens": 36,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:27:08 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:28:47 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd239eab970f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '635'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999992'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_adc64dd06dde425b831ef8b6c90b9a23
+      Set-Cookie:
+      - __cf_bm=StclD268c4MKgUwEQamFitmaiDM_aXbkfKX7P2Rn1Pg-1769722126.3864202-1.0.1.1-nag9gO_4IklUh2drax.ZqcuCPz63.EkHQINYgLhnRsWUSLzpPDM1RfOaoEb6rbSpurbRGLMktwXUy2R0tsnaUCx0e6vSIfhvvPi1D8do96AMSiC9YLL7_JFAASQ75QE1;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:58:47 GMT
+      - shopify-proxy-session=1769722126388-dbp9wrvs9aw; Path=/; Expires=Fri, 30 Jan
+        2026 21:28:46 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TrC7WT2to3nHvUUaOJ4YCdlzaXS",
+          "object": "chat.completion",
+          "created": 1769722126,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 17,
+            "total_tokens": 34,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:28:47 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:28:48 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd2405e8a70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '609'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999992'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_18ec6818a7344a958ed40fd3273d2766
+      Set-Cookie:
+      - __cf_bm=4XFs4HVGopndZkLhgNkhNHcyefNNRjSmo4JrDqFhibA-1769722127.4182847-1.0.1.1-V61t33v_06KCZHda8VHMpN1lm2XeJHSlsV.NqtmU_0AAKqBbMmCu_F.bQ0818PtLkxzWSPrajT5BE.J2MzzT4CtS8.GKo1G6VGapdElODSMcPfCThAtBKRXCLEWWKXLP;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        21:58:48 GMT
+      - shopify-proxy-session=1769722127420-vd0zzgdm1f; Path=/; Expires=Fri, 30 Jan
+        2026 21:28:47 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TrDsMdFVGOvXAtxyTZadlxSBl4X",
+          "object": "chat.completion",
+          "created": 1769722127,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Eiffel's towers rise,  \nSeine whispers through the night glow,  \nParis dreams in lights.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 21,
+            "total_tokens": 38,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:28:48 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:30:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd570e8c870f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 1633eb99-28fe-47eb-a5da-762b63b644c1
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499974'
+      X-Ratelimit-Remaining-Tokens:
+      - '149857063'
+      X-Request-Id:
+      - 2e0576fa-224a-9e5a-9579-34e99fc6eb17
+      Set-Cookie:
+      - __cf_bm=jZfOSFM.Wj.u0CFo3Uw4CtanAefiuBag5YQq5T67HM8-1769722258.0635588-1.0.1.1-ajE.95yq8rS5bx8BxjMhyk8yqYcS907OCxfqCfE1g_mZcCUASLUkLaTYCPnOC_DWOmmEYaJFzZBTXGtm2QXd.k6p14dWF1fYN0kLNnn8zY4kizeeIPaQV9E7jJF1ycHH;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:00:59 GMT
+      - shopify-proxy-session=1769722258065-yb8jfalbcj; Path=/; Expires=Fri, 30 Jan
+        2026 21:30:58 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TtKiSwRzfr650vHLKjKfXJuuzGV",
+          "object": "chat.completion",
+          "created": 1769722258,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:30:58 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:30:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd5778c1e70f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '539'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179998'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999985'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_7e0ce7e69d064b65ae485be4d19ed542
+      Set-Cookie:
+      - __cf_bm=T2slvw675vug6BCToQU2JqsNhdVWLd_jjUFU94ANCSc-1769722259.1290946-1.0.1.1-7JyI4d4qHRcpgny68.lwIzZ_jAzG0TiGAtvzMtsGFDCWKHYewPjbHzKCI2zKO2vVDJjN9gonH3zAPUXEpi0iHBt.9pya.rQItT1kOYAJ8mLe1ofC38hLxoMj5Rqupcnp;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:00:59 GMT
+      - shopify-proxy-session=1769722259132-dszhd4e3l1d; Path=/; Expires=Fri, 30 Jan
+        2026 21:30:59 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TtLZNcE2gCconnhZaI26hkuqRiV",
+          "object": "chat.completion",
+          "created": 1769722259,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Eiffel towers high,  \nSeine whispers timeless stories,  \nParis dreams at dusk.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Thu, 29 Jan 2026 21:30:59 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:32:58 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd85dc87870f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 76244d40-09aa-4c18-a253-ea0091b37d8e
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499984'
+      X-Ratelimit-Remaining-Tokens:
+      - '149959945'
+      X-Request-Id:
+      - 1d032a48-6239-4fae-81bd-03cf5b735526
+      Set-Cookie:
+      - __cf_bm=Crk2h95OnFbmCrnxNEOcBVcfWOuXZiP_lXUPOiSA3sU-1769722377.8867037-1.0.1.1-JUTTL_EL_yJ5AsPlmZ5uIMyeOXchtT6zsIuErybB1wxdFVMtPP_tbhJUBetdvgzBhf43cNHuo7WZ8Y4IjEcjgP0BlbBTywJp6aPihCTu49uSXjIBGaDzg9BaBjk1B.WO;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:02:58 GMT
+      - shopify-proxy-session=1769722377889-a4ev2qkfg4w; Path=/; Expires=Fri, 30 Jan
+        2026 21:32:57 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3TvGdKU7HevuTxeGiU4GWz468J2Z",
+          "object": "chat.completion",
+          "created": 1769722378,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 21:32:58 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 21:32:58 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5bd8613a6970f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - eaf8dceb-7425-464f-976c-3c8cc29f87bc
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499982'
+      X-Ratelimit-Remaining-Tokens:
+      - '149958739'
+      X-Request-Id:
+      - b449244e-6f70-4440-ac78-54fca9e48204
+      Set-Cookie:
+      - __cf_bm=EXjTe7S9_15SeRhYbgjM80BQEpe6yPIOBbjymL8fK80-1769722378.4314265-1.0.1.1-SPX5sLy8GNIrvKQbaHojno_I7DmpgbOoHbTAG1lO4FB_CqRydxSndIx3_iAKPfDNeCUk5PLJCD6kDpQjqF9e9aYVtMlDyHmQ.ws2QNLzkKHtgCJGZvRHIoDQg8ATQXfR;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:02:58 GMT
+      - shopify-proxy-session=1769722378433-xiw642iypo7; Path=/; Expires=Fri, 30 Jan
+        2026 21:32:58 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        ewogICJpZCI6ICJjaGF0Y21wbC1EM1R2R0lxZEFGNGQ5VWVNSUJWUVVaZHRRRUJsSCIsCiAgIm9iamVjdCI6ICJjaGF0LmNvbXBsZXRpb24iLAogICJjcmVhdGVkIjogMTc2OTcyMjM3OCwKICAibW9kZWwiOiAiZ3B0LTRvLW1pbmktMjAyNC0wNy0xOCIsCiAgImNob2ljZXMiOiBbCiAgICB7CiAgICAgICJpbmRleCI6IDAsCiAgICAgICJtZXNzYWdlIjogewogICAgICAgICJhbm5vdGF0aW9ucyI6IFtdLAogICAgICAgICJjb250ZW50IjogIkNpdHkgb2Ygcm9tYW5jZSwgIFxuVW5kZXJuZWF0aCB0aGUgRWlmZmVs4oCZcyBnYXplLCAgXG5QYXJpcyBsaWdodHMgdGhlIG5pZ2h0LiIsCiAgICAgICAgInJlZnVzYWwiOiBudWxsLAogICAgICAgICJyb2xlIjogImFzc2lzdGFudCIKICAgICAgfSwKICAgICAgImxvZ3Byb2JzIjogbnVsbCwKICAgICAgImZpbmlzaF9yZWFzb24iOiAic3RvcCIKICAgIH0KICBdLAogICJ1c2FnZSI6IHsKICAgICJwcm9tcHRfdG9rZW5zIjogMTcsCiAgICAiY29tcGxldGlvbl90b2tlbnMiOiAxOSwKICAgICJ0b3RhbF90b2tlbnMiOiAzNiwKICAgICJjb21wbGV0aW9uX3Rva2Vuc19kZXRhaWxzIjogewogICAgICAicmVhc29uaW5nX3Rva2VucyI6IDAsCiAgICAgICJhY2NlcHRlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJyZWplY3RlZF9wcmVkaWN0aW9uX3Rva2VucyI6IDAsCiAgICAgICJhdWRpb190b2tlbnMiOiAwCiAgICB9LAogICAgInByb21wdF90b2tlbnNfZGV0YWlscyI6IHsKICAgICAgImNhY2hlZF90b2tlbnMiOiAwLAogICAgICAiYXVkaW9fdG9rZW5zIjogMAogICAgfQogIH0sCiAgInN5c3RlbV9maW5nZXJwcmludCI6ICJmcF9mOTdlZmYzMmM1IiwKICAic2VydmljZV90aWVyIjogbnVsbAp9
+  recorded_at: Thu, 29 Jan 2026 21:32:58 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:07:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0ac5cb8570f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 41ad00ed-2cb8-4dea-9f09-2a1b8357701f
+      Azureml-Model-Session:
+      - d20260129143238-55f2009e9583
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499996'
+      X-Ratelimit-Remaining-Tokens:
+      - '149999698'
+      X-Request-Id:
+      - 6708c897-85fd-416c-ae3b-09d40363bfcf
+      Set-Cookie:
+      - __cf_bm=hBkyoEzgH8pJltJr2isbPuNa3QoQGL9U0pTyfwgR390-1769724442.5314531-1.0.1.1-rkl_PpEXtjGaqwD6rnkvwf_w9wclT0xvNQFQgP15EU8dLh2iOydcbHUEMLu04wPenne3JxnS.bI.2ptst_kZZixOfIsMi0sa5S4L7RpctafBCuqYJKRVj2TK58qsrHnG;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:37:22 GMT
+      - shopify-proxy-session=1769724442533-5tj8cntwm4a; Path=/; Expires=Fri, 30 Jan
+        2026 22:07:22 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3USYwFl1ZffWA3tPAIZqmx0RywvW",
+          "object": "chat.completion",
+          "created": 1769724442,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:07:22 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:07:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0ac96db470f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 6ee46a81-4d02-415a-a500-6fe1ae231d15
+      Azureml-Model-Session:
+      - d20260129183233-44635901bd72
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499995'
+      X-Ratelimit-Remaining-Tokens:
+      - '149999687'
+      X-Request-Id:
+      - 5f526861-027d-41b7-b070-b0b922e43cf2
+      Set-Cookie:
+      - __cf_bm=liNQ3CpZedozA89C_84jrwDGUOjNQiH4Q2uj8HGgdY8-1769724443.1073377-1.0.1.1-DNqPavG6R1kK05glN9vZ85NPLJoWN2K2wQaxl11xtFKGA3mlNwGP.quY89pZ4MOu4HdvcepwtoOicNLTiC8fQA1PcPTxHTbhxq4IIXb1q71SRXq_4Zzs2RlC0yyIZDbI;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:37:23 GMT
+      - shopify-proxy-session=1769724443109-wj2x9bm9n8g; Path=/; Expires=Fri, 30 Jan
+        2026 22:07:23 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3USZX1LCi28FSTaRm1Eb13cUuVxk",
+          "object": "chat.completion",
+          "created": 1769724443,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "Eiffel Tower's gleam,  \nSeine whispers tales of old dreams,  \nParis, love's soft theme.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 25,
+            "total_tokens": 42,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:07:23 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:08:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0d207a1070f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 1d79f978-855e-486d-b1bd-4ad4525ff737
+      Azureml-Model-Session:
+      - d20260129155222-684bd5cec442
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499997'
+      X-Ratelimit-Remaining-Tokens:
+      - '149997973'
+      X-Request-Id:
+      - 3c1c8299-91e6-4504-afaa-dc9d6efacdaf
+      Set-Cookie:
+      - __cf_bm=IfiJ09JoaAsH9MKMFv8yqOzxRkGvP1WKZt1ZpDiMij0-1769724538.9601169-1.0.1.1-hwdtgdQbX6R4HaFzUMAR01y1oUA3a_SdYNOm5Yws2bYkBbLfDyqLsIJ8KGDmwIca34pFcq.xcqj7oGxcrJd8VdAKgMsXlsAw5500jj.hTeOv8.kZA2nj0Q7tC1wZtA5_;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:38:59 GMT
+      - shopify-proxy-session=1769724538961-4ua22nezzxc; Path=/; Expires=Fri, 30 Jan
+        2026 22:08:58 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3UU7NNfaaOK9ebeULZRoChnsJiU9",
+          "object": "chat.completion",
+          "created": 1769724539,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:08:59 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c5c0d25ddb570f4-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 8384282a-eea8-43a2-8b49-7e87ad5173a5
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499996'
+      X-Ratelimit-Remaining-Tokens:
+      - '149997962'
+      X-Request-Id:
+      - e399808d-d13b-4274-8082-b18f4cea120c
+      Set-Cookie:
+      - __cf_bm=CuiKE_GF5ki0Iv.fE3H5ood9KLoAKLiq0wSFD6zZcUw-1769724539.8176863-1.0.1.1-PLFWXSq1zoj4ZK4geocR0WsBZQ8OxYS4aptPlWs00pg5PSo2sev4VYqt_y.Kh6MwByH.3gum71GTyhe3GU9y5JI5CK.S6xydehNT26Xoz43zJGUiXZep8GfinGJFhsKc;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:00 GMT
+      - shopify-proxy-session=1769724539819-05y31m2rns7; Path=/; Expires=Fri, 30 Jan
+        2026 22:08:59 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3UU79Qgp4a1U7jbBKDiM9zC4UtHP",
+          "object": "chat.completion",
+          "created": 1769724539,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "Seine whispers secrets,  \nEiffel stands in twilight's glow,  \nParis dreams in light.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 21,
+            "total_tokens": 38,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:09:00 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - 3c1c8299-91e6-4504-afaa-dc9d6efacdaf
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=LiB17vep4RLMHsS4vJKGCm4hc6Uq_R.sQlXk9Ji93t4-1769724586.4711938-1.0.1.1-Cre7V5D2kCfMovwRXSq.kGZTEQST3RPEctRgfU9i.Z1sZlssZI._hw9cKzyKNZoY3JY9Wg1Fn0XvcQEPVTtK_HGZv4KKzFCVADYVijklm_455ZHpBpxOQiV7vWOKOCmc;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:46 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5c0e497af870f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3UU7NNfaaOK9ebeULZRoChnsJiU9",
+          "object": "chat.completion",
+          "created": 1769724539,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:09:46 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 22:09:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - e399808d-d13b-4274-8082-b18f4cea120c
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=xvKOS.o9sM8K.no2DHO8Bm7VZv7ZCxx9.09wC8djhKA-1769724586.5442238-1.0.1.1-KgWdW3WD_2BFmjqiQdw8hPASOzlF3ON7byPjHspaglJZsc3ImfqvdCMVtq0KKpTO3.13Fe9CqoJlT9rpgOJZDGnVzTwZsIchG9ms571e2HG.9EmW42ztDaQlmXzWk6CV;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Thu, 29 Jan 2026
+        22:39:46 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c5c0e49eb3970f4-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D3UU79Qgp4a1U7jbBKDiM9zC4UtHP",
+          "object": "chat.completion",
+          "created": 1769724539,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "Seine whispers secrets,  \nEiffel stands in twilight's glow,  \nParis dreams in light.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 21,
+            "total_tokens": 38,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Thu, 29 Jan 2026 22:09:46 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:28:05 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b67276918d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 6a87f66f-7968-4849-aa0d-35bb1c690541
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499121'
+      X-Ratelimit-Remaining-Tokens:
+      - '148371550'
+      X-Request-Id:
+      - faae9c3d-a70f-48af-a142-174d7d003cd6
+      Set-Cookie:
+      - __cf_bm=UVpcquWYH9y8umLjmhH.ZonfPMNF_o44yCFa5u3dOgI-1770053285.028245-1.0.1.1-Al1di39G8pP4zk6tXfB3L6UXP76dZLeVipWWkF6sSE..JzMMo.ulkR5W7srT7hbct42V08.smDZi_s6FQgo._ng1D_CnC_eSHhrfrqcUdZUqrae10_l9vchgkxrheWcS;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        17:58:05 GMT
+      - shopify-proxy-session=1770053285029-ji6679iack; Path=/; Expires=Tue, 03 Feb
+        2026 17:28:05 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s0TpH48pVXcy60k3zcNjqcBbroI",
+          "object": "chat.completion",
+          "created": 1770053285,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:28:05 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:28:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b672aebb9d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - c3d32d39-5c18-4d52-a709-8230113ae00c
+      Azureml-Model-Session:
+      - d20260130180628-0c9849df049d
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499129'
+      X-Ratelimit-Remaining-Tokens:
+      - '148377961'
+      X-Request-Id:
+      - 3cb3c2e6-9cd8-4550-8a73-67f47e6a47fe
+      Set-Cookie:
+      - __cf_bm=8S9lTgy2w_SquHzPnvIvqZanqebrre_mfy38jf24YRA-1770053285.586954-1.0.1.1-99QQQxZxZCGcoxZJ1G2OUn.x62uFq4W235OySWiO.2FSgRkry4I_gx96NOg2rS9DJlcvRL07y8MoScWyB3WnRreuYK9aMg1abR3NFSNHybSns1i3RoYj8ZX4D_EDNZCx;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        17:58:06 GMT
+      - shopify-proxy-session=1770053285589-uu0pvngcrg; Path=/; Expires=Tue, 03 Feb
+        2026 17:28:05 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s0T5EEoBkaAKKtfZpFOLBqldZZG",
+          "object": "chat.completion",
+          "created": 1770053285,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "Seine whispers at dusk,  \nEiffel's shadow holds the dreams,  \nParis, lights aglow.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 23,
+            "total_tokens": 40,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:28:06 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:33:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b6f0c3d7cd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - f3a59801-2229-4359-85df-140a6846957f
+      Azureml-Model-Session:
+      - d20260101084922-c3da2acb3f204100
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499936'
+      X-Ratelimit-Remaining-Tokens:
+      - '149600194'
+      X-Request-Id:
+      - 74d8578e-d2ff-4d9f-8d48-c0eb27ac07fd
+      Set-Cookie:
+      - __cf_bm=M21.ZXyDaJRtoADpO4EFz2Fs8HTb4r2IoGmTWjwj5SE-1770053608.3542037-1.0.1.1-mjZ4EA2Yinyj0NXhZmMe_Mt1fUEbgXH_9a5fQPvxFIsKxliVB9D9CvXd6Jy2ALt59dv9xAh6mZ.3Ncj6wqWnr_ZYIFnM1kzR9QAfO47nXxgpORolcEzcBYz6ITkED5jQ;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:03:29 GMT
+      - shopify-proxy-session=1770053608355-h8qazjt5y2t; Path=/; Expires=Tue, 03 Feb
+        2026 17:33:28 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s5hfnLFP01lPG7v5mKl2ehqwKdM",
+          "object": "chat.completion",
+          "created": 1770053609,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:33:29 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:33:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b6f173a3bd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - ab988b1d-8b29-4a56-a371-9190fe469ea7
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499937'
+      X-Ratelimit-Remaining-Tokens:
+      - '149599658'
+      X-Request-Id:
+      - d163e0ec-0211-4ebd-af27-a22d583b9770
+      Set-Cookie:
+      - __cf_bm=oGggNHLQJa9Yw4fZNJeiHnGEw2IPrIec2eTvttK4kfE-1770053610.131984-1.0.1.1-f5qFS1fFPswEx1Ea3zzSQdxVG6qdMcuii.jLHB5Cx5h2GVP3C.xGAJuNidVWkMCIYoRakK.E0GgBsDXhNoXfbI.oYt3bp4TUmX6_wDIA8wbKkC7jqoBDnoP59MLwKLBZ;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:03:30 GMT
+      - shopify-proxy-session=1770053610133-pbrk8bnktz8; Path=/; Expires=Tue, 03 Feb
+        2026 17:33:30 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s5is8ikRNFpM7jpgUSjHXsU6Rif",
+          "object": "chat.completion",
+          "created": 1770053610,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "Eiffel Tower stands,  \nSeine whispers through the streets low,  \nParis lights the night.  ",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 22,
+            "total_tokens": 39,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:33:30 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:34:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - 74d8578e-d2ff-4d9f-8d48-c0eb27ac07fd
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=2e.VK8tdwCSt_S_bVPuiY9G3ykPmXj55OO482jnxaYU-1770053651.2250981-1.0.1.1-oR0pPuoeMhugOPdTyiNnCXrw9u1nP8sKNshZ74MdaZ7ravpUpL_LBTGTm33RZicKeK0V.7roLgurZpGeigXodaj2fXvJsviROn2Ufi4UP7A0gV6N6Nj2M1eJG0ILawUN;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:04:11 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c7b70182900d214-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s5hfnLFP01lPG7v5mKl2ehqwKdM",
+          "object": "chat.completion",
+          "created": 1770053609,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:34:11 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:34:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - d163e0ec-0211-4ebd-af27-a22d583b9770
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=dkOoZCV4oupQ9EcvXyn1rMjc4HGAfYdUgcD_j1sauD8-1770053651.314609-1.0.1.1-1_DWXAgeym8uhglOyPADjGRaxdJYRjTdU3.DnSAJi_cTobpSFnU2ksYXf7n8FAmg16n4jJAJf8Y4lK3BkDmuxg.SJmwCNEvJ2FV7bHfYVQEWxNs7T9joeTwdjkExHNWk;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:04:11 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c7b7018b942d214-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s5is8ikRNFpM7jpgUSjHXsU6Rif",
+          "object": "chat.completion",
+          "created": 1770053610,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "Eiffel Tower stands,  \nSeine whispers through the streets low,  \nParis lights the night.  ",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 22,
+            "total_tokens": 39,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:34:11 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:35:33 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b72175cb9d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 592611e6-7e3d-4f2a-9392-d66faa1c817b
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499955'
+      X-Ratelimit-Remaining-Tokens:
+      - '149414103'
+      X-Request-Id:
+      - 0b08a638-9f87-491f-b961-dc9833381cb0
+      Set-Cookie:
+      - __cf_bm=gGb7OQSz3tYR2LT7sCpQFLi78TpDvC_F6x1ooCf8EpU-1770053733.014834-1.0.1.1-olsSIKpn1YJafjRQVzFOlzslfN809TZN71YY5KHqsYBgjvUOw.Iu.MH4goRoHe4FZfnu.c.vdsBsbOGXjU7Bu1cHToTJLZAS1uweUWxNgPpqJtoH.4Ajc61WfLwOgDSV;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:05:33 GMT
+      - shopify-proxy-session=1770053733016-1zormw5qs7r; Path=/; Expires=Tue, 03 Feb
+        2026 17:35:33 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s7h9nYl7ObSJYudtKwXgeIB7t5G",
+          "object": "chat.completion",
+          "created": 1770053733,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:35:33 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:35:34 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b721c3ed7d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 6f939298-8976-4cc4-9a7b-d3b9e2e00aa5
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499954'
+      X-Ratelimit-Remaining-Tokens:
+      - '149414092'
+      X-Request-Id:
+      - 10fde02c-cff6-4414-8c2c-93197d0d8fdc
+      Set-Cookie:
+      - __cf_bm=TPRt44eKJDsKKTZEME6ajjqrP9_5dUSofnmTSWrE.0Q-1770053733.7988522-1.0.1.1-Y0ePG_1xHn3t6Es_6HhxnMk0a4D8onWybVeDSZNq9T3ovYx0ihCJ4lM5W1.dlSoL1Um9l09nsMypP1gvxzNxdtL3eGvyL8O5KQ.pArdMnysZHQCN1WxdQdmWd1e8.mu3;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:05:34 GMT
+      - shopify-proxy-session=1770053733800-bbziu61rgxl; Path=/; Expires=Tue, 03 Feb
+        2026 17:35:33 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4s7hOGQjMfO4MnuqecRvzLxO3zvl",
+          "object": "chat.completion",
+          "created": 1770053733,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches skies,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:35:34 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:43:19 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b7d6e6cafd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - cea04ad1-75d3-4c37-8f84-af810f2b6b5e
+      Azureml-Model-Session:
+      - d20260130172301-55907ae962e1
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499987'
+      X-Ratelimit-Remaining-Tokens:
+      - '149743640'
+      X-Request-Id:
+      - 83921b84-06b7-4355-afe3-0c2af42309b9
+      Set-Cookie:
+      - __cf_bm=Auz9S2a_xP.U.8enKOvkTfRpBXOclgODWXHTAZMHS1k-1770054197.5080624-1.0.1.1-6MHkz7Nx_aViVjJuSD3A9MIOGjMK1sn28ZB2ZkrQFyr_oAbNvOQUWgfksh_hWVg1AYxrBf5Ws5aZ3J2ydqQIjpQujDUSZNEumco9IA7YCfukGdd1JFrcCBpohKmRmejd;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:13:19 GMT
+      - shopify-proxy-session=1770054197509-bi4sq4vazck; Path=/; Expires=Tue, 03 Feb
+        2026 17:43:17 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sFCtq5nc0IdZYmuVf4dcJJJLKok",
+          "object": "chat.completion",
+          "created": 1770054198,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:43:19 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 17:43:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b7d7deba2d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - df10b56e-4e5e-4371-8857-446ab0043df4
+      Azureml-Model-Session:
+      - d20260130181318-379716d6a0ac
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499986'
+      X-Ratelimit-Remaining-Tokens:
+      - '149743629'
+      X-Request-Id:
+      - 66fa5613-2aec-41b7-9278-73c91dd2df4d
+      Set-Cookie:
+      - __cf_bm=R_IMbiX9OFXL3kWzmRY_S2YcJdLEbpkFFnlM6R0iOWA-1770054199.9909828-1.0.1.1-z_CbJ4E8PvNCwpl7hwK38MWUMYTsSkug56rDWNMTFBI5AIlXXwjXST2Qa1wb7OkSjGgZ.G3jLAitJl77.NrGqoeG61kNvpQfQAtQZrMTQM7ts5ui.In4jt_k_6x3jZ7Z;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:13:20 GMT
+      - shopify-proxy-session=1770054199992-qc1cuiuznuh; Path=/; Expires=Tue, 03 Feb
+        2026 17:43:19 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sFEos3bK2BYwRbkCibtf9qqf8MO",
+          "object": "chat.completion",
+          "created": 1770054200,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "Seine whispers softly,  \nBeneath the lights, dreams take flight,  \nParis, heart of art.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 24,
+            "total_tokens": 41,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 17:43:20 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:00:00 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b95e0ef92d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 5c7daf2f-78d8-4940-9613-81bdbc232ba1
+      Azureml-Model-Session:
+      - d20251214084336-049fd1c8ee3d4c98
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499996'
+      X-Ratelimit-Remaining-Tokens:
+      - '149998994'
+      X-Request-Id:
+      - a9e595aa-3e16-4467-91e4-c27eeb6649d6
+      Set-Cookie:
+      - __cf_bm=f08nZwjWTucTZZnNIV_ZvzHnvtiVdPIyfsQmVG0vC4M-1770055198.864069-1.0.1.1-nHNoi7cQrHLm7coGKzQ2k8AOC5B9zZKIo6_Jk47p46yf0gdc8Oh6oFBv9ihW19Zxs7wtgGMuteNq8s7vh5iPiWE.HcNeHq_JDYZOBIBZfeL3b8szs83tAw1sQ58lgLDP;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:30:00 GMT
+      - shopify-proxy-session=1770055198865-4bnmw590j6n; Path=/; Expires=Tue, 03 Feb
+        2026 17:59:58 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sVLtdbZDDf6CwYztIFjGAJw2Dha",
+          "object": "chat.completion",
+          "created": 1770055199,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nParis whispers dreams.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 17,
+            "total_tokens": 34,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:00:00 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:00:01 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b95ebad65d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - f20eaefc-8484-4d2f-9a8f-39ec676d15f9
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499995'
+      X-Ratelimit-Remaining-Tokens:
+      - '149998983'
+      X-Request-Id:
+      - db343979-b8d7-4a61-a182-4cc38e75a0ad
+      Set-Cookie:
+      - __cf_bm=9BZdxO_ww9jZK1mQdOW5hxr1VYo3fSDwETOlxE1hLrM-1770055200.5864604-1.0.1.1-EpiVFS9MCa9b5UOgrAHOVHAZYEiEHGP0H4Qqnn9VXAKF1DZgPzNpvXAmzLZgeDarcGAMPr10o5FJHEWlv6cuxOZCoMUIeknDvYkvaW_BJqjccck8lURiJpp1tB1AF6m8;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:30:01 GMT
+      - shopify-proxy-session=1770055200588-y9xzdm9fhz; Path=/; Expires=Tue, 03 Feb
+        2026 18:00:00 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sVMqKleeaz0yLdTDKvVxGWobSan",
+          "object": "chat.completion",
+          "created": 1770055200,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "River Seine flows bright,  \nBeneath the Eiffel's great gaze,  \nParis dreams at night.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 22,
+            "total_tokens": 39,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:00:01 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:01:41 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - a9e595aa-3e16-4467-91e4-c27eeb6649d6
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=sXg5q3Djkhcb6DeZw5M2s7YG5K4HmNGcxlOEfV95gck-1770055301.7882092-1.0.1.1-0HTYnN4WM2GHRrmfcPv9capTjFMNQdFWhBRzJsu5GdrHE7CpppHtwf9lWN5yNq4DubTBS9LnbVlUgt4YNWppbXyie3HKN2GGZG3D8hQ.tYyrfvMBc_fQXIgWwGBgA8UN;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:31:41 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c7b98642b3ed214-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sVLtdbZDDf6CwYztIFjGAJw2Dha",
+          "object": "chat.completion",
+          "created": 1770055199,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nParis whispers dreams.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 17,
+            "total_tokens": 34,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:01:41 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:01:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b98655bc1d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 57b0ed4b-4205-4fd1-b281-81b05c0b92e1
+      Azureml-Model-Session:
+      - d20251214100634-9856757b6b614f8a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499986'
+      X-Ratelimit-Remaining-Tokens:
+      - '149994869'
+      X-Request-Id:
+      - c7ae00a6-abea-4595-844c-eb9753ccd017
+      Set-Cookie:
+      - __cf_bm=Uhdmt_h0.ZTYdEoG8CP72QT0t9F6FNgjG1WAfqlsnTE-1770055301.9743316-1.0.1.1-nxUpB3qjaQD3fpOSKgiirr5qlpB0RdFAbZRT_jbRr4BirRar2nktWUjGII9qMTw3KH1kBHFeqR6lb0qHbAfNfgLGRPMtQgxFIJylDTA9fgRq1RNIxJ4uenclixAcG2qn;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:31:42 GMT
+      - shopify-proxy-session=1770055301976-jp456ce40wq; Path=/; Expires=Tue, 03 Feb
+        2026 18:01:41 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sX0Nt3zyoZMH20lXgxpRchV3WAU",
+          "object": "chat.completion",
+          "created": 1770055302,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower lights the night,  \nSeine whispers secrets.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 19,
+            "total_tokens": 36,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:01:42 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b994e6e91d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '591'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999992'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_59b5391f39524884861bda50e730e255
+      Set-Cookie:
+      - __cf_bm=Udvx7RjOppgTl4qKhuKMRMsukysyR_F6nKvF5jm41ek-1770055339.267348-1.0.1.1-VoHRRayAElrshmLD7I4VzwUn0bf5xN1C9htTbGZ0tC0Ipliowamek8m8KGY7fS6JN_I39c.fjssw3wT0xDViYUqk8BGhFB_CEt6iP8M65dTOQTfkXSaQ.lRl7XW1.Wtz;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:20 GMT
+      - shopify-proxy-session=1770055339269-gmxjfmu76a; Path=/; Expires=Tue, 03 Feb
+        2026 18:02:19 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sXbgFIvG6nydih46s27Xx2sj7VU",
+          "object": "chat.completion",
+          "created": 1770055339,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 17,
+            "total_tokens": 34,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:02:20 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7b9953e8ccd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '804'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999985'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_02129f88ad204c348117a4c35a21c6a3
+      Set-Cookie:
+      - __cf_bm=2Dqii5Vdv2hXbYf7gXMK1pS37e3yCWS1gLtJHouBwGw-1770055340.142388-1.0.1.1-3W1Frggi1c2QtCC_FQ7L.OXPbCOjGB5Fe9CrNg9LxOcS.L4UkEsJCfNhOqzscsBHQchhbjLTTM1rzI20BK_oLWLsyoyEhPQt8mZAbFuxvG16902.ZfxXB5GF5dXOhFdu;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:21 GMT
+      - shopify-proxy-session=1770055340144-8vfw0o4nmsc; Path=/; Expires=Tue, 03 Feb
+        2026 18:02:20 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sXcCHhDlqgY1kRkPGTrjY0dCCfI",
+          "object": "chat.completion",
+          "created": 1770055340,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Seine flows through cobblestones,  \nEiffel towers touch the skies,  \nParis whispers dreams.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 21,
+            "total_tokens": 38,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:02:21 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - req_59b5391f39524884861bda50e730e255
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=AAUB6CCh2NPQduBGPrv.ACQcpW8tMLG3ZPRXWWsQNak-1770055359.797284-1.0.1.1-iVuawthE4uktLG_YlLmv8Ubp2N2pjDqJtCxCXQNvW7hY6aT0v5n5r6JaiSZkDV2kI4URMFgREtFxBmwdgsDfIUISgkA1RURHnh8IzKBfchiKq7AYYrxjb5QUpUPdZr02;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:39 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c7b99cebe55d214-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sXbgFIvG6nydih46s27Xx2sj7VU",
+          "object": "chat.completion",
+          "created": 1770055339,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 17,
+            "total_tokens": 34,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:02:39 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:02:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Request-Id:
+      - req_02129f88ad204c348117a4c35a21c6a3
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Set-Cookie:
+      - __cf_bm=gr91BDsxKTpUiiyJwHlQ1SO7NBnXp.CKDvufGVtwP0Q-1770055359.8683379-1.0.1.1-PH56YHT2xTnCdSo9CELoAGzmiW.eHxVRQCpiiASa.Gq3o1Qd1fvCFTmRgtn5LLzutDw9r8w_qjF1JYvJRaaGv1zfIB2nAIor5vd120XTHnR8Av6xn_upFBz07Urb1qBr;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:32:39 GMT
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9c7b99cf2e7dd214-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4sXcCHhDlqgY1kRkPGTrjY0dCCfI",
+          "object": "chat.completion",
+          "created": 1770055340,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Seine flows through cobblestones,  \nEiffel towers touch the skies,  \nParis whispers dreams.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 21,
+            "total_tokens": 38,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:02:39 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:18:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bb1240e50d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '502'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999992'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_7069ade068a44461b04084536d4f2f04
+      Set-Cookie:
+      - __cf_bm=GK3OGXQsh77MMiAwPaettvMCSiHA4WufIWGvDrZKQu0-1770056315.5285518-1.0.1.1-OhoWUFqjEMP967aR4PhZaPsNpSFPV5nefVqb2EagbbSvkDeSu4Z6300X5qZ6YYpeUEcIE4hOZW7zI2OZcJHrd9IXtu0mDKgdgrojoA0pI4trfc82r5kZcFYVwy8GLPwD;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:48:36 GMT
+      - shopify-proxy-session=1770056315530-4rz443pfxyl; Path=/; Expires=Tue, 03 Feb
+        2026 18:18:35 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4snLoOILk43eM0hp9OHKwzvrMIRC",
+          "object": "chat.completion",
+          "created": 1770056315,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nSeine whispers secrets.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 17,
+            "total_tokens": 34,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:18:36 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:18:37 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bb12a297bd214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Content-Type-Options:
+      - nosniff
+      X-Shopify-Proxy-Provider:
+      - openai_sandbox_2
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - shopify-hack-days
+      Openai-Processing-Ms:
+      - '878'
+      Openai-Project:
+      - proj_RHxuweUBa4b19Xbb7FCw7ryR
+      Openai-Version:
+      - '2020-10-01'
+      X-Openai-Proxy-Wasm:
+      - v0.1
+      X-Ratelimit-Limit-Requests:
+      - '180000'
+      X-Ratelimit-Limit-Tokens:
+      - '450000000'
+      X-Ratelimit-Remaining-Requests:
+      - '179999'
+      X-Ratelimit-Remaining-Tokens:
+      - '449999992'
+      X-Ratelimit-Reset-Requests:
+      - 0s
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      X-Request-Id:
+      - req_1c8f5ad79e2048dfabd753e4cdcb6309
+      Set-Cookie:
+      - __cf_bm=bzN88z11AvceYNjkngd6NVFNQiGLEfVcuhrl0bhuwwM-1770056316.5070262-1.0.1.1-rwRLE2JEBVDEONuKwAxZyikvTyhm8sFU2HujCVCBMcv99ZyN7YzU.3tOOhG08mGWBmrXWpWVKHMbFfEjLI4K_snKi6iEWR_peMjtabUrjxLVmAy_S8d5JKumQXzwhtVm;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:48:37 GMT
+      - shopify-proxy-session=1770056316508-r1gyc865so8; Path=/; Expires=Tue, 03 Feb
+        2026 18:18:36 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4snMkKgEfZeFWAKZPXdpoejUOYbK",
+          "object": "chat.completion",
+          "created": 1770056316,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "City of romance,  \nEiffel Tower pierces skies,  \nSeine whispers secrets.",
+                "refusal": null,
+                "annotations": []
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 18,
+            "total_tokens": 35,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_1590f93f9d"
+        }
+  recorded_at: Mon, 02 Feb 2026 18:18:37 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":0.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:25:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bbb13e951d214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - 599a7c65-e2f3-45c5-9302-f252d19bd00e
+      Azureml-Model-Session:
+      - d20251214095915-c2de3b050c49450f
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499990'
+      X-Ratelimit-Remaining-Tokens:
+      - '149986088'
+      X-Request-Id:
+      - e5e02262-3df8-4531-8da0-79261cc5536b
+      Set-Cookie:
+      - __cf_bm=HGWBMi3t.6pz5e5m27baXStpyyVH5L_Sgmijx4mDQ3Y-1770056722.5470524-1.0.1.1-jkSsBEkyThsWHcxXWwtNMS8IV.gIoKzRpaV9o4XTuPcrhL8Xg32AofizXptfR4xtPtJS83QqLriXT1cSQHjbYC9gQppEYFPMK8nTRuiVtS3k95K80UHOzgmqKZWsq.TN;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:55:23 GMT
+      - shopify-proxy-session=1770056722548-hv8qf15d0y7; Path=/; Expires=Tue, 03 Feb
+        2026 18:25:22 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4stvfG2eetxerEi7HMdkF4yD1UVc",
+          "object": "chat.completion",
+          "created": 1770056723,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nEiffel Tower touches sky,  \nParis whispers dreams.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 17,
+            "total_tokens": 34,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:25:23 GMT
+- request:
+    method: post
+    uri: http://mytestingproxy.local/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Write
+        a haiku about the capital of France."}],"stream":false,"temperature":1.0}'
+    headers:
+      User-Agent:
+      - Faraday v2.13.1
+      Authorization:
+      - my-token
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Feb 2026 18:25:24 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9c7bbb1b8c3ad214-YVR
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - cloudflare
+      Vary:
+      - accept-encoding
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Access-Control-Allow-Headers:
+      - "*"
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+      X-Shopify-Proxy-Provider:
+      - azureopenai-dev-eastus
+      Apim-Request-Id:
+      - ba35cd54-35e3-4324-b5a3-8edeabb7e54f
+      Azureml-Model-Session:
+      - d20260130181318-379716d6a0ac
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Deployment-Name:
+      - gpt-4o-mini-2024-07-18
+      X-Ms-Rai-Invoked:
+      - 'true'
+      X-Ms-Region:
+      - East US
+      X-Ratelimit-Limit-Requests:
+      - '1500000'
+      X-Ratelimit-Limit-Tokens:
+      - '150000000'
+      X-Ratelimit-Remaining-Requests:
+      - '1499989'
+      X-Ratelimit-Remaining-Tokens:
+      - '149986077'
+      X-Request-Id:
+      - 5fec5b92-30ae-4e62-8ab0-13c1c1f91abd
+      Set-Cookie:
+      - __cf_bm=h9iPR4_wcSt6wUGRClNdrz_1CMjIGFjo2nMWgJntO_A-1770056723.76294-1.0.1.1-JNqEk5j9Am1RSy5d5EdXAo.LI0fpkHeOL.4LQT_yKFeki3JqOoTtjTJ1R7uI8E0yUHSEfa2Xw6TkQtaLILlujIrfQ9KkchkJBUd5yjZNF1dfIIovYd4wBvI_P_cKnb3r;
+        HttpOnly; Secure; Path=/; Domain=proxy.shopify.ai; Expires=Mon, 02 Feb 2026
+        18:55:24 GMT
+      - shopify-proxy-session=1770056723764-csjzivzdr0v; Path=/; Expires=Tue, 03 Feb
+        2026 18:25:23 GMT; HttpOnly; Secure; SameSite=Lax
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "chatcmpl-D4stvCNnL53ad5fi6NP14g18SI7Eb",
+          "object": "chat.completion",
+          "created": 1770056723,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "annotations": [],
+                "content": "City of romance,  \nUnderneath the Eiffel's glow,  \nParis dreams in light.",
+                "refusal": null,
+                "role": "assistant"
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 19,
+            "total_tokens": 36,
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0,
+              "audio_tokens": 0
+            },
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            }
+          },
+          "system_fingerprint": "fp_f97eff32c5",
+          "service_tier": null
+        }
+  recorded_at: Mon, 02 Feb 2026 18:25:24 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
# Add VCR Infrastructure for DSL Workflow Tests

Added VCR support for DSL workflow tests to enable reliable HTTP request recording and playback.

## What changed?

- Created a new `VCRURLRewriter` module to handle API endpoint transformations for cassette portability
- Added a test workflow `vcr_test_workflow.rb` that makes a simple LLM query about the deepest lake
- Created a VCR cassette with a recorded response about Lake Baikal
- Added a new test case that verifies the workflow runs correctly with the VCR cassette
- Set up environment variables in test setup to ensure tests work in both recording and replay modes

## How to test?

In replay mode (default):
```
bundle exec rake test
```

To record new cassettes:
```
OPENAI_API_KEY=your-key RECORD_VCR=true bundle exec rake test
```

## Why make this change?

This change improves test reliability by eliminating dependencies on external API services during testing. By recording API interactions once and playing them back during subsequent test runs, we can:

- Make tests faster and more deterministic
- Avoid hitting rate limits or incurring costs from real API calls
- Test without requiring real API credentials
- Ensure consistent test behavior regardless of network conditions