### PR TITLE
Introduce Event Framework

### DIFF
--- a/lib/roast/cog.rb
+++ b/lib/roast/cog.rb
@@ -62,6 +62,7 @@ module Roast
 
       @task = barrier.async(finished: false) do |task|
         task.annotate("#{self.class.name.not_nil!.demodulize.camelcase} Cog: #{@name}")
+        TaskContext.begin(@name)
         @config = config
         input_instance = self.class.input_class.new
         input_return = input_context.instance_exec(
@@ -84,6 +85,8 @@ module Roast
       rescue StandardError => e
         @failed = true
         raise e
+      ensure
+        TaskContext.end
       end
     end
 

--- a/lib/roast/event.rb
+++ b/lib/roast/event.rb
@@ -1,0 +1,75 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  class Event
+    class << self
+      #: (Hash[Symbol, untyped]) -> void
+      def <<(event)
+        EventMonitor.accept(Event.new(TaskContext.path, event))
+      end
+    end
+
+    LOG_TYPE_KEYS = [
+      :fatal,
+      :error,
+      :warn,
+      :info,
+      :debug,
+      :unknown,
+    ].freeze #: Array[Symbol]
+
+    OTHER_TYPE_KEYS = [
+      :begin,
+      :end,
+      :stdout,
+      :stderr,
+    ].freeze #: Array[Symbol]
+
+    #: Array[Symbol | Integer]
+    attr_reader :path
+
+    #: Hash[Symbol, untyped] :payload
+    attr_reader :payload
+
+    #: Time
+    attr_reader :time
+
+    delegate :[], :key?, :keys, to: :payload
+
+    #: (Array[Symbol | Integer] path, Hash[Symbol, untyped]) -> void
+    def initialize(path, payload)
+      @path = path
+      @payload = payload
+      @time = Time.now
+    end
+
+    #: () -> Symbol
+    def type
+      return :log if (LOG_TYPE_KEYS & @payload.keys).present?
+
+      (OTHER_TYPE_KEYS & @payload.keys).first || :unknown
+    end
+
+    #: () -> Integer
+    def log_severity
+      severity = case type
+      when :log
+        (LOG_TYPE_KEYS & @payload.keys).first || :unknown
+      when :stderr
+        :warn
+      else
+        :info
+      end
+      Logger::Severity.const_get(:LEVELS)[severity.to_s] # rubocop:disable Sorbet/ConstantsFromStrings
+    end
+
+    #: () -> String
+    def log_message
+      key = (LOG_TYPE_KEYS & @payload.keys).first
+      return "" unless key.present?
+
+      payload[key] || ""
+    end
+  end
+end

--- a/lib/roast/event_monitor.rb
+++ b/lib/roast/event_monitor.rb
@@ -1,0 +1,124 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module EventMonitor
+    extend self
+    include Kernel
+
+    class EventMonitorError < StandardError; end
+
+    class EventMonitorAlreadyStartedError < EventMonitorError; end
+
+    class EventMonitorNotRunningError < EventMonitorError; end
+
+    @queue = Async::Queue.new.tap(&:close) #: Async::Queue
+    @task = nil #: Async::Task?
+
+    #: () -> bool
+    def running?
+      !@queue.closed?
+    end
+
+    #: () -> Async::Task
+    def start!
+      raise EventMonitorAlreadyStartedError if running?
+
+      OutputRouter.enable!
+      @queue = Async::Queue.new
+      @task = Async(transient: true) do
+        OutputRouter.mark_as_output_fiber!
+        loop do
+          event = @queue.pop #: as Event?
+          break if event.nil?
+
+          handle_event(event)
+        end
+      end
+    end
+
+    #: () -> void
+    def stop!
+      raise EventMonitorNotRunningError unless running?
+
+      OutputRouter.disable!
+      @queue.close
+      @task&.wait
+      @task = nil
+    end
+
+    #: () -> void
+    def reset!
+      OutputRouter.disable!
+      @queue.close
+      @task = nil
+    end
+
+    #: (Event) -> void
+    def accept(event)
+      if running?
+        @queue.push(event)
+      else
+        handle_event(event)
+      end
+    end
+
+    private
+
+    #: (Event) -> void
+    def handle_event(event)
+      with_stubbed_class_method_returning(Time, :now, event.time) do
+        OutputRouter.mark_as_output_fiber!
+        handler_method_name = "handle_#{event.type}_event".to_sym
+        if respond_to?(handler_method_name, true)
+          send(handler_method_name, event)
+        else
+          handle_unknown_event(event)
+        end
+      end
+    end
+
+    #: (Event) -> void
+    def handle_begin_event(event)
+      Roast::Log.logger.debug(event.inspect)
+    end
+
+    #: (Event) -> void
+    def handle_end_event(event)
+      Roast::Log.logger.debug(event.inspect)
+    end
+
+    #: (Event) -> void
+    def handle_log_event(event)
+      Roast::Log.logger.add(event.log_severity, event.log_message)
+    end
+
+    #: (Event) -> void
+    def handle_stderr_event(event)
+      puts event[:stderr]
+    end
+
+    #: (Event) -> void
+    def handle_stdout_event(event)
+      puts event[:stdout]
+    end
+
+    #: (Event) -> void
+    def handle_unknown_event(event)
+      Roast::Log.logger.unknown(event.inspect)
+    end
+
+    #: [T] (Class, Symbol, untyped) { () -> T } -> T
+    def with_stubbed_class_method_returning(klass, method_name, return_value, &blk)
+      original_method = klass.singleton_class.instance_method(method_name)
+      klass.singleton_class.silence_redefinition_of_method(method_name)
+      klass.define_singleton_method(method_name, proc { return_value })
+      blk.call
+    ensure
+      if original_method
+        klass.singleton_class.silence_redefinition_of_method(method_name)
+        klass.define_singleton_method(method_name, original_method)
+      end
+    end
+  end
+end

--- a/lib/roast/log.rb
+++ b/lib/roast/log.rb
@@ -4,8 +4,9 @@
 module Roast
   # Central logging interface for Roast.
   #
-  # Provides a simple, testable logging API that wraps the standard library Logger.
-  # Outputs to $stderr by default.
+  # Provides a simple, testable logging API that wraps the standard library Logger
+  # and leverages Roast's Event framework for clean async task integration with proper task hierarchy attribution.
+  # Outputs to STDERR by default.
   #
   # @example Basic usage
   #   Roast::Log.info("Processing file...")
@@ -17,61 +18,74 @@ module Roast
   #   Roast::Log.logger = Rails.logger
   #
   module Log
+    extend self
+    include Kernel
+
     LOG_LEVELS = {
-      "DEBUG" => ::Logger::DEBUG,
-      "INFO" => ::Logger::INFO,
-      "WARN" => ::Logger::WARN,
-      "ERROR" => ::Logger::ERROR,
-      "FATAL" => ::Logger::FATAL,
-    }.freeze
+      DEBUG: ::Logger::DEBUG,
+      INFO: ::Logger::INFO,
+      WARN: ::Logger::WARN,
+      ERROR: ::Logger::ERROR,
+      FATAL: ::Logger::FATAL,
+    }.freeze #: Hash[Symbol, Integer]
 
-    class << self
-      attr_writer :logger
+    attr_writer :logger
 
-      def debug(message)
-        logger.debug(message)
+    #: (String) -> void
+    def debug(message)
+      Roast::Event << { debug: message }
+    end
+
+    #: (String) -> void
+    def info(message)
+      Roast::Event << { info: message }
+    end
+
+    #: (String) -> void
+    def warn(message)
+      Roast::Event << { warn: message }
+    end
+
+    #: (String) -> void
+    def error(message)
+      Roast::Event << { error: message }
+    end
+
+    #: (String) -> void
+    def fatal(message)
+      Roast::Event << { fatal: message }
+    end
+
+    #: (String) -> void
+    def unknown(message)
+      Roast::Event << { unknown: message }
+    end
+
+    #: () -> Logger
+    def logger
+      @logger ||= create_logger
+    end
+
+    #: () -> void
+    def reset!
+      @logger = nil
+    end
+
+    private
+
+    #: () -> Logger
+    def create_logger
+      ::Logger.new($stderr, progname: "Roast").tap do |l|
+        l.level = LOG_LEVELS.fetch(log_level)
       end
+    end
 
-      def info(message)
-        logger.info(message)
-      end
+    #: () -> Symbol
+    def log_level
+      level = (ENV["ROAST_LOG_LEVEL"] || "INFO").upcase.to_sym
+      raise ArgumentError, "Invalid log level: #{level}. Valid levels are: #{LOG_LEVELS.keys.join(", ")}" unless LOG_LEVELS.key?(level)
 
-      def warn(message)
-        logger.warn(message)
-      end
-
-      def error(message)
-        logger.error(message)
-      end
-
-      def fatal(message)
-        logger.fatal(message)
-      end
-
-      def logger
-        @logger ||= create_logger
-      end
-
-      def reset!
-        @logger = nil
-      end
-
-      private
-
-      def create_logger
-        ::Logger.new($stderr, progname: "roast").tap do |l|
-          l.level = LOG_LEVELS.fetch(log_level)
-        end
-      end
-
-      def log_level
-        level_str = (ENV["ROAST_LOG_LEVEL"] || "INFO").upcase
-        unless LOG_LEVELS.key?(level_str)
-          raise ArgumentError, "Invalid log level: #{level_str}. Valid levels are: #{LOG_LEVELS.keys.join(", ")}"
-        end
-
-        level_str
-      end
+      level
     end
   end
 end

--- a/lib/roast/output_router.rb
+++ b/lib/roast/output_router.rb
@@ -1,0 +1,76 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  class OutputRouter
+    # This is the name of the alias methods for `:write` on the $stdout and $stderr objects
+    # that bypass OutputRouter's wrapper. Calling this method will write to those output stream directly.
+    WRITE_WITHOUT_ROAST = :write_without_roast
+
+    class << self
+      #: () -> bool
+      def enable!
+        return false if enabled?
+
+        activate($stdout, :stdout)
+        activate($stderr, :stderr)
+        mark_as_output_fiber!
+        true
+      end
+
+      #: () -> bool
+      def disable!
+        return false unless enabled?
+
+        deactivate($stdout)
+        deactivate($stderr)
+        @output_fiber = nil
+        true
+      end
+
+      #: () -> bool
+      def enabled?
+        $stdout.respond_to?(WRITE_WITHOUT_ROAST)
+      end
+
+      #: () -> bool
+      def output_fiber?
+        @output_fiber == Fiber.current
+      end
+
+      #: () -> void
+      def mark_as_output_fiber!
+        @output_fiber = Fiber.current
+      end
+
+      private
+
+      #: (IO stream, Symbol name) -> void
+      def activate(stream, name)
+        router = self
+        stream.singleton_class.send(:alias_method, WRITE_WITHOUT_ROAST, :write)
+        stream.define_singleton_method(:write) do |*args|
+          if router.output_fiber?
+            self #: as untyped # rubocop:disable Style/RedundantSelf
+              .send(WRITE_WITHOUT_ROAST, *args)
+          else
+            str = args.map(&:to_s).join
+            Event << case name
+            when :stdout then { stdout: str }
+            when :stderr then { stderr: str }
+            else { unknown: str }
+            end
+          end
+        end
+      end
+
+      #: (IO stream) -> void
+      def deactivate(stream)
+        sc = stream.singleton_class
+        sc.send(:remove_method, :write)
+        sc.send(:alias_method, :write, WRITE_WITHOUT_ROAST)
+        sc.send(:remove_method, WRITE_WITHOUT_ROAST)
+      end
+    end
+  end
+end

--- a/lib/roast/task_context.rb
+++ b/lib/roast/task_context.rb
@@ -1,0 +1,27 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module TaskContext
+    extend self
+
+    #: () -> Array[Symbol | Integer]
+    def path
+      Fiber[:path]&.dup || []
+    end
+
+    #: (Symbol | Integer) -> Array[Symbol | Integer]
+    def begin(id)
+      Event << { begin: id }
+      Fiber[:path] = (Fiber[:path] || []) + [id]
+      path
+    end
+
+    #: () -> [Symbol | Integer, Array[Symbol | Integer]]
+    def end
+      id = Fiber[:path]&.pop
+      Event << { end: id }
+      [id, path]
+    end
+  end
+end

--- a/lib/roast/workflow.rb
+++ b/lib/roast/workflow.rb
@@ -4,20 +4,28 @@
 module Roast
   class Workflow
     class WorkflowError < Roast::Error; end
+
     class WorkflowNotPreparedError < WorkflowError; end
+
     class WorkflowAlreadyPreparedError < WorkflowError; end
+
     class WorkflowAlreadyStartedError < WorkflowError; end
+
     class InvalidLoadableReference < WorkflowError; end
 
     class << self
       #: (String | Pathname, WorkflowParams) -> void
       def from_file(workflow_path, params)
-        Dir.mktmpdir("roast-") do |tmpdir|
-          workflow_dir = Pathname.new(workflow_path).dirname
-          workflow_context = WorkflowContext.new(params: params, tmpdir: tmpdir, workflow_dir: workflow_dir)
-          workflow = new(workflow_path, workflow_context)
-          workflow.prepare!
-          workflow.start!
+        Sync do
+          Dir.mktmpdir("roast-") do |tmpdir|
+            EventMonitor.start!
+            workflow_dir = Pathname.new(workflow_path).dirname
+            workflow_context = WorkflowContext.new(params: params, tmpdir: tmpdir, workflow_dir: workflow_dir)
+            workflow = new(workflow_path, workflow_context)
+            workflow.prepare!
+            workflow.start!
+            EventMonitor.stop!
+          end
         end
       end
     end

--- a/test/examples/functional/roast_examples_test.rb
+++ b/test/examples/functional/roast_examples_test.rb
@@ -8,6 +8,14 @@ module Examples
     EMPTY_PARAMS = Roast::WorkflowParams.new([], [], {})
 
     class RoastExamplesTest < FunctionalTest
+      setup do
+        Roast::EventMonitor.reset!
+      end
+
+      teardown do
+        Roast::EventMonitor.reset!
+      end
+
       test "async_cogs.rb workflow runs successfully" do
         stdout, stderr = in_sandbox :async_cogs do
           Roast::Workflow.from_file("examples/async_cogs.rb", EMPTY_PARAMS)

--- a/test/roast/event_monitor_test.rb
+++ b/test/roast/event_monitor_test.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  class EventMonitorTest < ActiveSupport::TestCase
+    setup do
+      EventMonitor.reset!
+      Roast::Log.reset!
+    end
+
+    teardown do
+      EventMonitor.reset!
+      Roast::Log.reset!
+    end
+
+    # --- Error classes ---
+
+    test "EventMonitorError is a StandardError" do
+      assert EventMonitor::EventMonitorError < StandardError
+    end
+
+    test "EventMonitorAlreadyStartedError is an EventMonitorError" do
+      assert EventMonitor::EventMonitorAlreadyStartedError < EventMonitor::EventMonitorError
+    end
+
+    test "EventMonitorNotRunningError is an EventMonitorError" do
+      assert EventMonitor::EventMonitorNotRunningError < EventMonitor::EventMonitorError
+    end
+
+    # --- running? ---
+
+    test "running? returns false initially" do
+      refute_predicate EventMonitor, :running?
+    end
+
+    test "running? returns true after start!" do
+      Sync do
+        EventMonitor.start!
+
+        assert_predicate EventMonitor, :running?
+      end
+    end
+
+    test "running? returns false after stop!" do
+      Sync do
+        EventMonitor.start!
+        assert_predicate EventMonitor, :running?
+        EventMonitor.stop!
+
+        refute_predicate EventMonitor, :running?
+      end
+    end
+
+    # --- start! ---
+
+    test "start! raises EventMonitorAlreadyStartedError when already running" do
+      Sync do
+        EventMonitor.start!
+
+        assert_raises(EventMonitor::EventMonitorAlreadyStartedError) do
+          EventMonitor.start!
+        end
+      ensure
+        EventMonitor.reset!
+      end
+    end
+
+    test "start! enables OutputRouter" do
+      Sync do
+        refute_predicate OutputRouter, :enabled?
+        EventMonitor.start!
+        assert_predicate OutputRouter, :enabled?
+      end
+    end
+
+    # --- stop! ---
+
+    test "stop! raises EventMonitorNotRunningError when not running" do
+      assert_raises(EventMonitor::EventMonitorNotRunningError) do
+        EventMonitor.stop!
+      end
+    end
+
+    test "stop! disables OutputRouter" do
+      Sync do
+        EventMonitor.start!
+        assert_predicate OutputRouter, :enabled?
+        EventMonitor.stop!
+        refute_predicate OutputRouter, :enabled?
+      end
+    end
+
+    # --- reset! ---
+
+    test "reset! stops the monitor without raising if monitor is already stopped" do
+      refute_predicate EventMonitor, :running?
+      assert_nothing_raised do
+        EventMonitor.reset!
+      end
+      refute_predicate EventMonitor, :running?
+    end
+
+    test "reset! stops a running monitor" do
+      Sync do
+        EventMonitor.start!
+        EventMonitor.reset!
+
+        refute_predicate EventMonitor, :running?
+      end
+    end
+
+    # --- accept ---
+
+    test "accept handles event directly when not running" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output)
+
+      event = Event.new([], { info: "direct message" })
+      EventMonitor.accept(event)
+
+      assert_includes output.string, "direct message"
+    end
+
+    test "accept queues event for async handling when running" do
+      handler_fiber = nil
+      caller_fiber = nil
+
+      _, stderr = capture_io do
+        Sync do
+          EventMonitor.start!
+
+          # Temporarily intercept handle_log_event to record which fiber processes it
+          original_method = EventMonitor.method(:handle_log_event)
+          EventMonitor.singleton_class.silence_redefinition_of_method(:handle_log_event)
+          EventMonitor.define_singleton_method(:handle_log_event) do |event|
+            handler_fiber = Fiber.current
+            original_method.call(event)
+          end
+
+          caller_fiber = Fiber.current
+          event = Event.new([], { info: "queued message" })
+          EventMonitor.accept(event)
+
+          EventMonitor.stop!
+        ensure
+          # Restore original
+          EventMonitor.singleton_class.silence_redefinition_of_method(:handle_log_event)
+          EventMonitor.define_singleton_method(:handle_log_event, original_method) if original_method.present?
+        end
+      end
+
+      assert_includes stderr, "queued message"
+      assert_not_nil handler_fiber, "Expected event to be handled"
+      assert_not_equal caller_fiber, handler_fiber, "Expected event to be handled on a different fiber (the consumer), not the caller"
+    end
+
+    # --- Event handler routing ---
+
+    test "handle_log_event routes log events to the logger" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output, level: Logger::DEBUG)
+
+      event = Event.new([], { debug: "debug message" })
+      EventMonitor.accept(event)
+
+      assert_includes output.string, "debug message"
+    end
+
+    test "handle_begin_event logs begin events at debug level" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output, level: Logger::DEBUG)
+
+      event = Event.new([:workflow], { begin: :step1 })
+      EventMonitor.accept(event)
+
+      assert_includes output.string, "begin"
+    end
+
+    test "handle_end_event logs end events at debug level" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output, level: Logger::DEBUG)
+
+      event = Event.new([:workflow], { end: :step1 })
+      EventMonitor.accept(event)
+
+      assert_includes output.string, "end"
+    end
+
+    test "handle_stdout_event outputs to puts" do
+      event = Event.new([], { stdout: "hello stdout" })
+
+      output = capture_io { EventMonitor.accept(event) }.first
+
+      assert_includes output, "hello stdout"
+    end
+
+    test "handle_stderr_event outputs to puts" do
+      event = Event.new([], { stderr: "hello stderr" })
+
+      output = capture_io { EventMonitor.accept(event) }.first
+
+      assert_includes output, "hello stderr"
+    end
+
+    test "handle_unknown_event logs unrecognized events at unknown level" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output)
+
+      event = Event.new([], { custom_type: "data" })
+      EventMonitor.accept(event)
+
+      assert_includes output.string, "custom_type"
+    end
+
+    # --- Time stubbing ---
+
+    test "handle_event preserves event time when dispatching" do
+      frozen_time = Time.new(2026, 1, 1, 12, 0, 0)
+      event = Event.new([], { info: "timed" })
+      event.instance_variable_set(:@time, frozen_time)
+
+      logged_time = nil
+      output = StringIO.new
+      logger = Logger.new(output)
+      logger.formatter = proc { |_severity, time, _progname, _msg|
+        logged_time = time
+        ""
+      }
+      Roast::Log.logger = logger
+
+      EventMonitor.accept(event)
+
+      assert_equal frozen_time, logged_time
+    end
+
+    # --- with_stubbed_class_method_returning ---
+
+    test "with_stubbed_class_method_returning temporarily overrides a class method" do
+      assert_instance_of Time, Time.now
+
+      EventMonitor.send(:with_stubbed_class_method_returning, Time, :now, :fake_value) do
+        assert_equal :fake_value, Time.now
+      end
+
+      assert_instance_of Time, Time.now
+    end
+
+    test "with_stubbed_class_method_returning restores the original method even on exception" do
+      begin
+        EventMonitor.send(:with_stubbed_class_method_returning, Time, :now, :fake) do
+          raise "boom"
+        end
+      rescue RuntimeError
+        # expected
+      end
+
+      assert_instance_of Time, Time.now
+    end
+  end
+end

--- a/test/roast/event_test.rb
+++ b/test/roast/event_test.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  class EventTest < ActiveSupport::TestCase
+    setup do
+      EventMonitor.reset!
+    end
+
+    teardown do
+      EventMonitor.reset!
+    end
+
+    # --- Initialization ---
+
+    test "initializes with path, payload, and records time" do
+      path = [:workflow, :step1]
+      payload = { info: "hello" }
+
+      event = Event.new(path, payload)
+
+      assert_equal [:workflow, :step1], event.path
+      assert_equal({ info: "hello" }, event.payload)
+      assert_instance_of Time, event.time
+    end
+
+    # --- Delegate methods ---
+
+    test "delegates [] to payload" do
+      event = Event.new([], { info: "msg" })
+
+      assert_equal "msg", event[:info]
+    end
+
+    test "delegates key? to payload" do
+      event = Event.new([], { warn: "caution" })
+
+      assert event.key?(:warn)
+      refute event.key?(:info)
+    end
+
+    test "delegates keys to payload" do
+      event = Event.new([], { error: "bad", fatal: "worse" })
+
+      assert_equal [:error, :fatal], event.keys
+    end
+
+    # --- Type detection ---
+
+    test "type returns :log for debug payload" do
+      event = Event.new([], { debug: "msg" })
+
+      assert_equal :log, event.type
+    end
+
+    test "type returns :log for info payload" do
+      event = Event.new([], { info: "msg" })
+
+      assert_equal :log, event.type
+    end
+
+    test "type returns :log for warn payload" do
+      event = Event.new([], { warn: "msg" })
+
+      assert_equal :log, event.type
+    end
+
+    test "type returns :log for error payload" do
+      event = Event.new([], { error: "msg" })
+
+      assert_equal :log, event.type
+    end
+
+    test "type returns :log for fatal payload" do
+      event = Event.new([], { fatal: "msg" })
+
+      assert_equal :log, event.type
+    end
+
+    test "type returns :log for unknown payload" do
+      event = Event.new([], { unknown: "msg" })
+
+      assert_equal :log, event.type
+    end
+
+    test "type returns :begin for begin payload" do
+      event = Event.new([], { begin: :step1 })
+
+      assert_equal :begin, event.type
+    end
+
+    test "type returns :end for end payload" do
+      event = Event.new([], { end: :step1 })
+
+      assert_equal :end, event.type
+    end
+
+    test "type returns :stdout for stdout payload" do
+      event = Event.new([], { stdout: "output" })
+
+      assert_equal :stdout, event.type
+    end
+
+    test "type returns :stderr for stderr payload" do
+      event = Event.new([], { stderr: "error output" })
+
+      assert_equal :stderr, event.type
+    end
+
+    test "type returns :unknown for unrecognized payload" do
+      event = Event.new([], { custom: "data" })
+
+      assert_equal :unknown, event.type
+    end
+
+    test "type prioritizes log type over other types" do
+      event = Event.new([], { info: "msg", begin: :step })
+
+      assert_equal :log, event.type
+    end
+
+    # --- Log severity ---
+
+    test "log_severity returns DEBUG for debug log" do
+      event = Event.new([], { debug: "msg" })
+
+      assert_equal Logger::DEBUG, event.log_severity
+    end
+
+    test "log_severity returns INFO for info log" do
+      event = Event.new([], { info: "msg" })
+
+      assert_equal Logger::INFO, event.log_severity
+    end
+
+    test "log_severity returns WARN for warn log" do
+      event = Event.new([], { warn: "msg" })
+
+      assert_equal Logger::WARN, event.log_severity
+    end
+
+    test "log_severity returns ERROR for error log" do
+      event = Event.new([], { error: "msg" })
+
+      assert_equal Logger::ERROR, event.log_severity
+    end
+
+    test "log_severity returns FATAL for fatal log" do
+      event = Event.new([], { fatal: "msg" })
+
+      assert_equal Logger::FATAL, event.log_severity
+    end
+
+    test "log_severity returns UNKNOWN for unknown log" do
+      event = Event.new([], { unknown: "msg" })
+
+      assert_equal Logger::Severity.const_get(:LEVELS)["unknown"], event.log_severity # rubocop:disable Sorbet/ConstantsFromStrings
+    end
+
+    test "log_severity returns WARN for stderr events" do
+      event = Event.new([], { stderr: "err" })
+
+      assert_equal Logger::WARN, event.log_severity
+    end
+
+    test "log_severity returns INFO for non-log event types" do
+      event = Event.new([], { begin: :step })
+
+      assert_equal Logger::INFO, event.log_severity
+    end
+
+    # --- Log message ---
+
+    test "log_message returns the message for a log event" do
+      event = Event.new([], { info: "hello world" })
+
+      assert_equal "hello world", event.log_message
+    end
+
+    test "log_message returns empty string for non-log events" do
+      event = Event.new([], { begin: :step })
+
+      assert_equal "", event.log_message
+    end
+
+    test "log_message returns empty string when log value is nil" do
+      event = Event.new([], { info: nil })
+
+      assert_equal "", event.log_message
+    end
+
+    test "log_message returns message for most severe matching log key" do
+      event = Event.new([], { debug: "debug msg", error: "error msg" })
+
+      assert_equal "error msg", event.log_message
+    end
+
+    # --- Class method << ---
+
+    test "Event.<< creates event and passes to EventMonitor.accept" do
+      EventMonitor.expects(:accept).with do |event|
+        event.is_a?(Event) && event[:info] == "test message"
+      end
+
+      Event << { info: "test message" }
+    end
+
+    test "Event.<< captures current TaskContext path" do
+      Fiber[:path] = [:workflow, :step1]
+
+      EventMonitor.expects(:accept).with do |event|
+        event.path == [:workflow, :step1]
+      end
+
+      Event << { info: "test" }
+    ensure
+      Fiber[:path] = nil
+    end
+  end
+end

--- a/test/roast/log_test.rb
+++ b/test/roast/log_test.rb
@@ -2,46 +2,224 @@
 
 require "test_helper"
 
-class LogTest < ActiveSupport::TestCase
-  setup do
-    Roast::Log.reset!
-  end
-
-  teardown do
-    Roast::Log.reset!
-  end
-
-  test "allows custom logger" do
-    custom_output = StringIO.new
-    custom_logger = Logger.new(custom_output)
-
-    Roast::Log.logger = custom_logger
-    Roast::Log.info("custom logger test")
-
-    assert_includes custom_output.string, "custom logger test"
-  end
-
-  test "reset! clears the logger" do
-    custom_output = StringIO.new
-    Roast::Log.logger = Logger.new(custom_output)
-
-    Roast::Log.reset!
-
-    _stdout, stderr = capture_io do
-      Roast::Log.info("after reset")
+module Roast
+  class LogTest < ActiveSupport::TestCase
+    setup do
+      Roast::Log.reset!
+      EventMonitor.reset!
     end
 
-    refute_includes custom_output.string, "after reset"
-    assert_includes stderr, "after reset"
-  end
+    teardown do
+      Roast::Log.reset!
+      EventMonitor.reset!
+    end
 
-  test "raises ArgumentError for invalid log level" do
-    assert_raises(ArgumentError) do
-      with_log_level("INVALID") do
-        capture_io do
-          Roast::Log.info("test")
+    # --- Event integration ---
+
+    test "debug emits a debug event via Event.<<" do
+      EventMonitor.expects(:accept).with { |e| e[:debug] == "debug msg" }
+      Roast::Log.debug("debug msg")
+    end
+
+    test "info emits an info event via Event.<<" do
+      EventMonitor.expects(:accept).with { |e| e[:info] == "info msg" }
+      Roast::Log.info("info msg")
+    end
+
+    test "warn emits a warn event via Event.<<" do
+      EventMonitor.expects(:accept).with { |e| e[:warn] == "warn msg" }
+      Roast::Log.warn("warn msg")
+    end
+
+    test "error emits an error event via Event.<<" do
+      EventMonitor.expects(:accept).with { |e| e[:error] == "error msg" }
+      Roast::Log.error("error msg")
+    end
+
+    test "fatal emits a fatal event via Event.<<" do
+      EventMonitor.expects(:accept).with { |e| e[:fatal] == "fatal msg" }
+      Roast::Log.fatal("fatal msg")
+    end
+
+    test "unknown emits an unknown event via Event.<<" do
+      EventMonitor.expects(:accept).with { |e| e[:unknown] == "unknown msg" }
+      Roast::Log.unknown("unknown msg")
+    end
+
+    # --- End-to-end: events reach the logger when monitor is not running ---
+
+    test "allows custom logger" do
+      custom_output = StringIO.new
+      custom_logger = Logger.new(custom_output)
+
+      Roast::Log.logger = custom_logger
+      Roast::Log.info("custom logger test")
+
+      assert_includes custom_output.string, "custom logger test"
+    end
+
+    test "reset! clears the logger" do
+      custom_output = StringIO.new
+      Roast::Log.logger = Logger.new(custom_output)
+
+      Roast::Log.reset!
+
+      _stdout, stderr = capture_io do
+        Roast::Log.info("after reset")
+      end
+
+      refute_includes custom_output.string, "after reset"
+      assert_includes stderr, "after reset"
+    end
+
+    test "raises ArgumentError for invalid log level" do
+      assert_raises(ArgumentError) do
+        with_log_level("INVALID") do
+          capture_io do
+            Roast::Log.info("test")
+          end
         end
       end
+    end
+
+    # --- End-to-end: events reach the logger through the running event monitor ---
+
+    test "info reaches the logger through a running event monitor" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output)
+
+      Sync do
+        EventMonitor.start!
+        Roast::Log.info("async info message")
+        EventMonitor.stop!
+      end
+
+      assert_includes output.string, "async info message"
+    end
+
+    test "debug reaches the logger through a running event monitor" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output, level: Logger::DEBUG)
+
+      Sync do
+        EventMonitor.start!
+        Roast::Log.debug("async debug message")
+        EventMonitor.stop!
+      end
+
+      assert_includes output.string, "async debug message"
+    end
+
+    test "warn reaches the logger through a running event monitor" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output)
+
+      Sync do
+        EventMonitor.start!
+        Roast::Log.warn("async warn message")
+        EventMonitor.stop!
+      end
+
+      assert_includes output.string, "async warn message"
+    end
+
+    test "error reaches the logger through a running event monitor" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output)
+
+      Sync do
+        EventMonitor.start!
+        Roast::Log.error("async error message")
+        EventMonitor.stop!
+      end
+
+      assert_includes output.string, "async error message"
+    end
+
+    test "fatal reaches the logger through a running event monitor" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output)
+
+      Sync do
+        EventMonitor.start!
+        Roast::Log.fatal("async fatal message")
+        EventMonitor.stop!
+      end
+
+      assert_includes output.string, "async fatal message"
+    end
+
+    test "multiple messages arrive in order through a running event monitor" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output)
+
+      Sync do
+        EventMonitor.start!
+        Roast::Log.info("first")
+        Roast::Log.info("second")
+        Roast::Log.info("third")
+        EventMonitor.stop!
+      end
+
+      positions = ["first", "second", "third"].map { |msg| output.string.index(msg) }
+      assert positions.all?(&:present?), "Expected all messages in output: #{output.string}"
+      assert_equal positions, positions.sort
+    end
+
+    test "log severity is respected through a running event monitor" do
+      output = StringIO.new
+      Roast::Log.logger = Logger.new(output, level: Logger::WARN)
+
+      Sync do
+        EventMonitor.start!
+        Roast::Log.debug("should be filtered")
+        Roast::Log.info("also filtered")
+        Roast::Log.warn("should appear")
+        EventMonitor.stop!
+      end
+
+      refute_includes output.string, "should be filtered"
+      refute_includes output.string, "also filtered"
+      assert_includes output.string, "should appear"
+    end
+
+    test "custom logger receives messages through a running event monitor" do
+      custom_output = StringIO.new
+      Roast::Log.logger = Logger.new(custom_output)
+
+      Sync do
+        EventMonitor.start!
+        Roast::Log.info("custom async test")
+        EventMonitor.stop!
+      end
+
+      assert_includes custom_output.string, "custom async test"
+    end
+
+    # --- Logger creation ---
+
+    test "logger creates a Logger writing to stderr by default" do
+      _stdout, stderr = capture_io do
+        Roast::Log.logger.info("default output test")
+      end
+
+      assert_includes stderr, "default output test"
+    end
+
+    test "logger uses ROAST_LOG_LEVEL env var" do
+      with_log_level("ERROR") do
+        StringIO.new
+        Roast::Log.logger = nil # force re-creation won't work, need to use logger directly
+        Roast::Log.reset!
+        logger = Roast::Log.logger
+
+        assert_equal Logger::ERROR, logger.level
+      end
+    end
+
+    test "LOG_LEVELS contains all standard levels" do
+      expected = Logger::Severity.const_get(:LEVELS).except("unknown").transform_keys { |k| k.upcase.to_sym } # rubocop:disable Sorbet/ConstantsFromStrings
+      assert_equal expected, Roast::Log::LOG_LEVELS
     end
   end
 end

--- a/test/roast/output_router_test.rb
+++ b/test/roast/output_router_test.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  class OutputRouterTest < ActiveSupport::TestCase
+    setup do
+      EventMonitor.reset!
+      OutputRouter.disable!
+    end
+
+    teardown do
+      OutputRouter.disable!
+    end
+
+    # --- enabled? ---
+
+    test "enabled? returns false initially" do
+      refute_predicate OutputRouter, :enabled?
+    end
+
+    test "enabled? returns true after enable!" do
+      OutputRouter.enable!
+
+      assert_predicate OutputRouter, :enabled?
+    end
+
+    test "enabled? returns false after disable!" do
+      OutputRouter.enable!
+      assert_predicate OutputRouter, :enabled?
+      OutputRouter.disable!
+
+      refute_predicate OutputRouter, :enabled?
+    end
+
+    # --- enable! ---
+
+    test "enable! returns true on first call" do
+      assert_equal true, OutputRouter.enable!
+    end
+
+    test "enable! returns false when already enabled" do
+      OutputRouter.enable!
+
+      assert_equal false, OutputRouter.enable!
+    end
+
+    test "enable! adds write_without_roast method to stdout" do
+      OutputRouter.enable!
+
+      assert $stdout.respond_to?(OutputRouter::WRITE_WITHOUT_ROAST)
+    end
+
+    test "enable! adds write_without_roast method to stderr" do
+      OutputRouter.enable!
+
+      assert $stderr.respond_to?(OutputRouter::WRITE_WITHOUT_ROAST)
+    end
+
+    # --- disable! ---
+
+    test "disable! returns false when not enabled" do
+      assert_equal false, OutputRouter.disable!
+    end
+
+    test "disable! returns true when enabled" do
+      OutputRouter.enable!
+
+      assert_equal true, OutputRouter.disable!
+    end
+
+    test "disable! removes write_without_roast method from stdout" do
+      OutputRouter.enable!
+      assert $stdout.respond_to?(OutputRouter::WRITE_WITHOUT_ROAST)
+      OutputRouter.disable!
+
+      refute $stdout.respond_to?(OutputRouter::WRITE_WITHOUT_ROAST)
+    end
+
+    test "disable! removes write_without_roast method from stderr" do
+      OutputRouter.enable!
+      assert $stderr.respond_to?(OutputRouter::WRITE_WITHOUT_ROAST)
+      OutputRouter.disable!
+
+      refute $stderr.respond_to?(OutputRouter::WRITE_WITHOUT_ROAST)
+    end
+
+    # --- output_fiber? / mark_as_output_fiber! ---
+
+    test "output_fiber? returns false by default" do
+      refute_predicate OutputRouter, :output_fiber?
+    end
+
+    test "mark_as_output_fiber! makes output_fiber? return true for current fiber" do
+      OutputRouter.mark_as_output_fiber!
+
+      assert_predicate OutputRouter, :output_fiber?
+    end
+
+    test "output_fiber? is false for a different fiber" do
+      OutputRouter.mark_as_output_fiber!
+
+      other_fiber_result = nil
+      Fiber.new { other_fiber_result = OutputRouter.output_fiber? }.resume
+
+      refute other_fiber_result
+    end
+
+    # --- stdout/stderr routing ---
+
+    test "write on stdout routes to Event when not output fiber" do
+      OutputRouter.enable!
+      # Mark a different fiber as the output fiber
+      other_fiber = Fiber.new { OutputRouter.mark_as_output_fiber! }
+      other_fiber.resume
+
+      Event.expects(:<<).with { |payload| payload[:stdout] == "test output" }
+
+      $stdout.write("test output")
+    end
+
+    test "write on stderr routes to Event when not output fiber" do
+      OutputRouter.enable!
+      other_fiber = Fiber.new { OutputRouter.mark_as_output_fiber! }
+      other_fiber.resume
+
+      Event.expects(:<<).with { |payload| payload[:stderr] == "test error" }
+
+      $stderr.write("test error")
+    end
+
+    test "write on stdout passes through when on output fiber" do
+      OutputRouter.enable!
+      OutputRouter.mark_as_output_fiber!
+
+      Event.expects(:<<).never
+
+      _stdout, _stderr = capture_io do
+        $stdout.write("passthrough output")
+      end
+    end
+
+    test "write on stderr passes through when on output fiber" do
+      OutputRouter.enable!
+      OutputRouter.mark_as_output_fiber!
+
+      Event.expects(:<<).never
+
+      _stdout, _stderr = capture_io do
+        $stderr.write("passthrough error")
+      end
+    end
+
+    # --- WRITE_WITHOUT_ROAST constant ---
+
+    test "WRITE_WITHOUT_ROAST is defined" do
+      assert_equal :write_without_roast, OutputRouter::WRITE_WITHOUT_ROAST
+    end
+
+    # --- write_without_roast ---
+
+    test "write_without_roast is removed after disable!" do
+      OutputRouter.enable!
+      assert $stdout.respond_to?(OutputRouter::WRITE_WITHOUT_ROAST)
+      assert $stderr.respond_to?(OutputRouter::WRITE_WITHOUT_ROAST)
+
+      OutputRouter.disable!
+
+      refute $stdout.respond_to?(OutputRouter::WRITE_WITHOUT_ROAST)
+      refute $stderr.respond_to?(OutputRouter::WRITE_WITHOUT_ROAST)
+    end
+
+    test "write is restored to original behaviour after disable!" do
+      original_stdout_write = $stdout.method(:write)
+      original_stderr_write = $stderr.method(:write)
+
+      OutputRouter.enable!
+      OutputRouter.disable!
+
+      assert_equal original_stdout_write.unbind, $stdout.method(:write).unbind
+      assert_equal original_stderr_write.unbind, $stderr.method(:write).unbind
+    end
+  end
+end

--- a/test/roast/task_context_test.rb
+++ b/test/roast/task_context_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  class TaskContextTest < ActiveSupport::TestCase
+    setup do
+      Fiber[:path] = nil
+      EventMonitor.reset!
+    end
+
+    teardown do
+      Fiber[:path] = nil
+    end
+
+    # --- path ---
+
+    test "path returns empty array when no fiber path is set" do
+      assert_equal [], TaskContext.path
+    end
+
+    test "path returns a dup of the fiber-local path" do
+      Fiber[:path] = [:a, :b]
+
+      result = TaskContext.path
+
+      assert_equal [:a, :b], result
+      refute_same Fiber[:path], result
+    end
+
+    # --- begin ---
+
+    test "begin pushes id onto the fiber path" do
+      TaskContext.begin(:step1)
+
+      assert_equal [:step1], Fiber[:path]
+    end
+
+    test "begin returns the updated path" do
+      result = TaskContext.begin(:step1)
+
+      assert_equal [:step1], result
+    end
+
+    test "begin nests paths with successive calls" do
+      TaskContext.begin(:outer)
+      TaskContext.begin(:inner)
+
+      assert_equal [:outer, :inner], Fiber[:path]
+    end
+
+    test "begin emits a begin event" do
+      EventMonitor.expects(:accept).with do |event|
+        event.is_a?(Event) && event[:begin] == :my_step
+      end
+
+      TaskContext.begin(:my_step)
+    end
+
+    test "begin event has the path before the id is pushed" do
+      Fiber[:path] = [:existing]
+
+      EventMonitor.expects(:accept).with do |event|
+        event.path == [:existing]
+      end
+
+      TaskContext.begin(:new_step)
+    end
+
+    # --- end ---
+
+    test "end pops the last id from the fiber path" do
+      Fiber[:path] = [:a, :b]
+
+      TaskContext.end
+
+      assert_equal [:a], Fiber[:path]
+    end
+
+    test "end returns the popped id and remaining path" do
+      Fiber[:path] = [:a, :b]
+
+      id, remaining_path = TaskContext.end
+
+      assert_equal :b, id
+      assert_equal [:a], remaining_path
+    end
+
+    test "end emits an end event with the popped id and remaining path" do
+      Fiber[:path] = [:workflow, :step1]
+
+      EventMonitor.expects(:accept).with do |event|
+        event.is_a?(Event) && event[:end] == :step1 && event.path == [:workflow]
+      end
+
+      TaskContext.end
+    end
+
+    test "end returns nil id when path is empty" do
+      id, remaining_path = TaskContext.end
+
+      assert_nil id
+      assert_equal [], remaining_path
+    end
+
+    # --- begin/end round-trip ---
+
+    test "begin and end are symmetric" do
+      TaskContext.begin(:a)
+      TaskContext.begin(:b)
+      TaskContext.end
+      TaskContext.end
+
+      assert_equal [], Fiber[:path]
+    end
+
+    # --- fiber isolation ---
+
+    test "path is isolated between fibers with separate storage" do
+      Fiber[:path] = [:main_fiber]
+
+      other_path = nil
+      Fiber.new(storage: {}) do
+        other_path = TaskContext.path
+      end.resume
+
+      assert_equal [], other_path
+      assert_equal [:main_fiber], Fiber[:path]
+    end
+  end
+end

--- a/test/roast/workflow_test.rb
+++ b/test/roast/workflow_test.rb
@@ -4,6 +4,14 @@ require "test_helper"
 
 module Roast
   class WorkflowTest < ActiveSupport::TestCase
+    setup do
+      Roast::EventMonitor.reset!
+    end
+
+    teardown do
+      Roast::EventMonitor.reset!
+    end
+
     test "from_file raises error when file does not exist" do
       assert_raises(Errno::ENOENT) do
         Workflow.from_file("/non/existent/file.rb", WorkflowParams.new([], [], {}))


### PR DESCRIPTION
This PR introduces an asynchronous event framework for Roast, and uses it to wrap the existing logging infrastructure. Subsequent PRs will build on this functionality to produce:
- a more robust and comprehensive user experience at the console, especially when running in an interactive terminal,
- better attribution of log messages and exception stack traces to the point in the cog execution hierarchy they occurred, and
- cleaner handling of the parallel output of asynchronously running cogs

The design principle here is that:
- `TaskContext` maintains a fiber-local stack that tracks where in the cog execution hierarchy a particular task is executing
- Anything that produces a log event or console output pushes `Event`s into a queue instead of emitting that output directly.
- `Event` automatically captures the current `TaskContext` state for the fiber in which the `Event` is produced.
- `EventMonitor` consumes the event queue in one fiber, allowing it to orchestrate how the output of multiple cogs running in parallel is produced. The goal here is to ultimately power a cleaner interactive UI that allows the user to see the state of multiple cogs executing in parallel in a clean and non-interleaved way, while also producing elegant log output for non-interactive sessions.

This PR does not change anything yet about the format of what Roast actually outputs. It simply adds the new framework. (It does add some rough new debug log statements for the beginning and ending of each cog's execution).