### PR TITLE
Automatically capture logger output in all test cases

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,29 @@ if ENV["CI"]
   Minitest::RG.rg!(color: true)
 end
 
+# @requires_ancestor: ActiveSupport::TestCase
+module CaptureLogOutput
+  extend ActiveSupport::Concern
+
+  included do
+    setup do
+      @logger_output = StringIO.new
+      Roast::Log.logger = Logger.new(@logger_output)
+    end
+
+    teardown do
+      if !passed? && @logger_output.string.present?
+        $stderr.puts("\n--- Captured log output (#{name}) ---")
+        $stderr.puts(@logger_output.string)
+        $stderr.puts("--- End captured log output ---")
+      end
+      Roast::Log.reset!
+    end
+  end
+end
+
+ActiveSupport::TestCase.include(CaptureLogOutput)
+
 def slow_test!
   skip "slow test" unless ["1", "true"].include?(ENV["ROAST_RUN_SLOW_TESTS"])
 end


### PR DESCRIPTION
Test cases should be silent unless they fail. This addition to `ActiveSupport::TestCase` captures the output of `Roast::Log` to an instance variable for every test case, and prints it to `stderr` if the test case fails.

(A test case can, of course, assert anything it wants on the logger output as well).

As we add more logging to Roast, the output of running various operations will become noiser. This is a good thing in general, but not for the test suite. I think the cleanest approach is a central extension like this, as opposed to adding a concern, or manual setup/teardown logic in each test class.