### PR TITLE
Make config test resilient to having OPENAI_API_BASE set

### DIFF
--- a/test/roast/cogs/chat/config_test.rb
+++ b/test/roast/cogs/chat/config_test.rb
@@ -87,7 +87,9 @@ module Roast
         end
 
         test "valid_base_url returns default when not set" do
-          assert_equal "https://api.openai.com/v1", @config.valid_base_url
+          with_env("OPENAI_API_BASE", nil) do
+            assert_equal "https://api.openai.com/v1", @config.valid_base_url
+          end
         end
 
         test "valid_base_url returns environment value when set" do


### PR DESCRIPTION
If a developer had `OPENAI_API_BASE` set to a custom value in their environment when running tests locally, the `"valid_base_url returns default when not set"` test would fail