### PR TITLE
Ignore more Claude message fields

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/messages/result_message.rb
+++ b/lib/roast/cogs/agent/providers/claude/messages/result_message.rb
@@ -11,6 +11,7 @@ module Roast
               IGNORED_FIELDS = [
                 :duration_api_ms,
                 :permission_denials,
+                :stop_reason,
                 :usage,
                 :uuid,
               ].freeze

--- a/lib/roast/cogs/agent/providers/claude/messages/system_message.rb
+++ b/lib/roast/cogs/agent/providers/claude/messages/system_message.rb
@@ -9,23 +9,27 @@ module Roast
           module Messages
             class SystemMessage < Message
               IGNORED_FIELDS = [
-                :subtype,
-                :cwd,
-                :tools,
-                :mcp_servers,
-                :permissionMode,
-                :slash_commands,
-                :apiKeySource,
-                :claude_code_version,
-                :output_style,
                 :agents,
-                :skills,
-                :plugins,
-                :hook_name,
-                :hook_event,
-                :stdout,
-                :stderr,
+                :apiKeySource,
+                :compact_metadata,
+                :claude_code_version,
+                :cwd,
                 :exit_code,
+                :fast_mode_state,
+                :hook_event,
+                :hook_name,
+                :mcp_servers,
+                :output_style,
+                :permissionMode,
+                :plugins,
+                :skills,
+                :slash_commands,
+                # TODO: "status": "compacting" indicates compaction in progress. We might want to handle that someday
+                :status,
+                :stderr,
+                :stdout,
+                :subtype,
+                :tools,
               ].freeze
 
               #: String?

--- a/lib/roast/cogs/agent/providers/claude/messages/tool_use_message.rb
+++ b/lib/roast/cogs/agent/providers/claude/messages/tool_use_message.rb
@@ -9,6 +9,7 @@ module Roast
           module Messages
             class ToolUseMessage < Message
               IGNORED_FIELDS = [
+                :caller,
                 :role,
               ].freeze
 


### PR DESCRIPTION
Roast is currently spamming the terminal with warnings for unhandled fields in Claude streaming output that have been added to Claude since we last updated the message parser. Most of these are irrelevant to Roast, so we can just add them to the ignore list