### PR TITLE
Remove redundant array from use syntax

### DIFF
--- a/examples/demo/multiloading.rb
+++ b/examples/demo/multiloading.rb
@@ -1,0 +1,13 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::Workflow
+
+use "simple", "MyCogNamespace::Other", from: "plugin_gem_example"
+use "local"
+
+execute do
+  simple
+  other
+  local
+end

--- a/examples/demo/simple_external_cog.rb
+++ b/examples/demo/simple_external_cog.rb
@@ -8,7 +8,7 @@ use "MyCogNamespace::Other", from: "plugin_gem_example"
 use "local"
 
 # Use multiple cogs
-# use ["simple", "other"], from: "plugin_gem_example"
+# use "simple", "other", from: "plugin_gem_example"
 
 execute do
   simple

--- a/lib/roast/workflow.rb
+++ b/lib/roast/workflow.rb
@@ -7,7 +7,7 @@ module Roast
     class WorkflowNotPreparedError < WorkflowError; end
     class WorkflowAlreadyPreparedError < WorkflowError; end
     class WorkflowAlreadyStartedError < WorkflowError; end
-    class InvalidCogReference < WorkflowError; end
+    class InvalidLoadableReference < WorkflowError; end
 
     class << self
       #: (String | Pathname, WorkflowParams) -> void
@@ -94,18 +94,26 @@ module Roast
       (@execution_procs[scope] ||= []) << block
     end
 
-    def use(cogs = [], from: nil)
-      require from if from
+    def use(*loadables, from: nil)
+      if from
+        # Load gem - no special requires, gem must handle everything
+        require from
+      else
+        # Load from local path
+        loadables.each do |cog_name|
+          require @workflow_path.realdirpath.dirname.join("cogs/#{cog_name}").to_s
+        end
+      end
+      loadables.each do |name|
+        class_name_string = name.camelize
+        raise InvalidLoadableReference, "#{name} class not found" unless Object.const_defined?(class_name_string)
 
-      Array.wrap(cogs).each do |cog_name|
-        path = @workflow_path.realdirpath.dirname.join("cogs/#{cog_name}")
-        require path.to_s if from.nil?
-
-        cog_class_name = cog_name.camelize
-        raise InvalidCogReference, "Expected #{cog_class_name} class, not found in #{path}" unless Object.const_defined?(cog_class_name)
-
-        cog_class = cog_class_name.constantize # rubocop:disable Sorbet/ConstantsFromStrings
-        @cog_registry.use(cog_class)
+        class_name = class_name_string.constantize # rubocop:disable Sorbet/ConstantsFromStrings
+        if class_name < Roast::Cog
+          @cog_registry.use(class_name)
+        else
+          raise InvalidLoadableReference, "#{class_name_string} is not a subclass of a usable Roast primitive (cog, provider)."
+        end
       end
     end
 

--- a/test/examples/functional/roast_examples_test.rb
+++ b/test/examples/functional/roast_examples_test.rb
@@ -305,6 +305,38 @@ module Examples
         assert_empty lines
       end
 
+      test "simple_external_cog.rb workflow runs successfully" do
+        $LOAD_PATH.unshift(File.expand_path("examples/plugin-gem-example/lib", Dir.pwd))
+        stdout, stderr = in_sandbox :simple_external_cog do
+          Roast::Workflow.from_file("examples/demo/simple_external_cog.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          I'm a cog!
+          I'm a different cog!
+          I'm a workflow-specific cog!
+        EOF
+        assert_equal expected_stdout, stdout
+      ensure
+        $LOAD_PATH.delete(File.expand_path("examples/plugin-gem-example/lib", Dir.pwd))
+      end
+
+      test "multiloading.rb workflow runs successfully" do
+        $LOAD_PATH.unshift(File.expand_path("examples/plugin-gem-example/lib", Dir.pwd))
+        stdout, stderr = in_sandbox :multiloading do
+          Roast::Workflow.from_file("examples/demo/multiloading.rb", EMPTY_PARAMS)
+        end
+        assert_empty stderr
+        expected_stdout = <<~EOF
+          I'm a cog!
+          I'm a different cog!
+          I'm a workflow-specific cog!
+        EOF
+        assert_equal expected_stdout, stdout
+      ensure
+        $LOAD_PATH.delete(File.expand_path("examples/plugin-gem-example/lib", Dir.pwd))
+      end
+
       test "simple_agent.rb workflow runs successfully" do
         skip "work in progress - refactoring the agent cog"
         # Mock the claude CLI response


### PR DESCRIPTION
There's no need to wrap in an array, a splat arg will have the same effect.

Much nicer syntax.
