### PR TITLE
Add text and thinking streaming messages for Pi provider

### DIFF
--- a/lib/roast/cogs/agent/providers/pi/messages/text_delta_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/text_delta_message.rb
@@ -1,0 +1,38 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TextDeltaMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String
+              attr_reader :delta
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                @delta = event[:delta] || ""
+                event.except!(:type, :delta, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+
+              #: (PiInvocation::Context) -> String?
+              def format(context)
+                @delta
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/text_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/text_end_message.rb
@@ -1,0 +1,33 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TextEndMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String
+              attr_reader :content
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                @content = event[:content] || ""
+                event.except!(:type, :content, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/text_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/text_start_message.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TextStartMessage < Message
+              IGNORED_FIELDS = [
+                :assistantMessageEvent,
+              ].freeze
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/thinking_delta_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/thinking_delta_message.rb
@@ -1,0 +1,38 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ThinkingDeltaMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String
+              attr_reader :delta
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                @delta = event[:delta] || ""
+                event.except!(:type, :delta, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+
+              #: (PiInvocation::Context) -> String?
+              def format(context)
+                @delta
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/thinking_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/thinking_end_message.rb
@@ -1,0 +1,33 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ThinkingEndMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String
+              attr_reader :content
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                @content = event[:content] || ""
+                event.except!(:type, :content, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/thinking_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/thinking_start_message.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ThinkingStartMessage < Message
+              IGNORED_FIELDS = [
+                :assistantMessageEvent,
+              ].freeze
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/message_test.rb
@@ -57,6 +57,75 @@ module Roast
 
               assert_kind_of Messages::UnknownMessage, message
             end
+
+            # message_update sub-dispatch tests
+
+            test "from_hash dispatches message_update text_delta" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "text_delta", delta: "Hello", contentIndex: 0 },
+              })
+
+              assert_kind_of Messages::TextDeltaMessage, message
+              assert_equal "Hello", message.delta
+            end
+
+            test "from_hash dispatches message_update text_start" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "text_start", contentIndex: 0, partial: {} },
+              })
+
+              assert_kind_of Messages::TextStartMessage, message
+            end
+
+            test "from_hash dispatches message_update text_end" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "text_end", content: "Final text", contentIndex: 0, partial: {} },
+              })
+
+              assert_kind_of Messages::TextEndMessage, message
+              assert_equal "Final text", message.content
+            end
+
+            test "from_hash dispatches message_update thinking_delta" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "thinking_delta", delta: "Thinking...", contentIndex: 0 },
+              })
+
+              assert_kind_of Messages::ThinkingDeltaMessage, message
+              assert_equal "Thinking...", message.delta
+            end
+
+            test "from_hash dispatches message_update thinking_start" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "thinking_start", contentIndex: 0, partial: {} },
+              })
+
+              assert_kind_of Messages::ThinkingStartMessage, message
+            end
+
+            test "from_hash dispatches message_update thinking_end" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "thinking_end", content: "Full thought", contentIndex: 0, partial: {} },
+              })
+
+              assert_kind_of Messages::ThinkingEndMessage, message
+              assert_equal "Full thought", message.content
+            end
+
+            test "from_hash dispatches unknown message_update sub-type" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "new_event_type" },
+              })
+
+              assert_kind_of Messages::UnknownMessage, message
+            end
           end
         end
       end

--- a/test/roast/cogs/agent/providers/pi/messages/text_delta_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/text_delta_message_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TextDeltaMessageTest < ActiveSupport::TestCase
+              test "extracts delta from assistantMessageEvent" do
+                message = TextDeltaMessage.new(
+                  type: :text_delta,
+                  hash: {
+                    assistantMessageEvent: { type: "text_delta", delta: "Hello world", contentIndex: 0, partial: {} },
+                    message: {},
+                  },
+                )
+
+                assert_equal "Hello world", message.delta
+              end
+
+              test "format returns the delta text" do
+                message = TextDeltaMessage.new(
+                  type: :text_delta,
+                  hash: {
+                    assistantMessageEvent: { type: "text_delta", delta: "chunk", contentIndex: 0, partial: {} },
+                    message: {},
+                  },
+                )
+
+                assert_equal "chunk", message.format(nil)
+              end
+
+              test "delta defaults to empty string when missing" do
+                message = TextDeltaMessage.new(
+                  type: :text_delta,
+                  hash: { assistantMessageEvent: { type: "text_delta" } },
+                )
+
+                assert_equal "", message.delta
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/thinking_delta_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/thinking_delta_message_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ThinkingDeltaMessageTest < ActiveSupport::TestCase
+              test "extracts delta from assistantMessageEvent" do
+                message = ThinkingDeltaMessage.new(
+                  type: :thinking_delta,
+                  hash: {
+                    assistantMessageEvent: { type: "thinking_delta", delta: "Let me consider...", contentIndex: 0, partial: {} },
+                    message: {},
+                  },
+                )
+
+                assert_equal "Let me consider...", message.delta
+              end
+
+              test "format returns the thinking delta" do
+                message = ThinkingDeltaMessage.new(
+                  type: :thinking_delta,
+                  hash: {
+                    assistantMessageEvent: { type: "thinking_delta", delta: "hmm", contentIndex: 0, partial: {} },
+                    message: {},
+                  },
+                )
+
+                assert_equal "hmm", message.format(nil)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add message types for Pi's streaming text and thinking content:

- TextStartMessage, TextDeltaMessage, TextEndMessage for assistant text
- ThinkingStartMessage, ThinkingDeltaMessage, ThinkingEndMessage for
  reasoning/thinking blocks
- Delta messages implement format() to enable progress display
- Message factory dispatch tests for all message_update sub-types