### PR TITLE
Add example for defining new agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ The tutorial covers:
 7. Processing collections
 8. Iterative workflows
 9. Async execution
+10. Custom cogs
+11. Custom agent providers
 
 ## Documentation
 
-- [Tutorial](https://github.com/Shopify/roast/blob/main/tutorial/README.md) - Step-by-step guide with examples
+- [Tutorial](https://github.com/Shopify/roast/blob/main/tutorial/README.md) - Step-by-step guide covering workflows, configuration, control flow, and extensibility
 - [Workflow Examples](https://github.com/Shopify/roast/tree/main/examples) - Toy workflows that demonstrate all functional patterns, use for end-to-end test
 
 ## Documentation & References
@@ -121,6 +123,9 @@ class and method comments on the relevant classes.
     * [Chat cog configuration: `chat/config.rb`](https://github.com/Shopify/roast/blob/main/lib/roast/dsl/cogs/chat/config.rb)
     * [Cmd cog configuration: `cmd/config.rb`](https://github.com/Shopify/roast/blob/main/lib/roast/dsl/cogs/cmd.rb)
     * [Map cog configuration: `map.rb`](https://github.com/Shopify/roast/blob/main/lib/roast/dsl/system_cogs/map.rb)
+* __Agent Providers__
+    * [Agent provider base class: `provider.rb`](https://github.com/Shopify/roast/blob/main/lib/roast/cogs/agent/provider.rb)
+    * [Provider registry: `provider_registry.rb`](https://github.com/Shopify/roast/blob/main/lib/roast/provider_registry.rb)
 * __Execution__
     * [General Execution block: `execution-context.rbi`](https://github.com/Shopify/roast/blob/main/sorbet/rbi/shims/lib/roast/dsl/execution_context.rbi)
 * __Input and Output__

--- a/examples/demo/simple_external_agent.rb
+++ b/examples/demo/simple_external_agent.rb
@@ -1,0 +1,17 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::Workflow
+
+use "cool_agent", from: "plugin_gem_example"
+
+config do
+  agent do
+    provider :cool_agent
+    show_prompt!
+  end
+end
+
+execute do
+  agent { "What is the world's largest lake?" }
+end

--- a/examples/plugin-gem-example/lib/cool_agent.rb
+++ b/examples/plugin-gem-example/lib/cool_agent.rb
@@ -1,0 +1,22 @@
+# typed: true
+# frozen_string_literal: true
+
+class CoolAgent < Roast::Cogs::Agent::Provider
+  class Output < Roast::Cogs::Agent::Output
+    def stats
+      Roast::Cogs::Agent::Stats.new
+    end
+
+    def response
+      "I think lakes are cool"
+    end
+
+    def success
+      true
+    end
+  end
+
+  def invoke(input)
+    return Output.new
+  end
+end

--- a/examples/plugin-gem-example/lib/plugin_gem_example.rb
+++ b/examples/plugin-gem-example/lib/plugin_gem_example.rb
@@ -3,3 +3,4 @@
 
 require "simple"
 require "other"
+require "cool_agent"

--- a/lib/roast/cogs/agent.rb
+++ b/lib/roast/cogs/agent.rb
@@ -49,9 +49,7 @@ module Roast
       def execute(input)
         puts "[USER PROMPT] #{input.valid_prompt!}" if config.show_prompt?
         output = config.values[:provider].invoke(input)
-        # NOTE: If progress is displayed, the agent's response will always be the last progress message,
-        # so showing it again is duplicative.
-        puts "[AGENT RESPONSE] #{output.response}" if config.show_response? && !config.show_progress?
+        puts "[AGENT RESPONSE] #{output.response}" if config.show_response?
         puts "[AGENT STATS] #{output.stats}" if config.show_stats?
         puts "Session ID: #{output.session}" if config.show_stats?
         output

--- a/lib/roast/cogs/agent/providers/claude/claude_invocation.rb
+++ b/lib/roast/cogs/agent/providers/claude/claude_invocation.rb
@@ -148,9 +148,6 @@ module Roast
 
               @result.session = message.session_id if message.session_id.present?
 
-              formatted_message = message.format(@context)
-              puts formatted_message if formatted_message.present? && @show_progress
-
               unless message.unparsed.blank?
                 # TODO: do something better with unhandled data so we can improve the parser
                 Roast::Log.warn("Unhandled data in Claude #{message.type} message:")

--- a/test/examples/functional/roast_examples_test.rb
+++ b/test/examples/functional/roast_examples_test.rb
@@ -305,6 +305,34 @@ module Examples
         assert_empty lines
       end
 
+      test "simple_external_cog.rb workflow runs successfully" do
+        $LOAD_PATH.unshift(File.expand_path("examples/plugin-gem-example/lib", Dir.pwd))
+        stdout, stderr = in_sandbox :simple_external_cog do
+          Roast::Workflow.from_file("examples/demo/simple_external_cog.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          I'm a cog!
+          I'm a different cog!
+          I'm a workflow-specific cog!
+        EOF
+        assert_equal expected_stdout, stdout
+      ensure
+        $LOAD_PATH.delete(File.expand_path("examples/plugin-gem-example/lib", Dir.pwd))
+      end
+
+      test "simple_external_agent.rb workflow runs successfully" do
+        $LOAD_PATH.unshift(File.expand_path("examples/plugin-gem-example/lib", Dir.pwd))
+        stdout, stderr = in_sandbox :simple_external_agent do
+          Roast::Workflow.from_file("examples/demo/simple_external_agent.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        assert_includes stdout, "[USER PROMPT] What is the world's largest lake?"
+        assert_includes stdout, "[AGENT RESPONSE] I think lakes are cool"
+      ensure
+        $LOAD_PATH.delete(File.expand_path("examples/plugin-gem-example/lib", Dir.pwd))
+      end
+
       test "simple_agent.rb workflow runs successfully" do
         skip "work in progress - refactoring the agent cog"
         # Mock the claude CLI response

--- a/tutorial/10_custom_cogs/README.md
+++ b/tutorial/10_custom_cogs/README.md
@@ -1,0 +1,455 @@
+![roast-horiz-logo](https://github.com/user-attachments/assets/f9b1ace2-5478-4f4a-ac8e-5945ed75c5b4)
+
+# Chapter 10: Custom Cogs
+
+🔥 _version 1.0 feature preview_ 🔥
+
+## Overview
+
+Roast's built-in cogs (`chat`, `agent`, `cmd`, `ruby`, `map`, `repeat`, `call`) cover many common use cases, but sometimes you need specialized functionality. Custom cogs let you:
+
+- **Integrate external services** - API clients, databases, cloud services
+- **Reuse complex logic** - Multi-step operations that you use across workflows
+- **Add domain-specific operations** - Business logic specific to your organization
+- **Create testable components** - Isolated units with clear inputs and outputs
+- **Package and share functionality** - As gems or local files
+
+This chapter teaches you how to create custom cogs that seamlessly integrate with Roast workflows.
+
+## When to Create a Custom Cog
+
+Create custom cogs when you need to:
+
+✅ **Wrap an external API or service** that you call frequently
+✅ **Encapsulate multi-step logic** that appears in multiple workflows
+✅ **Add organization-specific operations** (e.g., deploy to your infrastructure)
+✅ **Create reusable, testable components** with clear interfaces
+
+❌ Don't create a custom cog for one-off operations - use the `ruby` cog instead
+❌ Don't create a cog just to wrap a single method call - keep it simple
+
+## Anatomy of a Cog
+
+Every cog has three main components:
+
+```ruby
+class MyCog < Roast::Cog
+  # 1. Config - Configuration options (optional)
+  class Config < Roast::Cog::Config
+    attr_accessor :timeout
+
+    def initialize
+      @timeout = 30
+    end
+  end
+
+  # 2. Input - Defines what data the cog accepts
+  class Input < Roast::Cog::Input
+    attr_accessor :query
+
+    def validate!
+      raise "Query is required" if query.nil? || query.empty?
+      true
+    end
+  end
+
+  # 3. Output - Defines what data the cog returns (optional)
+  class Output < Roast::Cog::Output
+    attr_accessor :result, :count
+  end
+
+  # Execute method - The cog's main logic
+  def execute(input)
+    # Access config via @config
+    # Process input
+    # Return output (optional)
+
+    Output.new.tap do |output|
+      output.result = process(input.query)
+      output.count = output.result.length
+    end
+  end
+end
+```
+
+### Config (Optional)
+
+The `Config` class defines configuration options that users can set in their workflows:
+
+```ruby
+class Config < Roast::Cog::Config
+  attr_accessor :timeout, :retries
+
+  def initialize
+    @timeout = 30
+    @retries = 3
+  end
+end
+```
+
+Users configure it in their workflow:
+
+```ruby
+config do
+  my_cog do
+    timeout 60
+    retries 5
+  end
+end
+```
+
+### Input (Required)
+
+The `Input` class defines what data the cog accepts and validation rules:
+
+```ruby
+class Input < Roast::Cog::Input
+  attr_accessor :query, :limit
+
+  def validate!
+    raise "Query is required" if query.nil? || query.empty?
+    raise "Limit must be positive" if limit && limit <= 0
+    true
+  end
+end
+```
+
+### Output (Optional)
+
+The `Output` class defines what data the cog returns:
+
+```ruby
+class Output < Roast::Cog::Output
+  attr_accessor :results, :count, :success
+end
+```
+
+If you don't define an Output class, the cog's return value becomes the output.
+
+### Execute Method (Required)
+
+The `execute` method contains the cog's main logic:
+
+```ruby
+def execute(input)
+  # Access configuration
+  timeout = @config.timeout
+
+  # Process input
+  results = fetch_data(input.query, timeout: timeout)
+
+  # Return output
+  Output.new.tap do |output|
+    output.results = results
+    output.count = results.length
+    output.success = true
+  end
+end
+```
+
+## Simple Custom Cog Example
+
+Here's the simplest possible custom cog:
+
+```ruby
+# cogs/simple.rb
+class Simple < Roast::Cog
+  class Input < Roast::Cog::Input
+    def validate!
+      true
+    end
+  end
+
+  def execute(input)
+    puts "I'm a cog!"
+  end
+end
+```
+
+See the complete example: [`examples/plugin-gem-example/lib/simple.rb`](https://github.com/Shopify/roast/tree/main/examples/plugin-gem-example/lib/simple.rb)
+
+## Using Custom Cogs in Workflows
+
+### From a Gem
+
+If you've packaged your cog in a gem:
+
+```ruby
+# workflow.rb
+use "simple", from: "my_gem"
+
+execute do
+  simple  # Invokes Simple cog
+end
+```
+
+### From Local Files
+
+For project-specific cogs:
+
+```ruby
+# workflow.rb
+use "local"  # Loads from ./cogs/local.rb
+
+execute do
+  local  # Invokes Local cog
+end
+```
+
+The `use` directive automatically loads `.rb` files from the `cogs/` directory relative to your workflow file.
+
+### Loading Multiple Cogs
+
+```ruby
+# Load multiple cogs from a gem
+use ["simple", "other"], from: "my_gem"
+
+# Load namespaced cogs
+use "MyCogNamespace::Other", from: "my_gem"
+
+# Mix gem and local cogs
+use ["simple", "other"], from: "my_gem"
+use "local"
+
+execute do
+  simple
+  other
+  local
+end
+```
+
+## Cog Naming Conventions
+
+The cog method name is automatically derived from the class name using `underscore`:
+
+- `Simple` → `simple`
+- `DatabaseQuery` → `database_query`
+- `MyCustomCog` → `my_custom_cog`
+- `MyCogNamespace::Other` → `other` (namespace is stripped)
+
+## File Structure for Local Cogs
+
+Place local cogs in a `cogs/` directory relative to your workflow:
+
+```
+my_project/
+├── workflow.rb
+└── cogs/
+    ├── local.rb          # Simple cog
+    └── database_query.rb # More complex cog
+```
+
+Each file should define one cog class matching the filename.
+
+## Complete Custom Cog Example
+
+Let's build a more realistic example - a cog that fetches weather data:
+
+```ruby
+# cogs/weather.rb
+require "net/http"
+require "json"
+
+class Weather < Roast::Cog
+  class Config < Roast::Cog::Config
+    attr_accessor :api_key, :timeout
+
+    def initialize
+      @timeout = 10
+    end
+  end
+
+  class Input < Roast::Cog::Input
+    attr_accessor :city
+
+    def validate!
+      raise "City is required" if city.nil? || city.empty?
+      true
+    end
+  end
+
+  class Output < Roast::Cog::Output
+    attr_accessor :temperature, :conditions, :city
+  end
+
+  def execute(input)
+    weather_data = fetch_weather(input.city)
+
+    Output.new.tap do |output|
+      output.city = input.city
+      output.temperature = weather_data["temp"]
+      output.conditions = weather_data["conditions"]
+    end
+  end
+
+  private
+
+  def fetch_weather(city)
+    uri = URI("https://api.weather.example.com/v1/weather?city=#{city}&key=#{@config.api_key}")
+    response = Net::HTTP.get_response(uri)
+    JSON.parse(response.body)
+  end
+end
+```
+
+Use it in a workflow:
+
+```ruby
+# workflow.rb
+use "weather"
+
+config do
+  weather do
+    api_key ENV["WEATHER_API_KEY"]
+  end
+end
+
+execute do
+  weather do
+    city "San Francisco"
+  end
+
+  chat do
+    <<~PROMPT
+      The weather in #{weather!.city} is #{weather!.temperature}°F and #{weather!.conditions}.
+      Should I bring an umbrella?
+    PROMPT
+  end
+end
+```
+
+## Namespaced Cogs
+
+For better organization, you can namespace your cogs:
+
+```ruby
+# lib/other.rb
+module MyCogNamespace
+  class Other < Roast::Cog
+    class Input < Roast::Cog::Input
+      def validate!
+        true
+      end
+    end
+
+    def execute(input)
+      puts "I'm a namespaced cog!"
+    end
+  end
+end
+```
+
+Use the full namespace when loading:
+
+```ruby
+use "MyCogNamespace::Other", from: "my_gem"
+
+execute do
+  other  # Method name is derived from class name (namespace stripped)
+end
+```
+
+See the complete example: [`examples/plugin-gem-example/lib/other.rb`](https://github.com/Shopify/roast/tree/main/examples/plugin-gem-example/lib/other.rb)
+
+## Working Examples
+
+The Roast repository includes complete working examples of custom cogs:
+
+### Simple Cog
+- **Implementation:** [`examples/plugin-gem-example/lib/simple.rb`](https://github.com/Shopify/roast/tree/main/examples/plugin-gem-example/lib/simple.rb)
+- Shows the minimal cog structure
+
+### Namespaced Cog
+- **Implementation:** [`examples/plugin-gem-example/lib/other.rb`](https://github.com/Shopify/roast/tree/main/examples/plugin-gem-example/lib/other.rb)
+- Shows how to organize cogs in namespaces
+
+### Local Cog
+- **Implementation:** [`examples/demo/cogs/local.rb`](https://github.com/Shopify/roast/tree/main/examples/demo/cogs/local.rb)
+- Shows a project-specific cog loaded from local files
+
+### Workflow Using Custom Cogs
+- **Workflow:** [`examples/demo/simple_external_cog.rb`](https://github.com/Shopify/roast/tree/main/examples/demo/simple_external_cog.rb)
+- Demonstrates loading and using multiple custom cogs (from gem and local)
+
+Run the example:
+```bash
+cd examples/demo
+bin/roast execute simple_external_cog.rb
+```
+
+## Creating a Gem with Custom Cogs
+
+To share your custom cogs across projects, package them as a gem.
+
+### Basic Gem Structure
+
+```
+my-roast-cogs/
+├── lib/
+│   ├── my_roast_cogs.rb       # Main gem file
+│   ├── simple.rb               # Custom cog
+│   ├── weather.rb              # Another cog
+│   └── database_query.rb       # Yet another cog
+├── my-roast-cogs.gemspec       # Gem specification
+└── Gemfile
+```
+
+### Gem Specification
+
+```ruby
+# my-roast-cogs.gemspec
+Gem::Specification.new do |spec|
+  spec.name          = "my-roast-cogs"
+  spec.version       = "1.0.0"
+  spec.authors       = ["Your Name"]
+  spec.summary       = "Custom Roast cogs for my organization"
+  spec.description   = "A collection of reusable Roast cogs"
+
+  spec.files         = Dir["lib/**/*.rb"]
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "roast-ai", "~> 1.0"
+end
+```
+
+### Using Your Gem
+
+```ruby
+# Gemfile
+gem "my-roast-cogs", path: "../my-roast-cogs"
+# or for published gems:
+# gem "my-roast-cogs", "~> 1.0"
+```
+
+```ruby
+# workflow.rb
+use ["simple", "weather", "database_query"], from: "my_roast_cogs"
+
+execute do
+  weather { city "Portland" }
+  database_query { query "SELECT * FROM users LIMIT 10" }
+  simple
+end
+```
+
+### Complete Gem Example
+
+See the complete example gem in the Roast repository:
+
+- **Gem structure:** [`examples/plugin-gem-example/`](https://github.com/Shopify/roast/tree/main/examples/plugin-gem-example/)
+- **Gemspec:** [`examples/plugin-gem-example/plugin-gem-example.gemspec`](https://github.com/Shopify/roast/tree/main/examples/plugin-gem-example/plugin-gem-example.gemspec)
+- **Cog implementations:** [`examples/plugin-gem-example/lib/`](https://github.com/Shopify/roast/tree/main/examples/plugin-gem-example/lib/)
+
+## Key Takeaways
+
+- **Custom cogs extend Roast** with domain-specific operations and integrations
+- **Three main components:** Config (optional), Input (required), Output (optional)
+- **Execute method** contains the main logic
+- **Use `use` directive** to load from gems or local files
+- **Automatic naming** converts class names to method names (e.g., `Weather` → `weather`)
+- **Local cogs** in `cogs/` directory for project-specific functionality
+- **Package as gems** to share across projects and teams
+
+## What's Next?
+
+Continue to [Chapter 11: Custom Providers](../11_custom_providers/README.md) to learn how to create custom agent providers.

--- a/tutorial/11_custom_providers/README.md
+++ b/tutorial/11_custom_providers/README.md
@@ -1,0 +1,516 @@
+![roast-horiz-logo](https://github.com/user-attachments/assets/f9b1ace2-5478-4f4a-ac8e-5945ed75c5b4)
+
+# Chapter 11: Custom Agent Providers
+
+🔥 _version 1.0 feature preview_ 🔥
+
+## Overview
+
+The `agent` cog uses a provider system to execute agent tasks. By default, it uses the Claude Code CLI provider, but you can create custom providers to:
+
+- **Integrate alternative agent backends** - Use different AI coding agents
+- **Create mock agents for testing** - Simulate agent behavior without API calls
+- **Wrap proprietary agent services** - Integrate your organization's internal tools
+- **Add custom agent logic** - Pre-process prompts, post-process responses, etc.
+
+This chapter teaches you how to create custom agent providers that seamlessly work with the `agent` cog.
+
+## When to Create a Custom Provider
+
+Create custom agent providers when you need to:
+
+✅ **Integrate a different agent backend** (e.g., Cursor, Aider, custom agents)
+✅ **Create mock agents for testing** workflows without API costs
+✅ **Wrap proprietary agent services** specific to your organization
+✅ **Add custom logic** around agent calls (logging, monitoring, retries)
+
+## How Agent Providers Work
+
+The built-in `agent` cog doesn't directly execute agent tasks. Instead, it:
+
+1. Receives a prompt from the workflow
+2. Passes the prompt to the configured **provider**
+3. The provider executes the agent task (via API, CLI, etc.)
+4. Returns an **Output** with the agent's response
+
+```
+Workflow → agent cog → Provider → Agent Backend
+                          ↓
+                       Output
+```
+
+The default provider uses the Claude Code CLI, but you can replace it with any custom implementation.
+
+## Anatomy of a Provider
+
+Every agent provider has two main components:
+
+```ruby
+class MyAgent < Roast::Cogs::Agent::Provider
+  # 1. Output class - Defines what the provider returns
+  class Output < Roast::Cogs::Agent::Output
+    def stats
+      # Return agent statistics (tokens used, etc.)
+      Roast::Cogs::Agent::Stats.new(
+        input_tokens: 100,
+        output_tokens: 50
+      )
+    end
+
+    def response
+      # Return the agent's text response
+      "I completed the task successfully"
+    end
+
+    def success
+      # Return whether the agent task succeeded
+      true
+    end
+  end
+
+  # 2. invoke method - The provider's main logic
+  def invoke(input)
+    # input.valid_prompt! gives you the user's prompt
+
+    # Call your agent backend (API, CLI, etc.)
+    result = call_agent_backend(input.valid_prompt!)
+
+    # Return an Output instance
+    Output.new
+  end
+end
+```
+
+### Output Class (Required)
+
+The `Output` class must inherit from `Roast::Cogs::Agent::Output` and implement three methods:
+
+```ruby
+class Output < Roast::Cogs::Agent::Output
+  def stats
+    # Return statistics about the agent execution
+    Roast::Cogs::Agent::Stats.new(
+      input_tokens: @input_tokens,
+      output_tokens: @output_tokens
+    )
+  end
+
+  def response
+    # Return the agent's text response
+    @response_text
+  end
+
+  def success
+    # Return true if the agent task succeeded, false otherwise
+    @success
+  end
+end
+```
+
+**Key methods:**
+
+- **`stats`** - Returns a `Roast::Cogs::Agent::Stats` object with token counts and other metrics
+- **`response`** - Returns the agent's text response as a string
+- **`success`** - Returns a boolean indicating success or failure
+
+### invoke Method (Required)
+
+The `invoke` method is called when the agent cog executes:
+
+```ruby
+def invoke(input)
+  # Get the user's prompt
+  prompt = input.valid_prompt!
+
+  # Call your agent backend
+  # This could be an API call, CLI command, etc.
+  result = call_my_agent_service(prompt)
+
+  # Create and return an Output instance
+  Output.new.tap do |output|
+    output.response_text = result[:response]
+    output.success = result[:success]
+    output.input_tokens = result[:input_tokens]
+    output.output_tokens = result[:output_tokens]
+  end
+end
+```
+
+## Simple Custom Provider Example
+
+Here's the simplest possible custom agent provider:
+
+```ruby
+# lib/cool_agent.rb
+class CoolAgent < Roast::Cogs::Agent::Provider
+  class Output < Roast::Cogs::Agent::Output
+    def stats
+      Roast::Cogs::Agent::Stats.new
+    end
+
+    def response
+      "I think lakes are cool"
+    end
+
+    def success
+      true
+    end
+  end
+
+  def invoke(input)
+    # input.valid_prompt! gives you the user's prompt
+    # For this simple example, we ignore it and return a canned response
+    Output.new
+  end
+end
+```
+
+This provider always returns the same response, regardless of the prompt. It's useful for testing or demonstrations.
+
+See the complete example: [`examples/plugin-gem-example/lib/cool_agent.rb`](https://github.com/Shopify/roast/tree/main/examples/plugin-gem-example/lib/cool_agent.rb)
+
+## Using Custom Providers in Workflows
+
+### From a Gem
+
+If you've packaged your provider in a gem:
+
+```ruby
+# workflow.rb
+use "cool_agent", from: "my_gem"
+
+config do
+  agent do
+    provider :cool_agent
+  end
+end
+
+execute do
+  agent { "What is the world's largest lake?" }
+end
+```
+
+### From Local Files
+
+For project-specific providers:
+
+```ruby
+# workflow.rb
+use "cool_agent"  # Loads from ./cogs/cool_agent.rb
+
+config do
+  agent do
+    provider :cool_agent
+  end
+end
+
+execute do
+  agent { "What is the world's largest lake?" }
+end
+```
+
+The `use` directive automatically loads `.rb` files from the `cogs/` directory relative to your workflow file.
+
+## Provider Naming Conventions
+
+The provider name is automatically derived from the class name using `underscore`:
+
+- `CoolAgent` → `:cool_agent`
+- `MyCustomProvider` → `:my_custom_provider`
+- `AiderAgent` → `:aider_agent`
+
+Use the symbol version when configuring the agent cog:
+
+```ruby
+config do
+  agent do
+    provider :cool_agent  # Symbol derived from class name
+  end
+end
+```
+
+## Complete Custom Provider Example
+
+Let's build a more realistic example - a provider that calls a hypothetical agent API:
+
+```ruby
+# lib/api_agent.rb
+require "net/http"
+require "json"
+
+class ApiAgent < Roast::Cogs::Agent::Provider
+  class Output < Roast::Cogs::Agent::Output
+    attr_accessor :response_text, :success_flag, :input_tokens, :output_tokens
+
+    def stats
+      Roast::Cogs::Agent::Stats.new(
+        input_tokens: @input_tokens || 0,
+        output_tokens: @output_tokens || 0
+      )
+    end
+
+    def response
+      @response_text
+    end
+
+    def success
+      @success_flag
+    end
+  end
+
+  def invoke(input)
+    prompt = input.valid_prompt!
+
+    # Call the agent API
+    result = call_agent_api(prompt)
+
+    # Create output
+    Output.new.tap do |output|
+      output.response_text = result["response"]
+      output.success_flag = result["success"]
+      output.input_tokens = result["usage"]["input_tokens"]
+      output.output_tokens = result["usage"]["output_tokens"]
+    end
+  end
+
+  private
+
+  def call_agent_api(prompt)
+    uri = URI("https://agent-api.example.com/v1/execute")
+    request = Net::HTTP::Post.new(uri, "Content-Type" => "application/json")
+    request.body = { prompt: prompt, api_key: ENV["AGENT_API_KEY"] }.to_json
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(request)
+    end
+
+    JSON.parse(response.body)
+  end
+end
+```
+
+Use it in a workflow:
+
+```ruby
+# workflow.rb
+use "api_agent"
+
+config do
+  agent do
+    provider :api_agent
+  end
+end
+
+execute do
+  agent { "Analyze this codebase and suggest improvements" }
+
+  chat do
+    "Summarize these improvements for stakeholders:\n\n#{agent!.response}"
+  end
+end
+```
+
+## Mock Provider for Testing
+
+Custom providers are useful for testing workflows without making real agent calls:
+
+```ruby
+# lib/mock_agent.rb
+class MockAgent < Roast::Cogs::Agent::Provider
+  class Output < Roast::Cogs::Agent::Output
+    attr_accessor :prompt
+
+    def stats
+      Roast::Cogs::Agent::Stats.new(
+        input_tokens: prompt.length / 4,  # Rough estimate
+        output_tokens: 50
+      )
+    end
+
+    def response
+      # Return a mock response based on the prompt
+      if prompt.include?("test")
+        "All tests passed successfully!"
+      elsif prompt.include?("analyze")
+        "Analysis complete. Found 3 potential issues."
+      else
+        "Task completed successfully."
+      end
+    end
+
+    def success
+      true
+    end
+  end
+
+  def invoke(input)
+    Output.new.tap do |output|
+      output.prompt = input.valid_prompt!
+    end
+  end
+end
+```
+
+Use it for testing:
+
+```ruby
+# test_workflow.rb
+use "mock_agent"
+
+config do
+  agent do
+    provider :mock_agent
+  end
+end
+
+execute do
+  agent { "Run all tests in the test/ directory" }
+
+  ruby do
+    puts "Agent response: #{agent!.response}"
+    # Output: "Agent response: All tests passed successfully!"
+  end
+end
+```
+
+## Working Examples
+
+The Roast repository includes a complete working example of a custom agent provider:
+
+### Simple Agent Provider
+- **Implementation:** [`examples/plugin-gem-example/lib/cool_agent.rb`](https://github.com/Shopify/roast/tree/main/examples/plugin-gem-example/lib/cool_agent.rb)
+- Shows the minimal provider structure
+
+### Workflow Using Custom Provider
+- **Workflow:** [`examples/demo/simple_external_agent.rb`](https://github.com/Shopify/roast/tree/main/examples/demo/simple_external_agent.rb)
+- Demonstrates loading and using a custom agent provider
+
+Run the example:
+```bash
+cd examples/demo
+bin/roast execute simple_external_agent.rb
+```
+
+## Creating a Gem with Custom Providers
+
+To share your custom providers across projects, package them as a gem.
+
+### Basic Gem Structure
+
+```
+my-roast-agents/
+├── lib/
+│   ├── my_roast_agents.rb      # Main gem file
+│   ├── cool_agent.rb           # Custom provider
+│   ├── api_agent.rb            # Another provider
+│   └── mock_agent.rb           # Mock provider for testing
+├── my-roast-agents.gemspec     # Gem specification
+└── Gemfile
+```
+
+### Gem Specification
+
+```ruby
+# my-roast-agents.gemspec
+Gem::Specification.new do |spec|
+  spec.name          = "my-roast-agents"
+  spec.version       = "1.0.0"
+  spec.authors       = ["Your Name"]
+  spec.summary       = "Custom Roast agent providers"
+  spec.description   = "Alternative agent backends for Roast workflows"
+
+  spec.files         = Dir["lib/**/*.rb"]
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "roast-ai", "~> 1.0"
+end
+```
+
+### Using Your Gem
+
+```ruby
+# Gemfile
+gem "my-roast-agents", path: "../my-roast-agents"
+# or for published gems:
+# gem "my-roast-agents", "~> 1.0"
+```
+
+```ruby
+# workflow.rb
+use "api_agent", from: "my_roast_agents"
+
+config do
+  agent do
+    provider :api_agent
+  end
+end
+
+execute do
+  agent { "What is the world's largest lake?" }
+end
+```
+
+### Combining Providers and Cogs in One Gem
+
+You can include both custom cogs and custom providers in the same gem:
+
+```
+my-roast-extensions/
+├── lib/
+│   ├── my_roast_extensions.rb
+│   ├── cool_agent.rb          # Agent provider
+│   ├── api_agent.rb           # Another provider
+│   ├── weather.rb             # Custom cog
+│   └── database_query.rb      # Another custom cog
+├── my-roast-extensions.gemspec
+└── Gemfile
+```
+
+See the complete example: [`examples/plugin-gem-example/`](https://github.com/Shopify/roast/tree/main/examples/plugin-gem-example/)
+
+## Configuring Providers Per Agent Cog
+
+You can use different providers for different agent cogs in the same workflow:
+
+```ruby
+use "cool_agent", from: "my_gem"
+use "api_agent", from: "my_gem"
+
+config do
+  # Default provider for all agent cogs
+  agent do
+    provider :cool_agent
+  end
+
+  # Override for specific agent cogs
+  agent(/analysis/) do
+    provider :api_agent
+  end
+end
+
+execute do
+  agent(:review) { "Review this code" }       # Uses :cool_agent
+  agent(:analysis) { "Deep analysis needed" } # Uses :api_agent
+end
+```
+
+## Key Takeaways
+
+- **Custom providers** integrate alternative agent backends with the `agent` cog
+- **Two main components:** Output class (required) and invoke method (required)
+- **Output class** must implement `stats`, `response`, and `success` methods
+- **invoke method** receives the prompt and returns an Output instance
+- **Use `use` directive** to load providers from gems or local files
+- **Automatic naming** converts class names to provider symbols (e.g., `CoolAgent` → `:cool_agent`)
+- **Mock providers** are useful for testing workflows without API calls
+- **Package as gems** to share providers across projects and teams
+
+## What's Next?
+
+You've completed the Roast tutorial! Here are some next steps:
+
+- Explore the [examples directory](https://github.com/Shopify/roast/tree/main/examples) for more real-world patterns
+- Check out the [source code documentation](https://github.com/Shopify/roast/tree/main/lib/roast/dsl) for advanced features
+- Build your own custom extensions and share them with the community
+
+Happy building! 🔥

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -218,5 +218,50 @@ that can run concurrently.
 
 ---
 
+### Chapter 10: Custom Cogs
+
+Learn how to create custom cogs to extend Roast with domain-specific operations and integrations.
+
+**You'll learn:**
+
+- When to create custom cogs vs using built-in cogs
+- Anatomy of a cog (Config, Input, Output, execute)
+- Creating simple and complex custom cogs
+- Loading cogs from gems vs local files
+- Cog naming conventions and file structure
+- Packaging custom cogs as reusable gems
+
+**Examples referenced:**
+
+- `examples/demo/simple_external_cog.rb` - Using custom cogs from gems and local files
+- `examples/plugin-gem-example/lib/simple.rb` - Simple custom cog
+- `examples/plugin-gem-example/lib/other.rb` - Namespaced custom cog
+- `examples/demo/cogs/local.rb` - Project-specific local cog
+- `examples/plugin-gem-example/` - Complete gem structure
+
+---
+
+### Chapter 11: Custom Agent Providers
+
+Learn how to create custom agent providers to integrate alternative agent backends with the `agent` cog.
+
+**You'll learn:**
+
+- How the agent provider system works
+- When to create custom providers
+- Anatomy of a provider (Output class, invoke method)
+- Creating providers for different agent backends
+- Mock providers for testing workflows
+- Loading providers from gems vs local files
+- Packaging custom providers as reusable gems
+
+**Examples referenced:**
+
+- `examples/demo/simple_external_agent.rb` - Using a custom agent provider
+- `examples/plugin-gem-example/lib/cool_agent.rb` - Simple custom provider
+- `examples/plugin-gem-example/` - Complete gem structure
+
+---
+
 Let's get started with
 [Chapter 1](https://github.com/Shopify/roast/blob/edge/tutorial/01_your_first_workflow/README.md)!


### PR DESCRIPTION
This is the most minimal possible agent. This one always responds with
the same thing and always succeeds. This should make it easier to
understand how to implement providers, as the Claude version is quite
complex.

Also we decided we don't care about duplicated agent responses in Claude
and removed some special casing.