### PR TITLE
Add Pi coding agent provider for agent cog

### DIFF
--- a/lib/roast/cogs/agent.rb
+++ b/lib/roast/cogs/agent.rb
@@ -64,6 +64,8 @@ module Roast
         @provider ||= case config.valid_provider!
         when :claude
           Providers::Claude.new(config)
+        when :pi
+          Providers::Pi.new(config)
         else
           raise UnknownProviderError, "Unknown provider: #{config.valid_provider!}"
         end

--- a/lib/roast/cogs/agent/config.rb
+++ b/lib/roast/cogs/agent/config.rb
@@ -5,7 +5,7 @@ module Roast
   module Cogs
     class Agent < Cog
       class Config < Cog::Config
-        VALID_PROVIDERS = [:claude].freeze #: Array[Symbol]
+        VALID_PROVIDERS = [:claude, :pi].freeze #: Array[Symbol]
 
         # Configure the cog to use a specified provider when invoking an agent
         #

--- a/lib/roast/cogs/agent/providers/pi.rb
+++ b/lib/roast/cogs/agent/providers/pi.rb
@@ -1,0 +1,29 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class Output < Agent::Output
+            delegate :response, :session, :stats, to: :@invocation_result
+
+            #: (PiInvocation::Result) -> void
+            def initialize(invocation_result)
+              super()
+              @invocation_result = invocation_result
+            end
+          end
+
+          #: (Agent::Input) -> Agent::Output
+          def invoke(input)
+            invocation = PiInvocation.new(@config, input)
+            invocation.run!
+            Output.new(invocation.result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/message.rb
+++ b/lib/roast/cogs/agent/providers/pi/message.rb
@@ -1,0 +1,101 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class Message
+            class << self
+              #: (String, ?raw_dump_file: Pathname?) -> Message
+              def from_json(json, raw_dump_file: nil)
+                raw_dump_file&.dirname&.mkpath
+                File.write("./tmp/pi-messages.log", "#{json}\n", mode: "a") if raw_dump_file
+                from_hash(JSON.parse(json, symbolize_names: true))
+              end
+
+              #: (Hash[Symbol, untyped]) -> Message
+              def from_hash(hash)
+                type = hash.delete(:type)&.to_s
+                case type
+                when "session"
+                  Messages::SessionMessage.new(type: :session, hash: hash)
+                when "agent_start"
+                  Messages::AgentStartMessage.new(type: :agent_start, hash: hash)
+                when "agent_end"
+                  Messages::AgentEndMessage.new(type: :agent_end, hash: hash)
+                when "turn_start"
+                  Messages::TurnStartMessage.new(type: :turn_start, hash: hash)
+                when "turn_end"
+                  Messages::TurnEndMessage.new(type: :turn_end, hash: hash)
+                when "message_start"
+                  Messages::MessageStartMessage.new(type: :message_start, hash: hash)
+                when "message_end"
+                  Messages::MessageEndMessage.new(type: :message_end, hash: hash)
+                when "message_update"
+                  from_message_update(hash)
+                when "tool_execution_start"
+                  Messages::ToolExecutionStartMessage.new(type: :tool_execution_start, hash: hash)
+                when "tool_execution_update"
+                  Messages::ToolExecutionUpdateMessage.new(type: :tool_execution_update, hash: hash)
+                when "tool_execution_end"
+                  Messages::ToolExecutionEndMessage.new(type: :tool_execution_end, hash: hash)
+                else
+                  Messages::UnknownMessage.new(type: type&.to_sym || :unknown, hash: hash)
+                end
+              end
+
+              private
+
+              #: (Hash[Symbol, untyped]) -> Message
+              def from_message_update(hash)
+                event = hash[:assistantMessageEvent]
+                sub_type = event&.dig(:type)&.to_s
+
+                case sub_type
+                when "text_start"
+                  Messages::TextStartMessage.new(type: :text_start, hash: hash)
+                when "text_delta"
+                  Messages::TextDeltaMessage.new(type: :text_delta, hash: hash)
+                when "text_end"
+                  Messages::TextEndMessage.new(type: :text_end, hash: hash)
+                when "thinking_start"
+                  Messages::ThinkingStartMessage.new(type: :thinking_start, hash: hash)
+                when "thinking_delta"
+                  Messages::ThinkingDeltaMessage.new(type: :thinking_delta, hash: hash)
+                when "thinking_end"
+                  Messages::ThinkingEndMessage.new(type: :thinking_end, hash: hash)
+                when "toolcall_start"
+                  Messages::ToolCallStartMessage.new(type: :toolcall_start, hash: hash)
+                when "toolcall_delta"
+                  Messages::ToolCallDeltaMessage.new(type: :toolcall_delta, hash: hash)
+                when "toolcall_end"
+                  Messages::ToolCallEndMessage.new(type: :toolcall_end, hash: hash)
+                else
+                  Messages::UnknownMessage.new(type: :unknown, hash: hash)
+                end
+              end
+            end
+
+            #: Symbol
+            attr_reader :type
+
+            #: Hash[Symbol, untyped]
+            attr_reader :unparsed
+
+            #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+            def initialize(type:, hash:)
+              @type = type
+              @unparsed = hash
+            end
+
+            #: (PiInvocation::Context) -> String?
+            def format(context)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/agent_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/agent_end_message.rb
@@ -1,0 +1,85 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Final message emitted by Pi containing the full conversation history
+            #
+            # Extracts the final response text and computes aggregate usage statistics
+            # from all assistant messages in the conversation.
+            class AgentEndMessage < Message
+              #: String
+              attr_reader :response
+
+              #: bool
+              attr_reader :success
+
+              #: Stats
+              attr_reader :stats
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                messages = hash.delete(:messages) || []
+                @response = extract_response(messages)
+                @success = true
+                @stats = extract_stats(messages)
+                super(type:, hash:)
+              end
+
+              private
+
+              # Extract the final text response from the last assistant message
+              #
+              #: (Array[Hash[Symbol, untyped]]) -> String
+              def extract_response(messages)
+                last_assistant = messages.reverse.find { |m| m[:role] == "assistant" }
+                return "" unless last_assistant
+
+                content = last_assistant[:content] || []
+                content
+                  .select { |c| c[:type] == "text" }
+                  .map { |c| c[:text] }
+                  .join
+                  .strip
+              end
+
+              # Compute aggregate stats from all assistant messages
+              #
+              #: (Array[Hash[Symbol, untyped]]) -> Stats
+              def extract_stats(messages)
+                stats = Stats.new
+                assistant_messages = messages.select { |m| m[:role] == "assistant" }
+
+                assistant_messages.each do |msg|
+                  usage_data = msg[:usage]
+                  next unless usage_data
+
+                  model = msg[:model] || "unknown"
+                  model_usage = stats.model_usage[model] ||= Usage.new
+
+                  input = usage_data[:input] || 0
+                  output = usage_data[:output] || 0
+                  cost = usage_data.dig(:cost, :total) || 0.0
+
+                  model_usage.input_tokens = (model_usage.input_tokens || 0) + input
+                  model_usage.output_tokens = (model_usage.output_tokens || 0) + output
+                  model_usage.cost_usd = (model_usage.cost_usd || 0.0) + cost
+
+                  stats.usage.input_tokens = (stats.usage.input_tokens || 0) + input
+                  stats.usage.output_tokens = (stats.usage.output_tokens || 0) + output
+                  stats.usage.cost_usd = (stats.usage.cost_usd || 0.0) + cost
+                end
+
+                stats
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/agent_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/agent_start_message.rb
@@ -1,0 +1,21 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class AgentStartMessage < Message
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/message_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/message_end_message.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class MessageEndMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/message_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/message_start_message.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class MessageStartMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/session_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/session_message.rb
@@ -1,0 +1,32 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class SessionMessage < Message
+              IGNORED_FIELDS = [
+                :version,
+                :timestamp,
+                :cwd,
+              ].freeze
+
+              #: String?
+              attr_reader :session_id
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @session_id = hash.delete(:id)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/text_delta_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/text_delta_message.rb
@@ -1,0 +1,38 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TextDeltaMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String
+              attr_reader :delta
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                @delta = event[:delta] || ""
+                event.except!(:type, :delta, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+
+              #: (PiInvocation::Context) -> String?
+              def format(context)
+                @delta
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/text_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/text_end_message.rb
@@ -1,0 +1,33 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TextEndMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String
+              attr_reader :content
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                @content = event[:content] || ""
+                event.except!(:type, :content, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/text_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/text_start_message.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TextStartMessage < Message
+              IGNORED_FIELDS = [
+                :assistantMessageEvent,
+              ].freeze
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/thinking_delta_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/thinking_delta_message.rb
@@ -1,0 +1,38 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ThinkingDeltaMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String
+              attr_reader :delta
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                @delta = event[:delta] || ""
+                event.except!(:type, :delta, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+
+              #: (PiInvocation::Context) -> String?
+              def format(context)
+                @delta
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/thinking_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/thinking_end_message.rb
@@ -1,0 +1,33 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ThinkingEndMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String
+              attr_reader :content
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                @content = event[:content] || ""
+                event.except!(:type, :content, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/thinking_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/thinking_start_message.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ThinkingStartMessage < Message
+              IGNORED_FIELDS = [
+                :assistantMessageEvent,
+              ].freeze
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_call_delta_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_call_delta_message.rb
@@ -1,0 +1,31 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolCallDeltaMessage < Message
+              IGNORED_FIELDS = [
+                :assistantMessageEvent,
+              ].freeze
+
+              #: String
+              attr_reader :delta
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.dig(:assistantMessageEvent) || {}
+                @delta = event[:delta] || ""
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_call_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_call_end_message.rb
@@ -1,0 +1,48 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolCallEndMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String?
+              attr_reader :tool_call_id
+
+              #: Symbol
+              attr_reader :name
+
+              #: Hash[Symbol, untyped]
+              attr_reader :arguments
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                tool_call = event[:toolCall] || {}
+                @tool_call_id = tool_call[:id]
+                @name = tool_call[:name]&.downcase&.to_sym || :unknown
+                @arguments = tool_call[:arguments] || {}
+                event.except!(:type, :toolCall, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+
+              #: (PiInvocation::Context) -> String?
+              def format(context)
+                tool_use = ToolUse.new(name:, input: arguments)
+                tool_use.format
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_call_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_call_start_message.rb
@@ -1,0 +1,47 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolCallStartMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String?
+              attr_reader :tool_call_id
+
+              #: Symbol
+              attr_reader :name
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                tool_call = extract_tool_call(event)
+                @tool_call_id = tool_call[:id]
+                @name = tool_call[:name]&.downcase&.to_sym || :unknown
+                event.except!(:type, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+
+              private
+
+              #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+              def extract_tool_call(event)
+                # The tool call info is in the partial's content array
+                content = event.dig(:partial, :content) || []
+                content.find { |c| c[:type] == "toolCall" } || {}
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_execution_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_execution_end_message.rb
@@ -1,0 +1,60 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolExecutionEndMessage < Message
+              #: String?
+              attr_reader :tool_call_id
+
+              #: String?
+              attr_reader :tool_name
+
+              #: Hash[Symbol, untyped]?
+              attr_reader :result_data
+
+              #: bool
+              attr_reader :is_error
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @tool_call_id = hash.delete(:toolCallId)
+                @tool_name = hash.delete(:toolName)
+                @result_data = hash.delete(:result)
+                @is_error = hash.delete(:isError) || false
+                super(type:, hash:)
+              end
+
+              #: (PiInvocation::Context) -> String?
+              def format(context)
+                tool_call = context.tool_call(tool_call_id)
+                content = extract_content
+                tool_result = ToolResult.new(tool_call:, content:, is_error:)
+                tool_result.format
+              end
+
+              private
+
+              #: () -> String?
+              def extract_content
+                return unless result_data
+
+                content_items = result_data[:content]
+                return result_data.to_s unless content_items.is_a?(Array)
+
+                content_items
+                  .select { |c| c[:type] == "text" }
+                  .map { |c| c[:text] }
+                  .join
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_execution_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_execution_start_message.rb
@@ -1,0 +1,34 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolExecutionStartMessage < Message
+              IGNORED_FIELDS = [
+                :args,
+              ].freeze
+
+              #: String?
+              attr_reader :tool_call_id
+
+              #: String?
+              attr_reader :tool_name
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @tool_call_id = hash.delete(:toolCallId)
+                @tool_name = hash.delete(:toolName)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_execution_update_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_execution_update_message.rb
@@ -1,0 +1,35 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolExecutionUpdateMessage < Message
+              IGNORED_FIELDS = [
+                :args,
+                :partialResult,
+              ].freeze
+
+              #: String?
+              attr_reader :tool_call_id
+
+              #: String?
+              attr_reader :tool_name
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @tool_call_id = hash.delete(:toolCallId)
+                @tool_name = hash.delete(:toolName)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/turn_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/turn_end_message.rb
@@ -1,0 +1,30 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TurnEndMessage < Message
+              IGNORED_FIELDS = [
+                :toolResults,
+              ].freeze
+
+              #: Hash[Symbol, untyped]?
+              attr_reader :message
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @message = hash.delete(:message)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/turn_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/turn_start_message.rb
@@ -1,0 +1,21 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TurnStartMessage < Message
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/unknown_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/unknown_message.rb
@@ -1,0 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class UnknownMessage < Message
+              #: Hash[Symbol, untyped]
+              attr_reader :raw
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                super(type:, hash:)
+                @raw = hash
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/pi_invocation.rb
+++ b/lib/roast/cogs/agent/providers/pi/pi_invocation.rb
@@ -1,0 +1,183 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class PiInvocation
+            class PiInvocationError < Roast::Error; end
+
+            class PiNotStartedError < PiInvocationError; end
+
+            class PiAlreadyStartedError < PiInvocationError; end
+
+            class PiNotCompletedError < PiInvocationError; end
+
+            class PiFailedError < PiInvocationError; end
+
+            class Context
+              def initialize
+                @tool_calls = {} #: Hash[String, Messages::ToolCallEndMessage]
+              end
+
+              #: (String?) -> Messages::ToolCallEndMessage?
+              def tool_call(tool_call_id)
+                @tool_calls[tool_call_id] if tool_call_id
+              end
+
+              #: (Messages::ToolCallEndMessage) -> void
+              def add_tool_call(tool_call_end_message)
+                id = tool_call_end_message.tool_call_id
+                @tool_calls[id] = tool_call_end_message if id
+              end
+            end
+
+            class Result
+              #: String
+              attr_accessor :response
+
+              #: bool
+              attr_accessor :success
+
+              #: String?
+              attr_accessor :session
+
+              #: Stats?
+              attr_accessor :stats
+
+              def initialize
+                @response = ""
+                @success = false
+              end
+            end
+
+            #: (Agent::Config, Agent::Input) -> void
+            def initialize(config, input)
+              @base_command = config.valid_command #: (String | Array[String])?
+              @model = config.valid_model #: String?
+              @append_system_prompt = config.valid_append_system_prompt #: String?
+              @replace_system_prompt = config.valid_replace_system_prompt #: String?
+              @working_directory = config.valid_working_directory #: Pathname?
+              @prompt = input.valid_prompt! #: String
+              @session = input.session #: String?
+              @context = Context.new #: Context
+              @result = Result.new #: Result
+              @raw_dump_file = config.valid_dump_raw_agent_messages_to_path #: Pathname?
+              @show_progress = config.show_progress? #: bool
+              @num_turns = 0 #: Integer
+            end
+
+            #: () -> void
+            def run!
+              raise PiAlreadyStartedError if started?
+
+              @started = true
+              _stdout, stderr, status = CommandRunner.execute(
+                command_line,
+                working_directory: @working_directory,
+                stdin_content: @prompt,
+                stdout_handler: lambda { |line| handle_stdout(line) },
+              )
+
+              if status.success?
+                @completed = true
+              else
+                @failed = true
+                @result.success = false
+                @result.response += "\n" unless @result.response.blank? || @result.response.ends_with?("\n")
+                @result.response += stderr
+              end
+            end
+
+            #: () -> bool
+            def started?
+              @started ||= false
+            end
+
+            #: () -> bool
+            def running?
+              started? && !completed? && !failed?
+            end
+
+            #: () -> bool
+            def completed?
+              @completed ||= false
+            end
+
+            #: () -> bool
+            def failed?
+              @failed ||= false
+            end
+
+            #: () -> Result
+            def result
+              raise PiNotStartedError unless started?
+              raise PiFailedError, @result.response if failed?
+              raise PiNotCompletedError, @result.response unless completed?
+
+              @result
+            end
+
+            private
+
+            #: (String) -> void
+            def handle_stdout(line)
+              line = line.strip
+              message = Message.from_json(line, raw_dump_file: @raw_dump_file) unless line.empty?
+              return unless message
+
+              handle_message(message)
+            end
+
+            #: (Message) -> void
+            def handle_message(message)
+              case message
+              when Messages::SessionMessage
+                @result.session = message.session_id
+              when Messages::AgentEndMessage
+                @result.response = message.response
+                @result.success = message.success
+                stats = message.stats
+                stats.num_turns = @num_turns
+                @result.stats = stats
+              when Messages::TurnEndMessage
+                @num_turns += 1
+              when Messages::ToolCallEndMessage
+                @context.add_tool_call(message)
+              end
+
+              formatted_message = message.format(@context)
+              puts formatted_message if formatted_message.present? && @show_progress
+
+              unless message.unparsed.blank?
+                Roast::Log.warn("Unhandled data in Pi #{message.type} message:")
+                Roast::Log.warn(JSON.pretty_generate(message.unparsed))
+                Roast::Log.debug("[FULL MESSAGE: #{message.type}]")
+                Roast::Log.debug(message.inspect)
+              end
+            end
+
+            #: () -> Array[String]
+            def command_line
+              command = if @base_command.is_a?(Array)
+                @base_command.dup
+              elsif @base_command.is_a?(String)
+                @base_command.split
+              else
+                ["pi"]
+              end
+              command.push("-p", "--mode", "json")
+              command.push("--model", @model) if @model
+              command.push("--system-prompt", @replace_system_prompt) if @replace_system_prompt
+              command.push("--append-system-prompt", @append_system_prompt) if @append_system_prompt
+              command.push("--session", @session) if @session.present?
+              command
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/tool_result.rb
+++ b/lib/roast/cogs/agent/providers/pi/tool_result.rb
@@ -1,0 +1,45 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class ToolResult
+            #: Symbol?
+            attr_reader :tool_name
+
+            #: String?
+            attr_reader :content
+
+            #: bool
+            attr_reader :is_error
+
+            #: (tool_call: Messages::ToolCallEndMessage?, content: String?, is_error: bool) -> void
+            def initialize(tool_call:, content:, is_error:)
+              @tool_name = tool_call&.name || :unknown
+              @content = content
+              @is_error = is_error
+            end
+
+            #: () -> String
+            def format
+              format_method_name = "format_#{tool_name}".to_sym
+              return send(format_method_name) if respond_to?(format_method_name, true)
+
+              format_unknown
+            end
+
+            private
+
+            #: () -> String
+            def format_unknown
+              "UNKNOWN [#{tool_name}] #{is_error ? "ERROR" : "OK"}\n#{content}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/pi/tool_use.rb
@@ -1,0 +1,76 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class ToolUse
+            #: Symbol
+            attr_reader :name
+
+            #: Hash[Symbol, untyped]
+            attr_reader :input
+
+            #: (name: Symbol, input: Hash[Symbol, untyped]) -> void
+            def initialize(name:, input:)
+              @name = name
+              @input = input
+            end
+
+            #: () -> String
+            def format
+              format_method_name = "format_#{name}".to_sym
+              return send(format_method_name) if respond_to?(format_method_name, true)
+
+              format_unknown
+            end
+
+            private
+
+            #: () -> String
+            def format_bash
+              "BASH #{input[:command]}"
+            end
+
+            #: () -> String
+            def format_read
+              "READ #{input[:path]}"
+            end
+
+            #: () -> String
+            def format_edit
+              "EDIT #{input[:path]}"
+            end
+
+            #: () -> String
+            def format_write
+              "WRITE #{input[:path]}"
+            end
+
+            #: () -> String
+            def format_grep
+              "GREP #{input[:pattern]} #{input[:path]}"
+            end
+
+            #: () -> String
+            def format_find
+              "FIND #{input[:path]} #{input[:pattern]}"
+            end
+
+            #: () -> String
+            def format_ls
+              "LS #{input[:path]}"
+            end
+
+            #: () -> String
+            def format_unknown
+              "UNKNOWN [#{name}] #{input.inspect}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/message_test.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class MessageTest < ActiveSupport::TestCase
+            test "from_json parses valid JSON" do
+              json = '{"type":"session","id":"abc123","version":3,"timestamp":"2026-01-01","cwd":"/tmp"}'
+              message = Message.from_json(json)
+
+              assert_kind_of Messages::SessionMessage, message
+              assert_equal "abc123", message.session_id
+            end
+
+            test "from_hash dispatches session type" do
+              message = Message.from_hash({ type: "session", id: "abc" })
+
+              assert_kind_of Messages::SessionMessage, message
+            end
+
+            test "from_hash dispatches agent_start type" do
+              message = Message.from_hash({ type: "agent_start" })
+
+              assert_kind_of Messages::AgentStartMessage, message
+            end
+
+            test "from_hash dispatches agent_end type" do
+              message = Message.from_hash({ type: "agent_end", messages: [] })
+
+              assert_kind_of Messages::AgentEndMessage, message
+            end
+
+            test "from_hash dispatches turn_start type" do
+              message = Message.from_hash({ type: "turn_start" })
+
+              assert_kind_of Messages::TurnStartMessage, message
+            end
+
+            test "from_hash dispatches turn_end type" do
+              message = Message.from_hash({ type: "turn_end", message: {}, toolResults: [] })
+
+              assert_kind_of Messages::TurnEndMessage, message
+            end
+
+            test "from_hash dispatches message_start type" do
+              message = Message.from_hash({ type: "message_start", message: {} })
+
+              assert_kind_of Messages::MessageStartMessage, message
+            end
+
+            test "from_hash dispatches message_end type" do
+              message = Message.from_hash({ type: "message_end", message: {} })
+
+              assert_kind_of Messages::MessageEndMessage, message
+            end
+
+            test "from_hash dispatches tool_execution_start type" do
+              message = Message.from_hash({
+                type: "tool_execution_start",
+                toolCallId: "123",
+                toolName: "bash",
+                args: {},
+              })
+
+              assert_kind_of Messages::ToolExecutionStartMessage, message
+            end
+
+            test "from_hash dispatches tool_execution_update type" do
+              message = Message.from_hash({
+                type: "tool_execution_update",
+                toolCallId: "123",
+                toolName: "bash",
+                args: {},
+                partialResult: {},
+              })
+
+              assert_kind_of Messages::ToolExecutionUpdateMessage, message
+            end
+
+            test "from_hash dispatches tool_execution_end type" do
+              message = Message.from_hash({
+                type: "tool_execution_end",
+                toolCallId: "123",
+                toolName: "bash",
+                result: { content: [{ type: "text", text: "output" }] },
+                isError: false,
+              })
+
+              assert_kind_of Messages::ToolExecutionEndMessage, message
+            end
+
+            test "from_hash dispatches unknown type" do
+              message = Message.from_hash({ type: "something_new", data: 123 })
+
+              assert_kind_of Messages::UnknownMessage, message
+            end
+
+            # message_update sub-dispatch tests
+
+            test "from_hash dispatches message_update text_delta" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "text_delta", delta: "Hello", contentIndex: 0 },
+              })
+
+              assert_kind_of Messages::TextDeltaMessage, message
+              assert_equal "Hello", message.delta
+            end
+
+            test "from_hash dispatches message_update text_start" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "text_start", contentIndex: 0, partial: {} },
+              })
+
+              assert_kind_of Messages::TextStartMessage, message
+            end
+
+            test "from_hash dispatches message_update text_end" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "text_end", content: "Final text", contentIndex: 0, partial: {} },
+              })
+
+              assert_kind_of Messages::TextEndMessage, message
+              assert_equal "Final text", message.content
+            end
+
+            test "from_hash dispatches message_update thinking_delta" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "thinking_delta", delta: "Thinking...", contentIndex: 0 },
+              })
+
+              assert_kind_of Messages::ThinkingDeltaMessage, message
+              assert_equal "Thinking...", message.delta
+            end
+
+            test "from_hash dispatches message_update thinking_start" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "thinking_start", contentIndex: 0, partial: {} },
+              })
+
+              assert_kind_of Messages::ThinkingStartMessage, message
+            end
+
+            test "from_hash dispatches message_update thinking_end" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "thinking_end", content: "Full thought", contentIndex: 0, partial: {} },
+              })
+
+              assert_kind_of Messages::ThinkingEndMessage, message
+              assert_equal "Full thought", message.content
+            end
+
+            test "from_hash dispatches message_update toolcall_start" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: {
+                  type: "toolcall_start",
+                  contentIndex: 1,
+                  partial: {
+                    content: [
+                      { type: "toolCall", id: "tool_1", name: "bash", arguments: {} },
+                    ],
+                  },
+                },
+              })
+
+              assert_kind_of Messages::ToolCallStartMessage, message
+              assert_equal "tool_1", message.tool_call_id
+              assert_equal :bash, message.name
+            end
+
+            test "from_hash dispatches message_update toolcall_delta" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "toolcall_delta", delta: '{"command": "ls' },
+              })
+
+              assert_kind_of Messages::ToolCallDeltaMessage, message
+              assert_equal '{"command": "ls', message.delta
+            end
+
+            test "from_hash dispatches message_update toolcall_end" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: {
+                  type: "toolcall_end",
+                  toolCall: { id: "tool_1", name: "bash", arguments: { command: "ls -la" } },
+                },
+              })
+
+              assert_kind_of Messages::ToolCallEndMessage, message
+              assert_equal "tool_1", message.tool_call_id
+              assert_equal :bash, message.name
+              assert_equal({ command: "ls -la" }, message.arguments)
+            end
+
+            test "from_hash dispatches unknown message_update sub-type" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "new_event_type" },
+              })
+
+              assert_kind_of Messages::UnknownMessage, message
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/agent_end_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/agent_end_message_test.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class AgentEndMessageTest < ActiveSupport::TestCase
+              test "extracts response from last assistant message" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      { role: "user", content: [{ type: "text", text: "hello" }] },
+                      { role: "assistant", content: [{ type: "text", text: "Hi there!" }], model: "test-model", usage: { input: 5, output: 10, cost: { total: 0.001 } } },
+                    ],
+                  },
+                )
+
+                assert_equal "Hi there!", message.response
+              end
+
+              test "joins multiple text content blocks" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      {
+                        role: "assistant",
+                        content: [
+                          { type: "thinking", thinking: "Let me think..." },
+                          { type: "text", text: "Part one. " },
+                          { type: "text", text: "Part two." },
+                        ],
+                        model: "test-model",
+                        usage: { input: 5, output: 10, cost: { total: 0.001 } },
+                      },
+                    ],
+                  },
+                )
+
+                assert_equal "Part one. Part two.", message.response
+              end
+
+              test "returns empty string when no assistant messages" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      { role: "user", content: [{ type: "text", text: "hello" }] },
+                    ],
+                  },
+                )
+
+                assert_equal "", message.response
+              end
+
+              test "success is true by default" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: { messages: [] },
+                )
+
+                assert message.success
+              end
+
+              test "computes aggregate stats from assistant messages" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      {
+                        role: "assistant",
+                        model: "claude-sonnet",
+                        content: [{ type: "text", text: "response 1" }],
+                        usage: { input: 100, output: 50, cost: { total: 0.01 } },
+                      },
+                      { role: "user", content: [{ type: "text", text: "followup" }] },
+                      {
+                        role: "assistant",
+                        model: "claude-sonnet",
+                        content: [{ type: "text", text: "response 2" }],
+                        usage: { input: 200, output: 80, cost: { total: 0.02 } },
+                      },
+                    ],
+                  },
+                )
+
+                stats = message.stats
+                assert_equal 300, stats.usage.input_tokens
+                assert_equal 130, stats.usage.output_tokens
+                assert_in_delta 0.03, stats.usage.cost_usd
+
+                model_usage = stats.model_usage["claude-sonnet"]
+                assert_not_nil model_usage
+                assert_equal 300, model_usage.input_tokens
+                assert_equal 130, model_usage.output_tokens
+              end
+
+              test "computes per-model stats for multiple models" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      {
+                        role: "assistant",
+                        model: "model-a",
+                        content: [{ type: "text", text: "" }],
+                        usage: { input: 100, output: 50, cost: { total: 0.01 } },
+                      },
+                      {
+                        role: "assistant",
+                        model: "model-b",
+                        content: [{ type: "text", text: "final" }],
+                        usage: { input: 200, output: 80, cost: { total: 0.02 } },
+                      },
+                    ],
+                  },
+                )
+
+                stats = message.stats
+                assert_equal 2, stats.model_usage.size
+                assert_equal 100, stats.model_usage["model-a"].input_tokens
+                assert_equal 200, stats.model_usage["model-b"].input_tokens
+              end
+
+              test "handles assistant messages without usage data" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      { role: "assistant", content: [{ type: "text", text: "hi" }] },
+                    ],
+                  },
+                )
+
+                assert_equal "hi", message.response
+                assert message.stats.model_usage.empty?
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/session_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/session_message_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class SessionMessageTest < ActiveSupport::TestCase
+              test "extracts session_id from id field" do
+                message = SessionMessage.new(
+                  type: :session,
+                  hash: { id: "abc-123", version: 3, timestamp: "2026-01-01", cwd: "/tmp" },
+                )
+
+                assert_equal "abc-123", message.session_id
+              end
+
+              test "ignores version, timestamp, and cwd" do
+                message = SessionMessage.new(
+                  type: :session,
+                  hash: { id: "abc-123", version: 3, timestamp: "2026-01-01", cwd: "/tmp" },
+                )
+
+                assert message.unparsed.empty?
+              end
+
+              test "session_id is nil when id not present" do
+                message = SessionMessage.new(type: :session, hash: {})
+
+                assert_nil message.session_id
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/text_delta_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/text_delta_message_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TextDeltaMessageTest < ActiveSupport::TestCase
+              test "extracts delta from assistantMessageEvent" do
+                message = TextDeltaMessage.new(
+                  type: :text_delta,
+                  hash: {
+                    assistantMessageEvent: { type: "text_delta", delta: "Hello world", contentIndex: 0, partial: {} },
+                    message: {},
+                  },
+                )
+
+                assert_equal "Hello world", message.delta
+              end
+
+              test "format returns the delta text" do
+                message = TextDeltaMessage.new(
+                  type: :text_delta,
+                  hash: {
+                    assistantMessageEvent: { type: "text_delta", delta: "chunk", contentIndex: 0, partial: {} },
+                    message: {},
+                  },
+                )
+
+                context = PiInvocation::Context.new
+                assert_equal "chunk", message.format(context)
+              end
+
+              test "delta defaults to empty string when missing" do
+                message = TextDeltaMessage.new(
+                  type: :text_delta,
+                  hash: { assistantMessageEvent: { type: "text_delta" } },
+                )
+
+                assert_equal "", message.delta
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/thinking_delta_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/thinking_delta_message_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ThinkingDeltaMessageTest < ActiveSupport::TestCase
+              test "extracts delta from assistantMessageEvent" do
+                message = ThinkingDeltaMessage.new(
+                  type: :thinking_delta,
+                  hash: {
+                    assistantMessageEvent: { type: "thinking_delta", delta: "Let me consider...", contentIndex: 0, partial: {} },
+                    message: {},
+                  },
+                )
+
+                assert_equal "Let me consider...", message.delta
+              end
+
+              test "format returns the thinking delta" do
+                message = ThinkingDeltaMessage.new(
+                  type: :thinking_delta,
+                  hash: {
+                    assistantMessageEvent: { type: "thinking_delta", delta: "hmm", contentIndex: 0, partial: {} },
+                    message: {},
+                  },
+                )
+
+                context = PiInvocation::Context.new
+                assert_equal "hmm", message.format(context)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/tool_call_end_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/tool_call_end_message_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolCallEndMessageTest < ActiveSupport::TestCase
+              test "extracts tool call details from assistantMessageEvent" do
+                message = ToolCallEndMessage.new(
+                  type: :toolcall_end,
+                  hash: {
+                    assistantMessageEvent: {
+                      type: "toolcall_end",
+                      toolCall: { id: "tool_abc", name: "bash", arguments: { command: "echo hi" } },
+                    },
+                  },
+                )
+
+                assert_equal "tool_abc", message.tool_call_id
+                assert_equal :bash, message.name
+                assert_equal({ command: "echo hi" }, message.arguments)
+              end
+
+              test "name defaults to :unknown when not present" do
+                message = ToolCallEndMessage.new(
+                  type: :toolcall_end,
+                  hash: {
+                    assistantMessageEvent: {
+                      type: "toolcall_end",
+                      toolCall: { id: "tool_abc" },
+                    },
+                  },
+                )
+
+                assert_equal :unknown, message.name
+              end
+
+              test "format returns tool use description" do
+                message = ToolCallEndMessage.new(
+                  type: :toolcall_end,
+                  hash: {
+                    assistantMessageEvent: {
+                      type: "toolcall_end",
+                      toolCall: { id: "tool_1", name: "bash", arguments: { command: "ls -la" } },
+                    },
+                  },
+                )
+
+                context = PiInvocation::Context.new
+                formatted = message.format(context)
+                assert_equal "BASH ls -la", formatted
+              end
+
+              test "format returns read description for read tool" do
+                message = ToolCallEndMessage.new(
+                  type: :toolcall_end,
+                  hash: {
+                    assistantMessageEvent: {
+                      type: "toolcall_end",
+                      toolCall: { id: "tool_1", name: "read", arguments: { path: "/tmp/file.rb" } },
+                    },
+                  },
+                )
+
+                context = PiInvocation::Context.new
+                formatted = message.format(context)
+                assert_equal "READ /tmp/file.rb", formatted
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/tool_execution_end_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/tool_execution_end_message_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolExecutionEndMessageTest < ActiveSupport::TestCase
+              test "extracts tool execution fields" do
+                message = ToolExecutionEndMessage.new(
+                  type: :tool_execution_end,
+                  hash: {
+                    toolCallId: "tool_123",
+                    toolName: "bash",
+                    result: { content: [{ type: "text", text: "output here" }] },
+                    isError: false,
+                  },
+                )
+
+                assert_equal "tool_123", message.tool_call_id
+                assert_equal "bash", message.tool_name
+                refute message.is_error
+              end
+
+              test "extracts text content from result" do
+                message = ToolExecutionEndMessage.new(
+                  type: :tool_execution_end,
+                  hash: {
+                    toolCallId: "tool_1",
+                    toolName: "bash",
+                    result: {
+                      content: [
+                        { type: "text", text: "line 1\n" },
+                        { type: "text", text: "line 2\n" },
+                      ],
+                    },
+                    isError: false,
+                  },
+                )
+
+                content = message.send(:extract_content)
+                assert_equal "line 1\nline 2\n", content
+              end
+
+              test "is_error defaults to false" do
+                message = ToolExecutionEndMessage.new(
+                  type: :tool_execution_end,
+                  hash: {
+                    toolCallId: "tool_1",
+                    toolName: "bash",
+                    result: {},
+                  },
+                )
+
+                refute message.is_error
+              end
+
+              test "format uses context to look up tool call" do
+                # First, register a tool call in context
+                tool_call = ToolCallEndMessage.new(
+                  type: :toolcall_end,
+                  hash: {
+                    assistantMessageEvent: {
+                      type: "toolcall_end",
+                      toolCall: { id: "tool_1", name: "bash", arguments: { command: "ls" } },
+                    },
+                  },
+                )
+                context = PiInvocation::Context.new
+                context.add_tool_call(tool_call)
+
+                message = ToolExecutionEndMessage.new(
+                  type: :tool_execution_end,
+                  hash: {
+                    toolCallId: "tool_1",
+                    toolName: "bash",
+                    result: { content: [{ type: "text", text: "file.txt\n" }] },
+                    isError: false,
+                  },
+                )
+
+                formatted = message.format(context)
+                assert_kind_of String, formatted
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/pi_invocation_test.rb
+++ b/test/roast/cogs/agent/providers/pi/pi_invocation_test.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class PiInvocationTest < ActiveSupport::TestCase
+            def setup
+              @config = Agent::Config.new
+              @config.provider(:pi)
+              @config.no_show_progress!
+              @input = Agent::Input.new
+              @input.prompt = "Test prompt"
+              @invocation = PiInvocation.new(@config, @input)
+            end
+
+            def success_status
+              mock = Minitest::Mock.new
+              mock.expect(:success?, true)
+              mock
+            end
+
+            def failure_status
+              mock = Minitest::Mock.new
+              mock.expect(:success?, false)
+              mock
+            end
+
+            # Context tests
+
+            test "Context#tool_call returns nil when tool_call_id is nil" do
+              context = PiInvocation::Context.new
+
+              assert_nil context.tool_call(nil)
+            end
+
+            test "Context#tool_call returns nil for unknown tool_call_id" do
+              context = PiInvocation::Context.new
+
+              assert_nil context.tool_call("unknown_id")
+            end
+
+            test "Context#tool_call returns stored ToolCallEndMessage for known id" do
+              context = PiInvocation::Context.new
+              tool_call_message = Messages::ToolCallEndMessage.new(
+                type: :toolcall_end,
+                hash: {
+                  assistantMessageEvent: {
+                    type: "toolcall_end",
+                    toolCall: { id: "test_id", name: "bash", arguments: { command: "ls" } },
+                  },
+                },
+              )
+              context.add_tool_call(tool_call_message)
+
+              result = context.tool_call("test_id")
+
+              assert_equal tool_call_message, result
+            end
+
+            test "Context#add_tool_call ignores message with nil id" do
+              context = PiInvocation::Context.new
+              tool_call_message = Messages::ToolCallEndMessage.new(
+                type: :toolcall_end,
+                hash: {
+                  assistantMessageEvent: {
+                    type: "toolcall_end",
+                    toolCall: { name: "bash", arguments: { command: "ls" } },
+                  },
+                },
+              )
+              context.add_tool_call(tool_call_message)
+
+              assert_nil context.tool_call(nil)
+            end
+
+            # Result tests
+
+            test "Result initializes with empty response and success false" do
+              result = PiInvocation::Result.new
+
+              assert_equal "", result.response
+              refute result.success
+              assert_nil result.session
+              assert_nil result.stats
+            end
+
+            # State tests
+
+            test "started? returns false initially" do
+              refute @invocation.started?
+            end
+
+            test "completed? returns false initially" do
+              refute @invocation.completed?
+            end
+
+            test "failed? returns false initially" do
+              refute @invocation.failed?
+            end
+
+            test "running? returns false when not started" do
+              refute @invocation.running?
+            end
+
+            test "result raises PiNotStartedError when not started" do
+              assert_raises(PiInvocation::PiNotStartedError) do
+                @invocation.result
+              end
+            end
+
+            test "result raises PiFailedError when failed" do
+              CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
+                @invocation.run!
+              end
+
+              assert_raises(PiInvocation::PiFailedError) do
+                @invocation.result
+              end
+            end
+
+            test "result raises PiNotCompletedError when started but not completed" do
+              CommandRunner.stub(:execute, ->(*) {
+                assert_raises(PiInvocation::PiNotCompletedError) do
+                  @invocation.result
+                end
+                ["", "", success_status]
+              }) do
+                @invocation.run!
+              end
+            end
+
+            test "run! raises PiAlreadyStartedError when called twice" do
+              CommandRunner.stub(:execute, ["", "", success_status]) do
+                @invocation.run!
+                assert_raises(PiInvocation::PiAlreadyStartedError) do
+                  @invocation.run!
+                end
+              end
+            end
+
+            test "run! sets started to true" do
+              CommandRunner.stub(:execute, ["", "", success_status]) do
+                @invocation.run!
+              end
+
+              assert @invocation.started?
+            end
+
+            test "run! sets completed to true on successful execution" do
+              CommandRunner.stub(:execute, ["", "", success_status]) do
+                @invocation.run!
+              end
+
+              assert @invocation.completed?
+              refute @invocation.failed?
+            end
+
+            test "run! sets failed to true on unsuccessful execution" do
+              CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
+                @invocation.run!
+              end
+
+              assert @invocation.failed?
+              refute @invocation.completed?
+            end
+
+            test "running? returns true during execution" do
+              CommandRunner.stub(:execute, ->(*) {
+                assert @invocation.started?
+                assert @invocation.running?
+                ["", "", success_status]
+              }) do
+                @invocation.run!
+              end
+
+              refute @invocation.running?
+            end
+
+            test "result returns Result object when completed successfully" do
+              CommandRunner.stub(:execute, ["", "", success_status]) do
+                @invocation.run!
+              end
+
+              result = @invocation.result
+              assert_kind_of PiInvocation::Result, result
+            end
+
+            # Command line tests
+
+            test "command_line uses default pi command" do
+              command = @invocation.send(:command_line)
+
+              assert_equal "pi", command.first
+              assert_includes command, "-p"
+              assert_includes command, "--mode"
+              assert_includes command, "json"
+            end
+
+            test "command_line uses custom command when configured as string" do
+              @config.command("custom-pi --flag")
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              assert_equal "custom-pi", command.first
+              assert_includes command, "--flag"
+            end
+
+            test "command_line uses custom command when configured as array" do
+              @config.command(["my-pi", "--opt"])
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              assert_equal "my-pi", command.first
+              assert_includes command, "--opt"
+            end
+
+            test "command_line includes model when configured" do
+              @config.model("claude-sonnet-4-20250514")
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              model_index = command.index("--model")
+              assert model_index
+              assert_equal "claude-sonnet-4-20250514", command[model_index + 1]
+            end
+
+            test "command_line includes replace_system_prompt when configured" do
+              @config.replace_system_prompt("Custom system prompt")
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              prompt_index = command.index("--system-prompt")
+              assert prompt_index
+              assert_equal "Custom system prompt", command[prompt_index + 1]
+            end
+
+            test "command_line includes append_system_prompt when configured" do
+              @config.append_system_prompt("Additional instructions")
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              prompt_index = command.index("--append-system-prompt")
+              assert prompt_index
+              assert_equal "Additional instructions", command[prompt_index + 1]
+            end
+
+            test "command_line includes session flag when session is set" do
+              @input.session = "/path/to/session.jsonl"
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              assert_includes command, "--session"
+              session_index = command.index("--session")
+              assert_equal "/path/to/session.jsonl", command[session_index + 1]
+            end
+
+            test "command_line does not include session flag when session is blank" do
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              refute_includes command, "--session"
+            end
+
+            # Message handling tests
+
+            test "handle_message processes SessionMessage and sets session" do
+              session_message = Messages::SessionMessage.new(
+                type: :session,
+                hash: { id: "session_123", version: 3, timestamp: "2026-01-01", cwd: "/tmp" },
+              )
+
+              @invocation.send(:handle_message, session_message)
+
+              internal_result = @invocation.instance_variable_get(:@result)
+              assert_equal "session_123", internal_result.session
+            end
+
+            test "handle_message processes AgentEndMessage and sets response" do
+              agent_end_message = Messages::AgentEndMessage.new(
+                type: :agent_end,
+                hash: {
+                  messages: [
+                    { role: "user", content: [{ type: "text", text: "hello" }] },
+                    {
+                      role: "assistant",
+                      model: "claude-sonnet-4-20250514",
+                      content: [{ type: "text", text: "Test response" }],
+                      usage: { input: 10, output: 20, cost: { total: 0.001 } },
+                    },
+                  ],
+                },
+              )
+
+              @invocation.send(:handle_message, agent_end_message)
+
+              internal_result = @invocation.instance_variable_get(:@result)
+              assert_equal "Test response", internal_result.response
+              assert internal_result.success
+              assert_not_nil internal_result.stats
+            end
+
+            test "handle_message processes TurnEndMessage and increments turn counter" do
+              turn_end = Messages::TurnEndMessage.new(
+                type: :turn_end,
+                hash: { message: { role: "assistant" }, toolResults: [] },
+              )
+
+              @invocation.send(:handle_message, turn_end)
+              @invocation.send(:handle_message, turn_end)
+
+              assert_equal 2, @invocation.instance_variable_get(:@num_turns)
+            end
+
+            test "handle_message processes ToolCallEndMessage and stores in context" do
+              tool_call_message = Messages::ToolCallEndMessage.new(
+                type: :toolcall_end,
+                hash: {
+                  assistantMessageEvent: {
+                    type: "toolcall_end",
+                    toolCall: { id: "tool_123", name: "bash", arguments: { command: "ls" } },
+                  },
+                },
+              )
+
+              @invocation.send(:handle_message, tool_call_message)
+
+              context = @invocation.instance_variable_get(:@context)
+              assert_equal tool_call_message, context.tool_call("tool_123")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/tool_result_test.rb
+++ b/test/roast/cogs/agent/providers/pi/tool_result_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class ToolResultTest < ActiveSupport::TestCase
+            test "extracts tool_name from tool_call" do
+              tool_call = Messages::ToolCallEndMessage.new(
+                type: :toolcall_end,
+                hash: {
+                  assistantMessageEvent: {
+                    type: "toolcall_end",
+                    toolCall: { id: "1", name: "bash", arguments: {} },
+                  },
+                },
+              )
+
+              tool_result = ToolResult.new(tool_call:, content: "output", is_error: false)
+
+              assert_equal :bash, tool_result.tool_name
+            end
+
+            test "uses :unknown when tool_call is nil" do
+              tool_result = ToolResult.new(tool_call: nil, content: "output", is_error: false)
+
+              assert_equal :unknown, tool_result.tool_name
+            end
+
+            test "format shows error status" do
+              tool_result = ToolResult.new(tool_call: nil, content: "error msg", is_error: true)
+
+              formatted = tool_result.format
+              assert_match(/ERROR/, formatted)
+              assert_match(/error msg/, formatted)
+            end
+
+            test "format shows OK status" do
+              tool_result = ToolResult.new(tool_call: nil, content: "success", is_error: false)
+
+              formatted = tool_result.format
+              assert_match(/OK/, formatted)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/pi/tool_use_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class ToolUseTest < ActiveSupport::TestCase
+            test "format_bash formats bash command" do
+              tool_use = ToolUse.new(name: :bash, input: { command: "ls -la" })
+
+              assert_equal "BASH ls -la", tool_use.format
+            end
+
+            test "format_read formats read path" do
+              tool_use = ToolUse.new(name: :read, input: { path: "/tmp/file.rb" })
+
+              assert_equal "READ /tmp/file.rb", tool_use.format
+            end
+
+            test "format_edit formats edit path" do
+              tool_use = ToolUse.new(name: :edit, input: { path: "/tmp/file.rb" })
+
+              assert_equal "EDIT /tmp/file.rb", tool_use.format
+            end
+
+            test "format_write formats write path" do
+              tool_use = ToolUse.new(name: :write, input: { path: "/tmp/file.rb" })
+
+              assert_equal "WRITE /tmp/file.rb", tool_use.format
+            end
+
+            test "format_grep formats grep command" do
+              tool_use = ToolUse.new(name: :grep, input: { pattern: "TODO", path: "/tmp" })
+
+              assert_equal "GREP TODO /tmp", tool_use.format
+            end
+
+            test "format_find formats find command" do
+              tool_use = ToolUse.new(name: :find, input: { path: "/tmp", pattern: "*.rb" })
+
+              assert_equal "FIND /tmp *.rb", tool_use.format
+            end
+
+            test "format_ls formats ls command" do
+              tool_use = ToolUse.new(name: :ls, input: { path: "/tmp" })
+
+              assert_equal "LS /tmp", tool_use.format
+            end
+
+            test "format_unknown for unrecognized tools" do
+              tool_use = ToolUse.new(name: :custom_tool, input: { key: "value" })
+
+              assert_match(/UNKNOWN \[custom_tool\]/, tool_use.format)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `:pi` as a new agent provider, allowing Roast workflows to use the [Pi coding agent](https://github.com/Shopify/pi) for local filesystem tasks.

## Motivation

The agent cog currently only supports Claude Code as a provider. Pi is another coding agent with local filesystem access, tool use, and session management — making it a natural fit as an additional provider.

## What changed

### Existing file changes (2 files)

- **`lib/roast/cogs/agent.rb`** — Added `when :pi` branch to the `provider` method
- **`lib/roast/cogs/agent/config.rb`** — Added `:pi` to `VALID_PROVIDERS`

### New source files (25 files)

The implementation mirrors the Claude provider architecture exactly:

| Component | File | Purpose |
|-----------|------|---------|
| Provider | `providers/pi.rb` | Entry point with `invoke(input)` and inner `Output` class |
| Invocation | `providers/pi/pi_invocation.rb` | Builds CLI command, executes via CommandRunner, parses streaming JSON |
| Message factory | `providers/pi/message.rb` | Dispatches JSON messages to typed message classes |
| 18 message types | `providers/pi/messages/*.rb` | Cover Pi's full streaming protocol |
| Tool formatters | `providers/pi/tool_use.rb`, `tool_result.rb` | Display formatters for Pi's tools |

### Pi CLI integration

- Runs `pi -p --mode json` for non-interactive streaming JSON output
- Supports `--model`, `--system-prompt`, `--append-system-prompt`, `--session` flags
- Extracts session ID from the `session` message for conversation resumption
- Computes aggregate token usage and cost stats from all assistant messages
- Counts turns from `turn_end` messages
- Streams progress (text deltas, thinking, tool calls) when `show_progress` is enabled

### Message protocol coverage

Pi's `--mode json` emits these message types, all of which are handled:

- `session` → Session ID extraction
- `agent_start` / `agent_end` → Agent lifecycle (end message computes final stats)
- `turn_start` / `turn_end` → Turn counting
- `message_start` / `message_end` → Message lifecycle
- `message_update` with sub-types: `text_start/delta/end`, `thinking_start/delta/end`, `toolcall_start/delta/end`
- `tool_execution_start/update/end` → Tool execution lifecycle

## Usage

```ruby
agent(:review) do |input|
  config.provider :pi
  config.model "anthropic/claude-sonnet-4-20250514"
  input.prompt = "Review this code for issues"
end
```

## Tests

- **87 new tests** covering invocation, message parsing, tool formatting
- **Full suite passes**: 895 tests, 1475 assertions, 0 failures, 0 errors