### PR TITLE
simplify-not-nil-to-just-bang

### DIFF
--- a/lib/roast/cog.rb
+++ b/lib/roast/cog.rb
@@ -61,7 +61,7 @@ module Roast
       raise CogAlreadyStartedError if @task
 
       @task = barrier.async(finished: false) do |task|
-        task.annotate("#{self.class.name.not_nil!.demodulize.camelcase} Cog: #{@name}")
+        task.annotate("#{self.class.name.!.demodulize.camelcase} Cog: #{@name}")
         @config = config
         input_instance = self.class.input_class.new
         input_return = input_context.instance_exec(

--- a/lib/roast/cogs/chat/config.rb
+++ b/lib/roast/cogs/chat/config.rb
@@ -98,7 +98,7 @@ module Roast
         #
         #: () -> String
         def valid_api_key!
-          value = @values.fetch(:api_key, ENV[PROVIDERS.dig(valid_provider!, :api_key_env_var).not_nil!])
+          value = @values.fetch(:api_key, ENV[PROVIDERS.dig(valid_provider!, :api_key_env_var).!])
           raise InvalidConfigError, "no api key provided" unless value
 
           value
@@ -146,7 +146,7 @@ module Roast
         #
         #: () -> String
         def valid_base_url
-          @values.fetch(:base_url, ENV[PROVIDERS.dig(valid_provider!, :base_url_env_var).not_nil!]) ||
+          @values.fetch(:base_url, ENV[PROVIDERS.dig(valid_provider!, :base_url_env_var).!]) ||
             PROVIDERS.dig(valid_provider!, :default_base_url)
         end
 

--- a/lib/roast/nil_assertions.rb
+++ b/lib/roast/nil_assertions.rb
@@ -3,7 +3,7 @@
 
 module Kernel
   #: -> self
-  def not_nil!
+  def !
     self
   end
 end
@@ -11,7 +11,7 @@ end
 class NilClass
   # @override
   #: -> bot
-  def not_nil!
+  def !
     raise UnexpectedNilError
   end
 end

--- a/lib/roast/workflow.rb
+++ b/lib/roast/workflow.rb
@@ -41,10 +41,10 @@ module Roast
       @preparing = true
       extract_dsl_procs!
       @config_manager = ConfigManager.new(@cog_registry, @config_procs)
-      @config_manager.not_nil!.prepare!
+      @config_manager.!.prepare!
       # TODO: probably we should just not pass the params as the top-level scope value anymore
-      @execution_manager = ExecutionManager.new(@cog_registry, @config_manager.not_nil!, @execution_procs, @workflow_context, scope_value: @workflow_context.params)
-      @execution_manager.not_nil!.prepare!
+      @execution_manager = ExecutionManager.new(@cog_registry, @config_manager.!, @execution_procs, @workflow_context, scope_value: @workflow_context.params)
+      @execution_manager.!.prepare!
 
       @prepared = true
     end

--- a/test/roast/nil_assertions_test.rb
+++ b/test/roast/nil_assertions_test.rb
@@ -3,46 +3,46 @@
 require "test_helper"
 
 class NilAssertionsTest < ActiveSupport::TestCase
-  test "not_nil! returns self for non-nil objects" do
+  test "! returns self for non-nil objects" do
     str = "hello"
-    result = str.not_nil!
+    result = str.!
 
     assert_equal str, result
     assert_same str, result
   end
 
-  test "not_nil! returns self for numeric values" do
+  test "! returns self for numeric values" do
     num = 42
-    result = num.not_nil!
+    result = num.!
 
     assert_equal num, result
   end
 
-  test "not_nil! returns self for arrays" do
+  test "! returns self for arrays" do
     arr = [1, 2, 3]
-    result = arr.not_nil!
+    result = arr.!
 
     assert_equal arr, result
     assert_same arr, result
   end
 
-  test "not_nil! returns self for hashes" do
+  test "! returns self for hashes" do
     hash = { key: "value" }
-    result = hash.not_nil!
+    result = hash.!
 
     assert_equal hash, result
     assert_same hash, result
   end
 
-  test "not_nil! returns self for false" do
-    result = false.not_nil!
+  test "! returns self for false" do
+    result = false.!
 
     assert_equal false, result
   end
 
-  test "not_nil! raises UnexpectedNilError for nil" do
+  test "! raises UnexpectedNilError for nil" do
     error = assert_raises(UnexpectedNilError) do
-      nil.not_nil!
+      nil.!
     end
 
     assert_equal "Unexpected nil value encountered.", error.message
@@ -60,15 +60,15 @@ class NilAssertionsTest < ActiveSupport::TestCase
     assert_equal "Unexpected nil value encountered.", error.message
   end
 
-  test "not_nil! can be chained with other methods on non-nil values" do
-    result = "hello".not_nil!.upcase
+  test "! can be chained with other methods on non-nil values" do
+    result = "hello".!.upcase
 
     assert_equal "HELLO", result
   end
 
-  test "not_nil! raises before chaining when value is nil" do
+  test "! raises before chaining when value is nil" do
     assert_raises(UnexpectedNilError) do
-      nil.not_nil!.upcase
+      nil.!.upcase
     end
   end
 end


### PR DESCRIPTION
`not_nil!` is really helpful, but wouldn't it be better if you could just use a single character to say that something is definitely not nil? Now you can!

```
foo = "hello" #: String | nil
foo.!.upcase
```