### PR TITLE
Refactor agent provider to allow support for custom agents

### DIFF
--- a/lib/roast/cogs/agent.rb
+++ b/lib/roast/cogs/agent.rb
@@ -48,25 +48,13 @@ module Roast
       #: (Input) -> Output
       def execute(input)
         puts "[USER PROMPT] #{input.valid_prompt!}" if config.show_prompt?
-        output = provider.invoke(input)
+        output = config.values[:provider].invoke(input)
         # NOTE: If progress is displayed, the agent's response will always be the last progress message,
         # so showing it again is duplicative.
         puts "[AGENT RESPONSE] #{output.response}" if config.show_response? && !config.show_progress?
         puts "[AGENT STATS] #{output.stats}" if config.show_stats?
         puts "Session ID: #{output.session}" if config.show_stats?
         output
-      end
-
-      private
-
-      #: () -> Provider
-      def provider
-        @provider ||= case config.valid_provider!
-        when :claude
-          Providers::Claude.new(config)
-        else
-          raise UnknownProviderError, "Unknown provider: #{config.valid_provider!}"
-        end
       end
     end
   end

--- a/lib/roast/cogs/agent/config.rb
+++ b/lib/roast/cogs/agent/config.rb
@@ -5,7 +5,17 @@ module Roast
   module Cogs
     class Agent < Cog
       class Config < Cog::Config
-        VALID_PROVIDERS = [:claude].freeze #: Array[Symbol]
+        #: (?Hash[Symbol, untyped]) -> void
+        def initialize(initial = {})
+          super(initial)
+
+          @provider_registry = {}
+        end
+
+        def validate!
+          # Provider registry is responsible for ensuring the validity of providers
+          @values[:provider] = @provider_registry.fetch(@values[:provider]).new(self)
+        end
 
         # Configure the cog to use a specified provider when invoking an agent
         #
@@ -34,27 +44,6 @@ module Roast
         #: () -> void
         def use_default_provider!
           @values[:provider] = nil
-        end
-
-        # Get the validated provider name that the cog is configured to use when invoking an agent
-        #
-        # Note: this method will return the name of a valid provider or raise an `InvalidConfigError`.
-        # It will __not__, however, validate that the agent is properly installed on your system.
-        # If the agent is not properly installed, you will likely experience a failure when Roast attempts to
-        # run your workflow.
-        #
-        # #### See Also
-        # - `provider`
-        # - `use_default_provider!`
-        #
-        #: () -> Symbol
-        def valid_provider!
-          provider = @values[:provider] || VALID_PROVIDERS.first
-          unless VALID_PROVIDERS.include?(provider)
-            raise ArgumentError, "'#{provider}' is not a valid provider. Available providers include: #{VALID_PROVIDERS.join(", ")}"
-          end
-
-          provider
         end
 
         # Configure the cog to use a specific base command when invoking the agent

--- a/lib/roast/provider_registry.rb
+++ b/lib/roast/provider_registry.rb
@@ -1,0 +1,45 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  # Maintains the list of registered agent providers
+  # Built in providers are registered automatically.
+  # Custom agents are registered per workflow with `use`.)
+  class ProviderRegistry
+    class ProviderRegistryError < Roast::Error; end
+    class DuplicateProviderNameError < ProviderRegistryError; end
+    class ProviderNotFoundError < ProviderRegistryError; end
+
+    #: Symbol
+    attr_accessor :default
+
+    delegate :key?, to: :@providers
+
+    def initialize
+      @providers = {} #: Hash[Symbol, singleton(Cogs::Agent::Provider)]
+      @default = :claude
+    end
+
+    #: (singleton(Cogs::Agent::Provider), ?Symbol?) -> void
+    def register(provider_class, name = nil)
+      name = build_provider_name(provider_class) if name.blank?
+      raise DuplicateProviderNameError if @providers.key?(name)
+
+      @providers[name] = provider_class
+    end
+
+    def fetch(name)
+      name = default if name.nil?
+      raise ProviderNotFoundError unless @providers.key?(name)
+
+      @providers.fetch(name)
+    end
+
+    private
+
+    #: (singleton(Cogs::Agent::Provider)) -> Symbol
+    def build_provider_name(provider_class)
+      provider_class.name.not_nil!.demodulize.underscore.to_sym
+    end
+  end
+end

--- a/test/roast/execution_manager_test.rb
+++ b/test/roast/execution_manager_test.rb
@@ -8,7 +8,7 @@ module Roast
       @registry = Cog::Registry.new
       @registry.use(TestCogSupport::TestCog)
 
-      @config_manager = ConfigManager.new(@registry, [])
+      @config_manager = ConfigManager.new(@registry, [], ProviderRegistry.new)
       @config_manager.prepare!
 
       @workflow_context = WorkflowContext.new(
@@ -68,7 +68,7 @@ module Roast
       conflicting_registry.use(conflicting_cog)
 
       # Use a clean registry for config_manager so it doesn't hit the same conflict
-      config_manager = ConfigManager.new(Cog::Registry.new, [])
+      config_manager = ConfigManager.new(Cog::Registry.new, [], ProviderRegistry.new)
       config_manager.prepare!
 
       manager = ExecutionManager.new(

--- a/test/roast/provider_registry_test.rb
+++ b/test/roast/provider_registry_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  class ProviderRegistryTest < ActiveSupport::TestCase
+    def setup
+      @registry = ProviderRegistry.new
+    end
+
+    test "register stores a provider class by derived name" do
+      @registry.register(Cogs::Agent::Providers::Claude)
+
+      assert_equal Cogs::Agent::Providers::Claude, @registry.fetch(:claude)
+    end
+
+    test "register uses explicit name when provided" do
+      @registry.register(Cogs::Agent::Providers::Claude, :custom_name)
+
+      assert_equal Cogs::Agent::Providers::Claude, @registry.fetch(:custom_name)
+    end
+
+    test "register derives name from demodulized underscored class name" do
+      provider = Class.new(Cogs::Agent::Provider)
+      stub_name = "Roast::Cogs::Agent::Providers::MyCustomProvider"
+      provider.define_singleton_method(:name) { stub_name }
+
+      @registry.register(provider)
+
+      assert_equal provider, @registry.fetch(:my_custom_provider)
+    end
+
+    test "register raises DuplicateProviderNameError for duplicate derived name" do
+      @registry.register(Cogs::Agent::Providers::Claude)
+
+      assert_raises(ProviderRegistry::DuplicateProviderNameError) do
+        @registry.register(Cogs::Agent::Providers::Claude)
+      end
+    end
+
+    test "register raises DuplicateProviderNameError for duplicate explicit name" do
+      @registry.register(Cogs::Agent::Providers::Claude, :my_provider)
+
+      other_provider = Class.new(Cogs::Agent::Provider)
+      other_provider.define_singleton_method(:name) { "OtherProvider" }
+
+      assert_raises(ProviderRegistry::DuplicateProviderNameError) do
+        @registry.register(other_provider, :my_provider)
+      end
+    end
+
+    test "fetch raises ProviderNotFoundError for unregistered provider" do
+      assert_raises(ProviderRegistry::ProviderNotFoundError) do
+        @registry.fetch(:nonexistent)
+      end
+    end
+
+    test "default is :claude" do
+      registry = ProviderRegistry.new
+      assert_equal :claude, registry.default
+    end
+
+    test "default is writable" do
+      @registry.default = :openai
+
+      assert_equal :openai, @registry.default
+    end
+
+    test "register multiple distinct providers" do
+      first_provider = Class.new(Cogs::Agent::Provider)
+      first_provider.define_singleton_method(:name) { "FirstProvider" }
+
+      second_provider = Class.new(Cogs::Agent::Provider)
+      second_provider.define_singleton_method(:name) { "SecondProvider" }
+
+      @registry.register(first_provider)
+      @registry.register(second_provider)
+
+      assert_equal first_provider, @registry.fetch(:first_provider)
+      assert_equal second_provider, @registry.fetch(:second_provider)
+    end
+
+    test "fetch with nil name returns provider registered under default" do
+      @registry.register(Cogs::Agent::Providers::Claude, :claude)
+
+      assert_equal Cogs::Agent::Providers::Claude, @registry.fetch(nil)
+    end
+
+    test "fetch with nil name uses custom default when set" do
+      provider = Class.new(Cogs::Agent::Provider)
+      provider.define_singleton_method(:name) { "CustomProvider" }
+
+      @registry.register(provider, :custom)
+      @registry.default = :custom
+
+      assert_equal provider, @registry.fetch(nil)
+    end
+
+    test "key? returns true for registered provider" do
+      @registry.register(Cogs::Agent::Providers::Claude)
+
+      assert @registry.key?(:claude)
+    end
+
+    test "key? returns false for unregistered provider" do
+      refute @registry.key?(:nonexistent)
+    end
+  end
+end

--- a/test/roast/system_cogs/map_test.rb
+++ b/test/roast/system_cogs/map_test.rb
@@ -9,7 +9,7 @@ module Roast
         @registry = Cog::Registry.new
         @registry.use(TestCogSupport::TestCog)
 
-        @config_manager = ConfigManager.new(@registry, [])
+        @config_manager = ConfigManager.new(@registry, [], ProviderRegistry.new)
         @config_manager.prepare!
 
         @workflow_context = WorkflowContext.new(
@@ -359,7 +359,7 @@ module Roast
 
       test "map executes in parallel when configured" do
         config_proc = proc { map { parallel! } }
-        config_manager = ConfigManager.new(@registry, [config_proc])
+        config_manager = ConfigManager.new(@registry, [config_proc], ProviderRegistry.new)
         config_manager.prepare!
 
         exec_procs = {


### PR DESCRIPTION
This will allow us to support agents other than Claude Code, though that's not implemented yet.

Primarily, what this does is move provider definitions to a registry on the workflow, rather than a hardcoded array. Roast will continue to define a select set of default providers  such as Claude Code (and opencode, soon). Third parties can add their own definitions in gems, and these providers will be pulled in on the necessary workflows via `use` statements (not implemented yet, coming next).