### PR TITLE
fix: handle unparsed agent system messages

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/messages/system_message.rb
+++ b/lib/roast/cogs/agent/providers/claude/messages/system_message.rb
@@ -21,6 +21,11 @@ module Roast
                 :agents,
                 :skills,
                 :plugins,
+                :hook_name,
+                :hook_event,
+                :stdout,
+                :stderr,
+                :exit_code,
               ].freeze
 
               #: String?


### PR DESCRIPTION
## What

While using the new ruby DSL executor I kept getting unparsed message logs printed to stdout when using the agent step. I've added those fields to the IGNORED list so they don't get logged anymore. I've also opened https://github.com/Shopify/roast/pull/681 to address similar issues be reintroducing a logger that outputs to stderr.

## Logs

```
[WARNING] Unhandled data in Claude system message:
{
  "hook_name": "SessionStart:startup",
  "hook_event": "SessionStart",
  "stdout": "",
  "stderr": "",
  "exit_code": 0
}
[FULL MESSAGE: system]
#<Roast::DSL::Cogs::Agent::Providers::Claude::Messages::SystemMessage:0x00000001428b9118
 @message=nil,
 @model=nil,
 @session_id="3380d510-8ad4-471e-8550-98d0a3946d70",
 @type=:system,
 @unparsed={hook_name: "SessionStart:startup", hook_event: "SessionStart", stdout: "", stderr: "", exit_code: 0}>
```