### PR TITLE
Make apply_permissions the default agent cog behaviour

### DIFF
--- a/lib/roast/cogs/agent/config.rb
+++ b/lib/roast/cogs/agent/config.rb
@@ -214,7 +214,7 @@ module Roast
         #
         # How these permissions are defined and configured is specific to the agent provider being used.
         #
-        # The cog's default behaviour is to run with __no__ permissions.
+        # The cog's default behaviour is to run __with__ permissions applied.
         #
         # #### Alias Methods
         # - `apply_permissions!`
@@ -231,7 +231,7 @@ module Roast
 
         # Configure the cog to run the agent with __no__ permissions applied
         #
-        # The cog's default behaviour is to run with __no__ permissions.
+        # The cog's default behaviour is to run __with__ permissions.
         #
         # #### Alias Methods
         # - `no_apply_permissions!`
@@ -256,7 +256,7 @@ module Roast
         #
         #: () -> bool
         def apply_permissions?
-          !!@values[:apply_permissions]
+          @values.fetch(:apply_permissions, true)
         end
 
         # Configure the cog to display the prompt when running the agent

--- a/test/roast/cogs/agent/config_test.rb
+++ b/test/roast/cogs/agent/config_test.rb
@@ -124,30 +124,44 @@ module Roast
 
         # Permissions configuration tests
         test "apply_permissions! enables permissions" do
+          # ensure that configured value is initially the opposite of what we want to test
+          @config.no_apply_permissions!
+          refute @config.apply_permissions?
+
           @config.apply_permissions!
 
           assert @config.apply_permissions?
         end
 
         test "no_apply_permissions! disables permissions" do
+          # ensure that configured value is initially the opposite of what we want to test
           @config.apply_permissions!
+          assert @config.apply_permissions?
+
           @config.no_apply_permissions!
 
           refute @config.apply_permissions?
         end
 
-        test "apply_permissions? returns false by default" do
-          refute @config.apply_permissions?
+        test "apply_permissions? returns true by default" do
+          assert @config.apply_permissions?
         end
 
         test "skip_permissions! is alias for no_apply_permissions!" do
+          # ensure that configured value is initially the opposite of what we want to test
           @config.apply_permissions!
+          assert @config.apply_permissions?
+
           @config.skip_permissions!
 
           refute @config.apply_permissions?
         end
 
         test "no_skip_permissions! is alias for apply_permissions!" do
+          # ensure that configured value is initially the opposite of what we want to test
+          @config.no_apply_permissions!
+          refute @config.apply_permissions?
+
           @config.no_skip_permissions!
 
           assert @config.apply_permissions?

--- a/test/roast/cogs/agent/providers/claude/claude_invocation_test.rb
+++ b/test/roast/cogs/agent/providers/claude/claude_invocation_test.rb
@@ -247,14 +247,23 @@ module Roast
               assert_equal "session_123", command[resume_index + 1]
             end
 
-            test "command_line includes dangerously-skip-permissions by default" do
+            test "command_line includes dangerously-skip-permissions when permissions skipped" do
+              @config.skip_permissions!
               command = @invocation.send(:command_line)
 
-              assert_includes command, "--dangerously-skip-permissions"
+              refute_includes command, "--dangerously-skip-permissions"
             end
 
             test "command_line omits dangerously-skip-permissions when permissions applied" do
               @config.apply_permissions!
+              invocation = ClaudeInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              refute_includes command, "--dangerously-skip-permissions"
+            end
+
+            test "command_line omits dangerously-skip-permissions by default" do
               invocation = ClaudeInvocation.new(@config, @input)
 
               command = invocation.send(:command_line)


### PR DESCRIPTION
The `agent` cog should apply configured agent permissions by default.

Since the agent runs non-interactively, users must ensure that sufficient permissions are granted to the agent to perform the tasks it is directed to perform, as it cannot ask permission to run commands or access data.

The `skip_permissions!` config option can still be used to disable agent permission checking in a known-safe sandbox environment