### PR TITLE
Add agent provider registry

### DIFF
--- a/lib/roast/cogs/agent.rb
+++ b/lib/roast/cogs/agent.rb
@@ -61,11 +61,12 @@ module Roast
 
       #: () -> Provider
       def provider
-        @provider ||= case config.valid_provider!
-        when :claude
-          Providers::Claude.new(config)
-        else
-          raise UnknownProviderError, "Unknown provider: #{config.valid_provider!}"
+        @provider ||= begin
+          provider_name = config.valid_provider!
+          provider_class = Provider.resolve(provider_name)
+          raise UnknownProviderError, "Unknown provider: #{provider_name}" unless provider_class
+
+          provider_class.new(config)
         end
       end
     end

--- a/lib/roast/cogs/agent/config.rb
+++ b/lib/roast/cogs/agent/config.rb
@@ -5,8 +5,6 @@ module Roast
   module Cogs
     class Agent < Cog
       class Config < Cog::Config
-        VALID_PROVIDERS = [:claude].freeze #: Array[Symbol]
-
         # Configure the cog to use a specified provider when invoking an agent
         #
         # The provider is the source of the agent tool itself.
@@ -49,9 +47,10 @@ module Roast
         #
         #: () -> Symbol
         def valid_provider!
-          provider = @values[:provider] || VALID_PROVIDERS.first
-          unless VALID_PROVIDERS.include?(provider)
-            raise ArgumentError, "'#{provider}' is not a valid provider. Available providers include: #{VALID_PROVIDERS.join(", ")}"
+          provider = @values[:provider] || Provider.default_provider_name
+          unless Provider.registered?(provider)
+            raise ArgumentError,
+              "'#{provider}' is not a valid provider. Available providers include: #{Provider.registered_provider_names.join(", ")}"
           end
 
           provider

--- a/lib/roast/cogs/agent/provider.rb
+++ b/lib/roast/cogs/agent/provider.rb
@@ -12,7 +12,81 @@ module Roast
       #
       # Subclasses should override `invoke` to provide concrete implementations that communicate
       # with their respective agent services.
+      #
+      # Provider also serves as the registry for available providers. Built-in providers are
+      # lazily registered on first access. External gems can register additional providers:
+      #
+      #   Roast::Cogs::Agent::Provider.register(:my_agent, MyGem::MyAgentProvider)
+      #
       class Provider
+        class << self
+          # Register a provider class under a symbolic name
+          #
+          #: (Symbol, singleton(Provider), ?default: bool) -> void
+          def register(name, provider_class, default: false)
+            ensure_initialized!
+            registry[name] = provider_class
+            @default_provider_name = name if default
+          end
+
+          # Return the provider class registered under the given name, or nil
+          #
+          #: (Symbol) -> singleton(Provider)?
+          def resolve(name)
+            ensure_initialized!
+            registry[name]
+          end
+
+          # Check whether a provider is registered under the given name
+          #
+          #: (Symbol) -> bool
+          def registered?(name)
+            ensure_initialized!
+            registry.key?(name)
+          end
+
+          # Return all registered provider names
+          #
+          #: () -> Array[Symbol]
+          def registered_provider_names
+            ensure_initialized!
+            registry.keys
+          end
+
+          # Return the name of the default provider
+          #
+          # The default is either the provider explicitly marked with `default: true`,
+          # or the first provider registered.
+          #
+          #: () -> Symbol?
+          def default_provider_name
+            ensure_initialized!
+            @default_provider_name || registry.keys.first
+          end
+
+          private
+
+          #: () -> Hash[Symbol, singleton(Provider)]
+          def registry
+            @registry ||= {}
+          end
+
+          # Ensure built-in providers are registered on first registry access
+          #
+          # References the built-in provider class to trigger Zeitwerk autoload on first
+          # load, then explicitly registers it. The explicit registration is necessary
+          # because Zeitwerk only executes the class body once — subsequent calls (e.g.,
+          # after reset_registry! in tests) need the fallback.
+          #
+          #: () -> void
+          def ensure_initialized!
+            return if @initialized
+
+            @initialized = true
+            register(:claude, Providers::Claude, default: true)
+          end
+        end
+
         # Initialize a new provider with the given configuration
         #
         # Stores the agent configuration for use during invocation. The configuration contains

--- a/lib/roast/cogs/agent/providers/claude.rb
+++ b/lib/roast/cogs/agent/providers/claude.rb
@@ -6,6 +6,8 @@ module Roast
     class Agent < Cog
       module Providers
         class Claude < Provider
+          Provider.register(:claude, self, default: true)
+
           class Output < Agent::Output
             delegate :response, :session, :stats, to: :@invocation_result
 

--- a/test/roast/cogs/agent/config_test.rb
+++ b/test/roast/cogs/agent/config_test.rb
@@ -8,10 +8,9 @@ module Roast
       class ConfigTest < ActiveSupport::TestCase
         def setup
           @config = Config.new
-          @default_provider = Config::VALID_PROVIDERS.first
+          @default_provider = Provider.default_provider_name
         end
 
-        # Provider configuration tests
         test "provider sets provider value" do
           @config.provider(@default_provider)
 

--- a/test/roast/cogs/agent/provider_test.rb
+++ b/test/roast/cogs/agent/provider_test.rb
@@ -41,6 +41,83 @@ module Roast
           assert_equal "Test response", output.response
         end
       end
+
+      class ProviderRegistryTest < ActiveSupport::TestCase
+        def setup
+          @original_registry = Provider.instance_variable_get(:@registry)&.dup
+          @original_default = Provider.instance_variable_get(:@default_provider_name)
+          Provider.instance_variable_set(:@registry, {})
+          Provider.instance_variable_set(:@default_provider_name, nil)
+          Provider.instance_variable_set(:@initialized, false)
+        end
+
+        def teardown
+          Provider.instance_variable_set(:@registry, @original_registry)
+          Provider.instance_variable_set(:@default_provider_name, @original_default)
+          Provider.instance_variable_set(:@initialized, true)
+        end
+
+        test "register adds a provider to the registry" do
+          provider_class = Class.new(Provider)
+          Provider.register(:test_provider, provider_class)
+
+          assert Provider.registered?(:test_provider)
+        end
+
+        test "resolve returns the registered class" do
+          provider_class = Class.new(Provider)
+          Provider.register(:test_provider, provider_class)
+
+          assert_equal provider_class, Provider.resolve(:test_provider)
+        end
+
+        test "resolve returns nil for unknown providers" do
+          assert_nil Provider.resolve(:nonexistent)
+        end
+
+        test "registered? returns true for registered providers" do
+          provider_class = Class.new(Provider)
+          Provider.register(:test_provider, provider_class)
+
+          assert Provider.registered?(:test_provider)
+        end
+
+        test "registered? returns false for unregistered providers" do
+          refute Provider.registered?(:nonexistent)
+        end
+
+        test "registered_provider_names lists all registered names" do
+          provider_a = Class.new(Provider)
+          provider_b = Class.new(Provider)
+          Provider.register(:alpha, provider_a)
+          Provider.register(:beta, provider_b)
+
+          assert_includes Provider.registered_provider_names, :alpha
+          assert_includes Provider.registered_provider_names, :beta
+        end
+
+        test "default_provider_name returns the provider marked as default" do
+          provider_a = Class.new(Provider)
+          provider_b = Class.new(Provider)
+          Provider.register(:alpha, provider_a)
+          Provider.register(:beta, provider_b, default: true)
+
+          assert_equal :beta, Provider.default_provider_name
+        end
+
+        test "default_provider_name can be overridden by registering a new default" do
+          provider_class = Class.new(Provider)
+          Provider.register(:custom, provider_class, default: true)
+
+          assert_equal :custom, Provider.default_provider_name
+        end
+
+        test "Claude is registered as default after initialization" do
+          assert Provider.registered?(:claude)
+          assert_equal :claude, Provider.default_provider_name
+          assert_equal Providers::Claude, Provider.resolve(:claude)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This allows gems to define their own agent providers without needing to
be merged with Roast.