### PR TITLE
Add AgentEndMessage with response extraction and stats computation

### DIFF
--- a/lib/roast/cogs/agent/providers/pi/messages/agent_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/agent_end_message.rb
@@ -1,0 +1,85 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Final message emitted by Pi containing the full conversation history
+            #
+            # Extracts the final response text and computes aggregate usage statistics
+            # from all assistant messages in the conversation.
+            class AgentEndMessage < Message
+              #: String
+              attr_reader :response
+
+              #: bool
+              attr_reader :success
+
+              #: Stats
+              attr_reader :stats
+
+              #: (type: Symbol, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                messages = hash.delete(:messages) || []
+                @response = extract_response(messages)
+                @success = true
+                @stats = extract_stats(messages)
+                super(type:, hash:)
+              end
+
+              private
+
+              # Extract the final text response from the last assistant message
+              #
+              #: (Array[Hash[Symbol, untyped]]) -> String
+              def extract_response(messages)
+                last_assistant = messages.reverse.find { |m| m[:role] == "assistant" }
+                return "" unless last_assistant
+
+                content = last_assistant[:content] || []
+                content
+                  .select { |c| c[:type] == "text" }
+                  .map { |c| c[:text] }
+                  .join
+                  .strip
+              end
+
+              # Compute aggregate stats from all assistant messages
+              #
+              #: (Array[Hash[Symbol, untyped]]) -> Stats
+              def extract_stats(messages)
+                stats = Stats.new
+                assistant_messages = messages.select { |m| m[:role] == "assistant" }
+
+                assistant_messages.each do |msg|
+                  usage_data = msg[:usage]
+                  next unless usage_data
+
+                  model = msg[:model] || "unknown"
+                  model_usage = stats.model_usage[model] ||= Usage.new
+
+                  input = usage_data[:input] || 0
+                  output = usage_data[:output] || 0
+                  cost = usage_data.dig(:cost, :total) || 0.0
+
+                  model_usage.input_tokens = (model_usage.input_tokens || 0) + input
+                  model_usage.output_tokens = (model_usage.output_tokens || 0) + output
+                  model_usage.cost_usd = (model_usage.cost_usd || 0.0) + cost
+
+                  stats.usage.input_tokens = (stats.usage.input_tokens || 0) + input
+                  stats.usage.output_tokens = (stats.usage.output_tokens || 0) + output
+                  stats.usage.cost_usd = (stats.usage.cost_usd || 0.0) + cost
+                end
+
+                stats
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/message_test.rb
@@ -28,6 +28,12 @@ module Roast
               assert_kind_of Messages::AgentStartMessage, message
             end
 
+            test "from_hash dispatches agent_end type" do
+              message = Message.from_hash({ type: "agent_end", messages: [] })
+
+              assert_kind_of Messages::AgentEndMessage, message
+            end
+
             test "from_hash dispatches turn_start type" do
               message = Message.from_hash({ type: "turn_start" })
 

--- a/test/roast/cogs/agent/providers/pi/messages/agent_end_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/agent_end_message_test.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class AgentEndMessageTest < ActiveSupport::TestCase
+              test "extracts response from last assistant message" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      { role: "user", content: [{ type: "text", text: "hello" }] },
+                      { role: "assistant", content: [{ type: "text", text: "Hi there!" }], model: "test-model", usage: { input: 5, output: 10, cost: { total: 0.001 } } },
+                    ],
+                  },
+                )
+
+                assert_equal "Hi there!", message.response
+              end
+
+              test "joins multiple text content blocks" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      {
+                        role: "assistant",
+                        content: [
+                          { type: "thinking", thinking: "Let me think..." },
+                          { type: "text", text: "Part one. " },
+                          { type: "text", text: "Part two." },
+                        ],
+                        model: "test-model",
+                        usage: { input: 5, output: 10, cost: { total: 0.001 } },
+                      },
+                    ],
+                  },
+                )
+
+                assert_equal "Part one. Part two.", message.response
+              end
+
+              test "returns empty string when no assistant messages" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      { role: "user", content: [{ type: "text", text: "hello" }] },
+                    ],
+                  },
+                )
+
+                assert_equal "", message.response
+              end
+
+              test "success is true by default" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: { messages: [] },
+                )
+
+                assert message.success
+              end
+
+              test "computes aggregate stats from assistant messages" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      {
+                        role: "assistant",
+                        model: "claude-sonnet",
+                        content: [{ type: "text", text: "response 1" }],
+                        usage: { input: 100, output: 50, cost: { total: 0.01 } },
+                      },
+                      { role: "user", content: [{ type: "text", text: "followup" }] },
+                      {
+                        role: "assistant",
+                        model: "claude-sonnet",
+                        content: [{ type: "text", text: "response 2" }],
+                        usage: { input: 200, output: 80, cost: { total: 0.02 } },
+                      },
+                    ],
+                  },
+                )
+
+                stats = message.stats
+                assert_equal 300, stats.usage.input_tokens
+                assert_equal 130, stats.usage.output_tokens
+                assert_in_delta 0.03, stats.usage.cost_usd
+
+                model_usage = stats.model_usage["claude-sonnet"]
+                assert_not_nil model_usage
+                assert_equal 300, model_usage.input_tokens
+                assert_equal 130, model_usage.output_tokens
+              end
+
+              test "computes per-model stats for multiple models" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      {
+                        role: "assistant",
+                        model: "model-a",
+                        content: [{ type: "text", text: "" }],
+                        usage: { input: 100, output: 50, cost: { total: 0.01 } },
+                      },
+                      {
+                        role: "assistant",
+                        model: "model-b",
+                        content: [{ type: "text", text: "final" }],
+                        usage: { input: 200, output: 80, cost: { total: 0.02 } },
+                      },
+                    ],
+                  },
+                )
+
+                stats = message.stats
+                assert_equal 2, stats.model_usage.size
+                assert_equal 100, stats.model_usage["model-a"].input_tokens
+                assert_equal 200, stats.model_usage["model-b"].input_tokens
+              end
+
+              test "handles assistant messages without usage data" do
+                message = AgentEndMessage.new(
+                  type: :agent_end,
+                  hash: {
+                    messages: [
+                      { role: "assistant", content: [{ type: "text", text: "hi" }] },
+                    ],
+                  },
+                )
+
+                assert_equal "hi", message.response
+                assert message.stats.model_usage.empty?
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
AgentEndMessage handles Pi's final agent_end message which contains the
full conversation history. It:

- Extracts the final text response from the last assistant message,
  joining multiple text content blocks and stripping whitespace
- Computes aggregate token usage stats (input/output tokens, cost)
  across all assistant messages in the conversation
- Tracks per-model usage breakdown when multiple models are used
- Gracefully handles missing usage data on assistant messages