### PR TITLE
Simplify CI config to only run with Ruby 3.4 and ActiveSupport 8.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,23 +14,14 @@ env:
   CI: true
 
 jobs:
-  rubies:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu]
-        ruby: ['3.2', '3.3', '3.4']
-        gemfile: ['activesupport7', 'activesupport8']
-    runs-on: ${{ matrix.os }}-latest
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+  ci:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y ripgrep graphviz wamerican
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake sorbet
       - run: bundle exec rake rubocop_ci

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
   remote: .
   specs:
     roast-ai (0.5.2)
-      activesupport (>= 7.0)
+      activesupport (~> 8.0)
       async (>= 2.34)
       benchmark (>= 0.4.1)
       cli-kit (>= 5.2)

--- a/dsl/plugin-gem-example/plugin-gem-example.gemspec
+++ b/dsl/plugin-gem-example/plugin-gem-example.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "TODO: Write a longer description or delete this line."
   spec.homepage = "TODO: Put your gem's website or public repo URL here."
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.4.0"
 
   spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 

--- a/dsl/targets_and_params.rb
+++ b/dsl/targets_and_params.rb
@@ -21,8 +21,7 @@ execute do
     puts "workflow args: #{params.args}" # [:hello, :world] (args are parsed as symbols)
 
     # {abc: "pqr", foo: "bar"} (keys are parsed as symbols, values as strings)
-    # (Note: using explicit formatting for compatibility with Ruby versions < 3.4)
-    puts "workflow kwargs: {#{params.kwargs.map { |k, v| "#{k}: #{v.inspect}" }.join(", ")}}"
+    puts "workflow kwargs: #{params.kwargs}"
   end
 
   # There are convenience methods to access the workflow params from any cog input context in any scope

--- a/gemfiles/activesupport7.gemfile
+++ b/gemfiles/activesupport7.gemfile
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-eval_gemfile "../Gemfile"
-gem "activesupport", "~> 7.0"

--- a/gemfiles/activesupport8.gemfile
+++ b/gemfiles/activesupport8.gemfile
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-eval_gemfile "../Gemfile"
-gem "activesupport", "~> 8.0"

--- a/roast-ai.gemspec
+++ b/roast-ai.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/Shopify/roast"
   spec.metadata["changelog_uri"] = "https://github.com/Shopify/roast/blob/main/CHANGELOG.md"
 
+  spec.required_ruby_version = ">= 3.4.0"
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
@@ -29,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("activesupport", ">= 7.0")
+  spec.add_dependency("activesupport", "~> 8.0")
   spec.add_dependency("async", ">= 2.34")
   spec.add_dependency("benchmark", ">= 0.4.1")
   spec.add_dependency("cli-kit", ">= 5.2")


### PR DESCRIPTION
Roast is a tool (like Foreman), not a gem that you would generally include in a project. We can be stricter about the versions that we require