### PR TITLE
Log new claude session IDs at debug level whenever a new session ID is seen

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/claude_invocation.rb
+++ b/lib/roast/cogs/agent/providers/claude/claude_invocation.rb
@@ -146,7 +146,10 @@ module Roast
                 message.messages.each { |msg| handle_message(msg) }
               end
 
-              @result.session = message.session_id if message.session_id.present?
+              if message.session_id.present?
+                (Event << { debug: "New Claude Session ID: #{message.session_id}" }) if @result.session != message.session_id
+                @result.session = message.session_id
+              end
 
               formatted_message = message.format(@context)
               puts formatted_message if formatted_message.present? && @show_progress

--- a/test/roast/cogs/agent/providers/claude/claude_invocation_test.rb
+++ b/test/roast/cogs/agent/providers/claude/claude_invocation_test.rb
@@ -341,6 +341,35 @@ module Roast
               internal_result = @invocation.instance_variable_get(:@result)
               assert_equal "new_session", internal_result.session
             end
+
+            test "handle_message emits info event when session_id is set for the first time" do
+              message = Messages::TextMessage.new(
+                type: :text,
+                hash: { text: "Hello", session_id: "first_session" },
+              )
+
+              Event.expects(:<<).with { |payload| payload[:debug] == "New Claude Session ID: first_session" }
+
+              @invocation.send(:handle_message, message)
+            end
+
+            test "handle_message emits info event when session_id changes" do
+              first = Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "session_1" })
+              second = Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "session_2" })
+
+              @invocation.send(:handle_message, first)
+              Event.expects(:<<).with { |payload| payload[:debug] == "New Claude Session ID: session_2" }
+              @invocation.send(:handle_message, second)
+            end
+
+            test "handle_message does not emit event when session_id is unchanged" do
+              first = Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "same_session" })
+              second = Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "same_session" })
+
+              @invocation.send(:handle_message, first)
+              Event.expects(:<<).never
+              @invocation.send(:handle_message, second)
+            end
           end
         end
       end


### PR DESCRIPTION
Logging Claude session IDs will make it possible to resume a Claude session if you see it doing the wrong thing and hit ctrl-C on the workflow to dig in. This will really help accelerate workflow development and debugging.

Longer term, I'd like to support and automatic summary output at the end of the workflow (on success or failure) with some info like all of the session IDs as well as stats like total token usage. But this feature is useful in the short term and still valuable overall