### PR TITLE
Use event framework for logging in all places that previously logged directly

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/claude_invocation.rb
+++ b/lib/roast/cogs/agent/providers/claude/claude_invocation.rb
@@ -153,10 +153,12 @@ module Roast
 
               unless message.unparsed.blank?
                 # TODO: do something better with unhandled data so we can improve the parser
-                Roast::Log.warn("Unhandled data in Claude #{message.type} message:")
-                Roast::Log.warn(JSON.pretty_generate(message.unparsed))
-                Roast::Log.debug("[FULL MESSAGE: #{message.type}]")
-                Roast::Log.debug(message.inspect)
+                Event << {
+                  debug: <<~DEBUG,
+                    Unhandled data in Claude #{message.type} message:
+                      #{JSON.pretty_generate(message.unparsed)}
+                  DEBUG
+                }
               end
 
               raise ClaudeFailedError, message.error if message.error.present?

--- a/lib/roast/command_runner.rb
+++ b/lib/roast/command_runner.rb
@@ -98,7 +98,7 @@ module Roast
               begin
                 stdout_handler&.call(line)
               rescue => e
-                Roast::Log.warn("stdout_handler raised: #{e.class} - #{e.message}")
+                Event << { warn: "stdout_handler raised: #{e.class} - #{e.message}" }
               end
             end
             buffer
@@ -114,7 +114,7 @@ module Roast
               begin
                 stderr_handler&.call(line)
               rescue => e
-                Roast::Log.warn("stderr_handler raised: #{e.class} - #{e.message}")
+                Event << { warn: "stderr_handler raised: #{e.class} - #{e.message}" }
               end
             end
             buffer
@@ -181,7 +181,7 @@ module Roast
       rescue Errno::ESRCH
         # Process already terminated
       rescue Errno::EPERM
-        Roast::Log.error("Could not kill process #{pid}: Permission denied")
+        Event << { error: "Could not kill process #{pid}: Permission denied" }
       end
 
       #: (Integer) -> bool

--- a/test/roast/cogs/agent/providers/claude/claude_invocation_test.rb
+++ b/test/roast/cogs/agent/providers/claude/claude_invocation_test.rb
@@ -308,6 +308,28 @@ module Roast
               end
             end
 
+            test "handle_message emits debug event for unparsed message data" do
+              message = Messages::TextMessage.new(
+                type: :text,
+                hash: { text: "Hello", extra_field: "unexpected" },
+              )
+
+              Event.expects(:<<).with { |payload| payload[:debug].include?("Unhandled data") }
+
+              @invocation.send(:handle_message, message)
+            end
+
+            test "handle_message does not emit event when unparsed data is blank" do
+              message = Messages::ResultMessage.new(
+                type: :result,
+                hash: { result: "Test response", subtype: "success" },
+              )
+
+              Event.expects(:<<).never
+
+              @invocation.send(:handle_message, message)
+            end
+
             test "handle_message captures session_id when present" do
               message = Messages::TextMessage.new(
                 type: :text,

--- a/test/roast/command_runner_test.rb
+++ b/test/roast/command_runner_test.rb
@@ -192,11 +192,18 @@ module Roast
       end
     end
 
-    test "handler exceptions are logged as warnings" do
+    test "stdout handler exceptions emit warning event" do
+      Event.expects(:<<).with { |payload| payload[:warn]&.include?("stdout_handler raised: StandardError - Test error") }
+
       stdout_handler = ->(_line) { raise StandardError, "Test error" }
       CommandRunner.execute(["echo", "test"], stdout_handler:)
+    end
 
-      assert_match(/stdout_handler raised: StandardError - Test error/, @logger_output.string)
+    test "stderr handler exceptions emit warning event" do
+      Event.expects(:<<).with { |payload| payload[:warn]&.include?("stderr_handler raised: StandardError - Test error") }
+
+      stderr_handler = ->(_line) { raise StandardError, "Test error" }
+      CommandRunner.execute(["bash", "-c", "echo 'err' >&2"], stderr_handler:)
     end
 
     test "runs command in current working directory if no working directory specified" do


### PR DESCRIPTION
A few places were still logging directly instead of using the event framework. As a result, their task paths were not getting captured and displayed correctly