### PR TITLE
Add tool call messages, tool execution messages, and display formatters

### DIFF
--- a/lib/roast/cogs/agent/providers/pi/messages/tool_call_delta_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_call_delta_message.rb
@@ -1,0 +1,31 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolCallDeltaMessage < Message
+              IGNORED_FIELDS = [
+                :assistantMessageEvent,
+              ].freeze
+
+              #: String
+              attr_reader :delta
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.dig(:assistantMessageEvent) || {}
+                @delta = event[:delta] || ""
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_call_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_call_end_message.rb
@@ -1,0 +1,48 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolCallEndMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String?
+              attr_reader :tool_call_id
+
+              #: Symbol
+              attr_reader :name
+
+              #: Hash[Symbol, untyped]
+              attr_reader :arguments
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                tool_call = event[:toolCall] || {}
+                @tool_call_id = tool_call[:id]
+                @name = tool_call[:name]&.downcase&.to_sym || :unknown
+                @arguments = tool_call[:arguments] || {}
+                event.except!(:type, :toolCall, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+
+              #: (PiInvocation::Context) -> String?
+              def format(context)
+                tool_use = ToolUse.new(name:, input: arguments)
+                tool_use.format
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_call_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_call_start_message.rb
@@ -1,0 +1,47 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolCallStartMessage < Message
+              IGNORED_FIELDS = [
+                :message,
+              ].freeze
+
+              #: String?
+              attr_reader :tool_call_id
+
+              #: Symbol
+              attr_reader :name
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                event = hash.delete(:assistantMessageEvent) || {}
+                tool_call = extract_tool_call(event)
+                @tool_call_id = tool_call[:id]
+                @name = tool_call[:name]&.downcase&.to_sym || :unknown
+                event.except!(:type, :contentIndex, :partial)
+                hash.merge!(event) unless event.empty?
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+
+              private
+
+              #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+              def extract_tool_call(event)
+                # The tool call info is in the partial's content array
+                content = event.dig(:partial, :content) || []
+                content.find { |c| c[:type] == "toolCall" } || {}
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_execution_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_execution_end_message.rb
@@ -1,0 +1,60 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolExecutionEndMessage < Message
+              #: String?
+              attr_reader :tool_call_id
+
+              #: String?
+              attr_reader :tool_name
+
+              #: Hash[Symbol, untyped]?
+              attr_reader :result_data
+
+              #: bool
+              attr_reader :is_error
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @tool_call_id = hash.delete(:toolCallId)
+                @tool_name = hash.delete(:toolName)
+                @result_data = hash.delete(:result)
+                @is_error = hash.delete(:isError) || false
+                super(type:, hash:)
+              end
+
+              #: (PiInvocation::Context) -> String?
+              def format(context)
+                tool_call = context.tool_call(tool_call_id)
+                content = extract_content
+                tool_result = ToolResult.new(tool_call:, content:, is_error:)
+                tool_result.format
+              end
+
+              private
+
+              #: () -> String?
+              def extract_content
+                return unless result_data
+
+                content_items = result_data[:content]
+                return result_data.to_s unless content_items.is_a?(Array)
+
+                content_items
+                  .select { |c| c[:type] == "text" }
+                  .map { |c| c[:text] }
+                  .join
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_execution_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_execution_start_message.rb
@@ -1,0 +1,34 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolExecutionStartMessage < Message
+              IGNORED_FIELDS = [
+                :args,
+              ].freeze
+
+              #: String?
+              attr_reader :tool_call_id
+
+              #: String?
+              attr_reader :tool_name
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @tool_call_id = hash.delete(:toolCallId)
+                @tool_name = hash.delete(:toolName)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_execution_update_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_execution_update_message.rb
@@ -1,0 +1,35 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolExecutionUpdateMessage < Message
+              IGNORED_FIELDS = [
+                :args,
+                :partialResult,
+              ].freeze
+
+              #: String?
+              attr_reader :tool_call_id
+
+              #: String?
+              attr_reader :tool_name
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @tool_call_id = hash.delete(:toolCallId)
+                @tool_name = hash.delete(:toolName)
+                hash.except!(*IGNORED_FIELDS)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/tool_result.rb
+++ b/lib/roast/cogs/agent/providers/pi/tool_result.rb
@@ -1,0 +1,45 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class ToolResult
+            #: Symbol?
+            attr_reader :tool_name
+
+            #: String?
+            attr_reader :content
+
+            #: bool
+            attr_reader :is_error
+
+            #: (tool_call: Messages::ToolCallEndMessage?, content: String?, is_error: bool) -> void
+            def initialize(tool_call:, content:, is_error:)
+              @tool_name = tool_call&.name || :unknown
+              @content = content
+              @is_error = is_error
+            end
+
+            #: () -> String
+            def format
+              format_method_name = "format_#{tool_name}".to_sym
+              return send(format_method_name) if respond_to?(format_method_name, true)
+
+              format_unknown
+            end
+
+            private
+
+            #: () -> String
+            def format_unknown
+              "UNKNOWN [#{tool_name}] #{is_error ? "ERROR" : "OK"}\n#{content}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/pi/tool_use.rb
@@ -1,0 +1,76 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class ToolUse
+            #: Symbol
+            attr_reader :name
+
+            #: Hash[Symbol, untyped]
+            attr_reader :input
+
+            #: (name: Symbol, input: Hash[Symbol, untyped]) -> void
+            def initialize(name:, input:)
+              @name = name
+              @input = input
+            end
+
+            #: () -> String
+            def format
+              format_method_name = "format_#{name}".to_sym
+              return send(format_method_name) if respond_to?(format_method_name, true)
+
+              format_unknown
+            end
+
+            private
+
+            #: () -> String
+            def format_bash
+              "BASH #{input[:command]}"
+            end
+
+            #: () -> String
+            def format_read
+              "READ #{input[:path]}"
+            end
+
+            #: () -> String
+            def format_edit
+              "EDIT #{input[:path]}"
+            end
+
+            #: () -> String
+            def format_write
+              "WRITE #{input[:path]}"
+            end
+
+            #: () -> String
+            def format_grep
+              "GREP #{input[:pattern]} #{input[:path]}"
+            end
+
+            #: () -> String
+            def format_find
+              "FIND #{input[:path]} #{input[:pattern]}"
+            end
+
+            #: () -> String
+            def format_ls
+              "LS #{input[:path]}"
+            end
+
+            #: () -> String
+            def format_unknown
+              "UNKNOWN [#{name}] #{input.inspect}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/message_test.rb
@@ -118,6 +118,85 @@ module Roast
               assert_equal "Full thought", message.content
             end
 
+            test "from_hash dispatches message_update toolcall_start" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: {
+                  type: "toolcall_start",
+                  contentIndex: 1,
+                  partial: {
+                    content: [
+                      { type: "toolCall", id: "tool_1", name: "bash", arguments: {} },
+                    ],
+                  },
+                },
+              })
+
+              assert_kind_of Messages::ToolCallStartMessage, message
+              assert_equal "tool_1", message.tool_call_id
+              assert_equal :bash, message.name
+            end
+
+            test "from_hash dispatches message_update toolcall_delta" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: { type: "toolcall_delta", delta: '{"command": "ls' },
+              })
+
+              assert_kind_of Messages::ToolCallDeltaMessage, message
+              assert_equal '{"command": "ls', message.delta
+            end
+
+            test "from_hash dispatches message_update toolcall_end" do
+              message = Message.from_hash({
+                type: "message_update",
+                assistantMessageEvent: {
+                  type: "toolcall_end",
+                  toolCall: { id: "tool_1", name: "bash", arguments: { command: "ls -la" } },
+                },
+              })
+
+              assert_kind_of Messages::ToolCallEndMessage, message
+              assert_equal "tool_1", message.tool_call_id
+              assert_equal :bash, message.name
+              assert_equal({ command: "ls -la" }, message.arguments)
+            end
+
+            test "from_hash dispatches tool_execution_start type" do
+              message = Message.from_hash({
+                type: "tool_execution_start",
+                toolCallId: "123",
+                toolName: "bash",
+                args: {},
+              })
+
+              assert_kind_of Messages::ToolExecutionStartMessage, message
+            end
+
+            test "from_hash dispatches tool_execution_update type" do
+              message = Message.from_hash({
+                type: "tool_execution_update",
+                toolCallId: "123",
+                toolName: "bash",
+                args: {},
+                partialResult: {},
+              })
+
+              assert_kind_of Messages::ToolExecutionUpdateMessage, message
+            end
+
+            test "from_hash dispatches tool_execution_end type" do
+              message = Message.from_hash({
+                type: "tool_execution_end",
+                toolCallId: "123",
+                toolName: "bash",
+                result: { content: [{ type: "text", text: "output" }] },
+                isError: false,
+              })
+
+              assert_kind_of Messages::ToolExecutionEndMessage, message
+            end
+
             test "from_hash dispatches unknown message_update sub-type" do
               message = Message.from_hash({
                 type: "message_update",

--- a/test/roast/cogs/agent/providers/pi/messages/tool_call_end_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/tool_call_end_message_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolCallEndMessageTest < ActiveSupport::TestCase
+              test "extracts tool call details from assistantMessageEvent" do
+                message = ToolCallEndMessage.new(
+                  type: :toolcall_end,
+                  hash: {
+                    assistantMessageEvent: {
+                      type: "toolcall_end",
+                      toolCall: { id: "tool_abc", name: "bash", arguments: { command: "echo hi" } },
+                    },
+                  },
+                )
+
+                assert_equal "tool_abc", message.tool_call_id
+                assert_equal :bash, message.name
+                assert_equal({ command: "echo hi" }, message.arguments)
+              end
+
+              test "name defaults to :unknown when not present" do
+                message = ToolCallEndMessage.new(
+                  type: :toolcall_end,
+                  hash: {
+                    assistantMessageEvent: {
+                      type: "toolcall_end",
+                      toolCall: { id: "tool_abc" },
+                    },
+                  },
+                )
+
+                assert_equal :unknown, message.name
+              end
+
+              test "format returns tool use description" do
+                message = ToolCallEndMessage.new(
+                  type: :toolcall_end,
+                  hash: {
+                    assistantMessageEvent: {
+                      type: "toolcall_end",
+                      toolCall: { id: "tool_1", name: "bash", arguments: { command: "ls -la" } },
+                    },
+                  },
+                )
+
+                assert_equal "BASH ls -la", message.format(nil)
+              end
+
+              test "format returns read description for read tool" do
+                message = ToolCallEndMessage.new(
+                  type: :toolcall_end,
+                  hash: {
+                    assistantMessageEvent: {
+                      type: "toolcall_end",
+                      toolCall: { id: "tool_1", name: "read", arguments: { path: "/tmp/file.rb" } },
+                    },
+                  },
+                )
+
+                assert_equal "READ /tmp/file.rb", message.format(nil)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/tool_execution_end_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/tool_execution_end_message_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolExecutionEndMessageTest < ActiveSupport::TestCase
+              test "extracts tool execution fields" do
+                message = ToolExecutionEndMessage.new(
+                  type: :tool_execution_end,
+                  hash: {
+                    toolCallId: "tool_123",
+                    toolName: "bash",
+                    result: { content: [{ type: "text", text: "output here" }] },
+                    isError: false,
+                  },
+                )
+
+                assert_equal "tool_123", message.tool_call_id
+                assert_equal "bash", message.tool_name
+                refute message.is_error
+              end
+
+              test "extracts text content from result" do
+                message = ToolExecutionEndMessage.new(
+                  type: :tool_execution_end,
+                  hash: {
+                    toolCallId: "tool_1",
+                    toolName: "bash",
+                    result: {
+                      content: [
+                        { type: "text", text: "line 1\n" },
+                        { type: "text", text: "line 2\n" },
+                      ],
+                    },
+                    isError: false,
+                  },
+                )
+
+                content = message.send(:extract_content)
+                assert_equal "line 1\nline 2\n", content
+              end
+
+              test "is_error defaults to false" do
+                message = ToolExecutionEndMessage.new(
+                  type: :tool_execution_end,
+                  hash: {
+                    toolCallId: "tool_1",
+                    toolName: "bash",
+                    result: {},
+                  },
+                )
+
+                refute message.is_error
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/tool_result_test.rb
+++ b/test/roast/cogs/agent/providers/pi/tool_result_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class ToolResultTest < ActiveSupport::TestCase
+            test "extracts tool_name from tool_call" do
+              tool_call = Messages::ToolCallEndMessage.new(
+                type: :toolcall_end,
+                hash: {
+                  assistantMessageEvent: {
+                    type: "toolcall_end",
+                    toolCall: { id: "1", name: "bash", arguments: {} },
+                  },
+                },
+              )
+
+              tool_result = ToolResult.new(tool_call:, content: "output", is_error: false)
+
+              assert_equal :bash, tool_result.tool_name
+            end
+
+            test "uses :unknown when tool_call is nil" do
+              tool_result = ToolResult.new(tool_call: nil, content: "output", is_error: false)
+
+              assert_equal :unknown, tool_result.tool_name
+            end
+
+            test "format shows error status" do
+              tool_result = ToolResult.new(tool_call: nil, content: "error msg", is_error: true)
+
+              formatted = tool_result.format
+              assert_match(/ERROR/, formatted)
+              assert_match(/error msg/, formatted)
+            end
+
+            test "format shows OK status" do
+              tool_result = ToolResult.new(tool_call: nil, content: "success", is_error: false)
+
+              formatted = tool_result.format
+              assert_match(/OK/, formatted)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/pi/tool_use_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class ToolUseTest < ActiveSupport::TestCase
+            test "format_bash formats bash command" do
+              tool_use = ToolUse.new(name: :bash, input: { command: "ls -la" })
+
+              assert_equal "BASH ls -la", tool_use.format
+            end
+
+            test "format_read formats read path" do
+              tool_use = ToolUse.new(name: :read, input: { path: "/tmp/file.rb" })
+
+              assert_equal "READ /tmp/file.rb", tool_use.format
+            end
+
+            test "format_edit formats edit path" do
+              tool_use = ToolUse.new(name: :edit, input: { path: "/tmp/file.rb" })
+
+              assert_equal "EDIT /tmp/file.rb", tool_use.format
+            end
+
+            test "format_write formats write path" do
+              tool_use = ToolUse.new(name: :write, input: { path: "/tmp/file.rb" })
+
+              assert_equal "WRITE /tmp/file.rb", tool_use.format
+            end
+
+            test "format_grep formats grep command" do
+              tool_use = ToolUse.new(name: :grep, input: { pattern: "TODO", path: "/tmp" })
+
+              assert_equal "GREP TODO /tmp", tool_use.format
+            end
+
+            test "format_find formats find command" do
+              tool_use = ToolUse.new(name: :find, input: { path: "/tmp", pattern: "*.rb" })
+
+              assert_equal "FIND /tmp *.rb", tool_use.format
+            end
+
+            test "format_ls formats ls command" do
+              tool_use = ToolUse.new(name: :ls, input: { path: "/tmp" })
+
+              assert_equal "LS /tmp", tool_use.format
+            end
+
+            test "format_unknown for unrecognized tools" do
+              tool_use = ToolUse.new(name: :custom_tool, input: { key: "value" })
+
+              assert_match(/UNKNOWN \[custom_tool\]/, tool_use.format)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add message types for Pi's tool use streaming and execution lifecycle:

- ToolCallStartMessage, ToolCallDeltaMessage, ToolCallEndMessage for
  streaming tool call arguments
- ToolExecutionStartMessage, ToolExecutionUpdateMessage,
  ToolExecutionEndMessage for tool execution lifecycle
- ToolUse formatter with specific formatting for Pi's built-in tools
  (bash, read, edit, write, grep, find, ls)
- ToolResult formatter for displaying tool execution results
- ToolCallEndMessage.format() and ToolExecutionEndMessage.format()
  integrate with formatters for progress display