### PR TITLE
Relax ruby version (temporarily)

### DIFF
--- a/roast-ai.gemspec
+++ b/roast-ai.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/Shopify/roast"
   spec.metadata["changelog_uri"] = "https://github.com/Shopify/roast/blob/main/CHANGELOG.md"
 
-  spec.required_ruby_version = ">= 3.4.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
The shipit pipeline is having some issues with a gemspec requiring ruby 3.4. I'd like to be able to deploy new releases.