### PR TITLE
fix: change .fetch(:api_key to .fetch(base_url for valid_base_url

### DIFF
--- a/lib/roast/dsl/cogs/chat/config.rb
+++ b/lib/roast/dsl/cogs/chat/config.rb
@@ -147,7 +147,7 @@ module Roast
           #
           #: () -> String
           def valid_base_url
-            @values.fetch(:api_key, ENV[PROVIDERS.dig(valid_provider!, :base_url_env_var).not_nil!]) ||
+            @values.fetch(:base_url, ENV[PROVIDERS.dig(valid_provider!, :base_url_env_var).not_nil!]) ||
               PROVIDERS.dig(valid_provider!, :default_base_url)
           end
 


### PR DESCRIPTION
### TL;DR

Fixed a bug in the `valid_base_url` method where it was incorrectly fetching the API key instead of the base URL.

### What changed?

Changed the key in the `@values.fetch` call from `:api_key` to `:base_url` in the `valid_base_url` method of the Chat config class. This ensures the method correctly retrieves the base URL value rather than the API key.

### How to test?

1. Configure a chat provider with a custom base URL
2. Verify that the custom base URL is correctly used when making API calls
3. Check that the fallback to environment variables works as expected when no base URL is explicitly provided

### Why make this change?

The `valid_base_url` method was incorrectly fetching the `:api_key` value when it should have been fetching the `:base_url` value. This bug would cause the method to ignore any custom base URL configurations and potentially use incorrect URLs for API requests.