### PR TITLE
Add Pi coding agent provider skeleton

### DIFF
--- a/lib/roast/cogs/agent.rb
+++ b/lib/roast/cogs/agent.rb
@@ -64,6 +64,8 @@ module Roast
         @provider ||= case config.valid_provider!
         when :claude
           Providers::Claude.new(config)
+        when :pi
+          Providers::Pi.new(config)
         else
           raise UnknownProviderError, "Unknown provider: #{config.valid_provider!}"
         end

--- a/lib/roast/cogs/agent/config.rb
+++ b/lib/roast/cogs/agent/config.rb
@@ -5,7 +5,7 @@ module Roast
   module Cogs
     class Agent < Cog
       class Config < Cog::Config
-        VALID_PROVIDERS = [:claude].freeze #: Array[Symbol]
+        VALID_PROVIDERS = [:claude, :pi].freeze #: Array[Symbol]
 
         # Configure the cog to use a specified provider when invoking an agent
         #

--- a/lib/roast/cogs/agent/providers/pi.rb
+++ b/lib/roast/cogs/agent/providers/pi.rb
@@ -1,0 +1,29 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class Output < Agent::Output
+            delegate :response, :session, :stats, to: :@invocation_result
+
+            #: (PiInvocation::Result) -> void
+            def initialize(invocation_result)
+              super()
+              @invocation_result = invocation_result
+            end
+          end
+
+          #: (Agent::Input) -> Agent::Output
+          def invoke(input)
+            invocation = PiInvocation.new(@config, input)
+            invocation.run!
+            Output.new(invocation.result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/pi_invocation.rb
+++ b/lib/roast/cogs/agent/providers/pi/pi_invocation.rb
@@ -1,0 +1,214 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class PiInvocation
+            class PiInvocationError < Roast::Error; end
+
+            class PiNotStartedError < PiInvocationError; end
+
+            class PiAlreadyStartedError < PiInvocationError; end
+
+            class PiNotCompletedError < PiInvocationError; end
+
+            class PiFailedError < PiInvocationError; end
+
+            class Result
+              #: String
+              attr_accessor :response
+
+              #: bool
+              attr_accessor :success
+
+              #: String?
+              attr_accessor :session
+
+              #: Stats?
+              attr_accessor :stats
+
+              def initialize
+                @response = ""
+                @success = false
+              end
+            end
+
+            #: (Agent::Config, Agent::Input) -> void
+            def initialize(config, input)
+              @base_command = config.valid_command #: (String | Array[String])?
+              @model = config.valid_model #: String?
+              @append_system_prompt = config.valid_append_system_prompt #: String?
+              @replace_system_prompt = config.valid_replace_system_prompt #: String?
+              @working_directory = config.valid_working_directory #: Pathname?
+              @prompt = input.valid_prompt! #: String
+              @session = input.session #: String?
+              @result = Result.new #: Result
+              @raw_dump_file = config.valid_dump_raw_agent_messages_to_path #: Pathname?
+              @show_progress = config.show_progress? #: bool
+            end
+
+            #: () -> void
+            def run!
+              raise PiAlreadyStartedError if started?
+
+              @started = true
+              _stdout, stderr, status = CommandRunner.execute(
+                command_line,
+                working_directory: @working_directory,
+                stdin_content: @prompt,
+                stdout_handler: lambda { |line| handle_stdout(line) },
+              )
+
+              if status.success?
+                @completed = true
+              else
+                @failed = true
+                @result.success = false
+                @result.response += "\n" unless @result.response.blank? || @result.response.ends_with?("\n")
+                @result.response += stderr
+              end
+            end
+
+            #: () -> bool
+            def started?
+              @started ||= false
+            end
+
+            #: () -> bool
+            def running?
+              started? && !completed? && !failed?
+            end
+
+            #: () -> bool
+            def completed?
+              @completed ||= false
+            end
+
+            #: () -> bool
+            def failed?
+              @failed ||= false
+            end
+
+            #: () -> Result
+            def result
+              raise PiNotStartedError unless started?
+              raise PiFailedError, @result.response if failed?
+              raise PiNotCompletedError, @result.response unless completed?
+
+              @result
+            end
+
+            private
+
+            #: (String) -> void
+            def handle_stdout(line)
+              # TODO: implement message parsing in PR 2/3
+              line = line.strip
+              return if line.empty?
+
+              if @raw_dump_file
+                @raw_dump_file.dirname.mkpath
+                File.write(@raw_dump_file.to_s, "#{line}\n", mode: "a")
+              end
+
+              begin
+                parsed = JSON.parse(line, symbolize_names: true)
+                handle_message(parsed)
+              rescue JSON::ParserError
+                Roast::Log.warn("Failed to parse Pi output line: #{line}")
+              end
+            end
+
+            #: (Hash[Symbol, untyped]) -> void
+            def handle_message(message)
+              type = message[:type]&.to_s
+
+              case type
+              when "session"
+                @result.session = message[:id]
+              when "agent_end"
+                extract_result_from_agent_end(message)
+              when "turn_end"
+                accumulate_turn_stats(message)
+              when "message_update"
+                handle_message_update(message)
+              end
+            end
+
+            #: (Hash[Symbol, untyped]) -> void
+            def extract_result_from_agent_end(message)
+              messages = message[:messages] || []
+              last_assistant = messages.reverse.find { |m| m[:role] == "assistant" }
+              if last_assistant
+                text_parts = (last_assistant[:content] || [])
+                  .select { |c| c[:type] == "text" }
+                  .map { |c| c[:text] }
+                @result.response = text_parts.join
+              end
+              @result.success = true
+            end
+
+            #: (Hash[Symbol, untyped]) -> void
+            def accumulate_turn_stats(message)
+              @result.stats ||= Stats.new
+              stats = @result.stats.not_nil!
+              stats.num_turns = (stats.num_turns || 0) + 1
+
+              assistant_message = message[:message]
+              return unless assistant_message
+
+              usage = assistant_message[:usage]
+              return unless usage
+
+              model = assistant_message[:model] || "unknown"
+              model_usage = stats.model_usage[model] ||= Usage.new
+              model_usage.input_tokens = (model_usage.input_tokens || 0) + (usage[:input] || 0)
+              model_usage.output_tokens = (model_usage.output_tokens || 0) + (usage[:output] || 0)
+
+              cost = usage[:cost]
+              if cost
+                model_usage.cost_usd = (model_usage.cost_usd || 0.0) + (cost[:total] || 0)
+                stats.usage.cost_usd = (stats.usage.cost_usd || 0.0) + (cost[:total] || 0)
+              end
+
+              stats.usage.input_tokens = (stats.usage.input_tokens || 0) + (usage[:input] || 0)
+              stats.usage.output_tokens = (stats.usage.output_tokens || 0) + (usage[:output] || 0)
+            end
+
+            #: (Hash[Symbol, untyped]) -> void
+            def handle_message_update(message)
+              event = message[:assistantMessageEvent]
+              return unless event
+
+              case event[:type]
+              when "text_delta"
+                delta = event[:delta]
+                puts delta if delta && @show_progress
+              end
+            end
+
+            #: () -> Array[String]
+            def command_line
+              command = if @base_command.is_a?(Array)
+                @base_command.dup
+              elsif @base_command.is_a?(String)
+                @base_command.split
+              else
+                ["pi"]
+              end
+              command.push("-p", "--mode", "json")
+              command.push("--model", @model) if @model
+              command.push("--system-prompt", @replace_system_prompt) if @replace_system_prompt
+              command.push("--append-system-prompt", @append_system_prompt) if @append_system_prompt
+              command.push("--session", @session) if @session.present?
+              command
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/pi_invocation_test.rb
+++ b/test/roast/cogs/agent/providers/pi/pi_invocation_test.rb
@@ -1,0 +1,331 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class PiInvocationTest < ActiveSupport::TestCase
+            def setup
+              @config = Agent::Config.new
+              @config.no_show_progress!
+              @input = Agent::Input.new
+              @input.prompt = "Test prompt"
+              @invocation = PiInvocation.new(@config, @input)
+            end
+
+            def success_status
+              mock = Minitest::Mock.new
+              mock.expect(:success?, true)
+              mock
+            end
+
+            def failure_status
+              mock = Minitest::Mock.new
+              mock.expect(:success?, false)
+              mock
+            end
+
+            # Result tests
+
+            test "Result initializes with empty response and success false" do
+              result = PiInvocation::Result.new
+
+              assert_equal "", result.response
+              refute result.success
+              assert_nil result.session
+              assert_nil result.stats
+            end
+
+            # Lifecycle state tests
+
+            test "started? returns false initially" do
+              refute @invocation.started?
+            end
+
+            test "completed? returns false initially" do
+              refute @invocation.completed?
+            end
+
+            test "failed? returns false initially" do
+              refute @invocation.failed?
+            end
+
+            test "running? returns false when not started" do
+              refute @invocation.running?
+            end
+
+            test "result raises PiNotStartedError when not started" do
+              assert_raises(PiInvocation::PiNotStartedError) do
+                @invocation.result
+              end
+            end
+
+            test "result raises PiFailedError when failed" do
+              CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
+                @invocation.run!
+              end
+
+              assert_raises(PiInvocation::PiFailedError) do
+                @invocation.result
+              end
+            end
+
+            test "result raises PiNotCompletedError when started but not completed" do
+              CommandRunner.stub(:execute, ->(*) {
+                assert_raises(PiInvocation::PiNotCompletedError) do
+                  @invocation.result
+                end
+                ["", "", success_status]
+              }) do
+                @invocation.run!
+              end
+            end
+
+            test "run! raises PiAlreadyStartedError when called twice" do
+              CommandRunner.stub(:execute, ["", "", success_status]) do
+                @invocation.run!
+                assert_raises(PiInvocation::PiAlreadyStartedError) do
+                  @invocation.run!
+                end
+              end
+            end
+
+            test "run! sets started to true" do
+              CommandRunner.stub(:execute, ["", "", success_status]) do
+                @invocation.run!
+              end
+
+              assert @invocation.started?
+            end
+
+            test "run! sets completed to true on successful execution" do
+              CommandRunner.stub(:execute, ["", "", success_status]) do
+                @invocation.run!
+              end
+
+              assert @invocation.completed?
+              refute @invocation.failed?
+            end
+
+            test "run! sets failed to true on unsuccessful execution" do
+              CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
+                @invocation.run!
+              end
+
+              assert @invocation.failed?
+              refute @invocation.completed?
+            end
+
+            test "running? returns true during execution" do
+              CommandRunner.stub(:execute, ->(*) {
+                assert @invocation.started?
+                assert @invocation.running?
+                ["", "", success_status]
+              }) do
+                @invocation.run!
+              end
+
+              refute @invocation.running?
+            end
+
+            test "result returns Result object when completed successfully" do
+              CommandRunner.stub(:execute, ["", "", success_status]) do
+                @invocation.run!
+              end
+
+              result = @invocation.result
+              assert_kind_of PiInvocation::Result, result
+            end
+
+            # Command line construction tests
+
+            test "command_line uses default pi command" do
+              command = @invocation.send(:command_line)
+
+              assert_equal "pi", command.first
+              assert_includes command, "-p"
+              assert_includes command, "--mode"
+              assert_includes command, "json"
+            end
+
+            test "command_line uses custom command when configured as string" do
+              @config.command("custom-pi --flag")
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              assert_equal "custom-pi", command.first
+              assert_includes command, "--flag"
+            end
+
+            test "command_line uses custom command when configured as array" do
+              @config.command(["my-pi", "--opt"])
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              assert_equal "my-pi", command.first
+              assert_includes command, "--opt"
+            end
+
+            test "command_line includes model when configured" do
+              @config.model("claude-sonnet-4-20250514")
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              model_index = command.index("--model")
+              assert model_index
+              assert_equal "claude-sonnet-4-20250514", command[model_index + 1]
+            end
+
+            test "command_line includes replace_system_prompt when configured" do
+              @config.replace_system_prompt("Custom system prompt")
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              prompt_index = command.index("--system-prompt")
+              assert prompt_index
+              assert_equal "Custom system prompt", command[prompt_index + 1]
+            end
+
+            test "command_line includes append_system_prompt when configured" do
+              @config.append_system_prompt("Additional instructions")
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              prompt_index = command.index("--append-system-prompt")
+              assert prompt_index
+              assert_equal "Additional instructions", command[prompt_index + 1]
+            end
+
+            test "command_line includes session flag when session is set" do
+              @input.session = "path/to/session.jsonl"
+              invocation = PiInvocation.new(@config, @input)
+
+              command = invocation.send(:command_line)
+
+              assert_includes command, "--session"
+              session_index = command.index("--session")
+              assert_equal "path/to/session.jsonl", command[session_index + 1]
+            end
+
+            test "command_line omits session flag when no session" do
+              command = @invocation.send(:command_line)
+
+              refute_includes command, "--session"
+            end
+
+            test "command_line does not include permissions flags" do
+              # Pi does not have a --dangerously-skip-permissions equivalent
+              command = @invocation.send(:command_line)
+
+              refute_includes command, "--dangerously-skip-permissions"
+            end
+
+            # Message handling tests
+
+            test "handle_message extracts session id from session message" do
+              message = { type: "session", id: "abc-123", version: 3 }
+
+              @invocation.send(:handle_message, message)
+
+              internal_result = @invocation.instance_variable_get(:@result)
+              assert_equal "abc-123", internal_result.session
+            end
+
+            test "handle_message extracts response from agent_end message" do
+              message = {
+                type: "agent_end",
+                messages: [
+                  { role: "user", content: [{ type: "text", text: "Hello" }] },
+                  { role: "assistant", content: [{ type: "text", text: "Hi there!" }] },
+                ],
+              }
+
+              @invocation.send(:handle_message, message)
+
+              internal_result = @invocation.instance_variable_get(:@result)
+              assert_equal "Hi there!", internal_result.response
+              assert internal_result.success
+            end
+
+            test "handle_message extracts response from last assistant message in agent_end" do
+              message = {
+                type: "agent_end",
+                messages: [
+                  { role: "user", content: [{ type: "text", text: "Hello" }] },
+                  { role: "assistant", content: [{ type: "toolCall", name: "read", arguments: {} }] },
+                  { role: "assistant", content: [{ type: "text", text: "Final response" }] },
+                ],
+              }
+
+              @invocation.send(:handle_message, message)
+
+              internal_result = @invocation.instance_variable_get(:@result)
+              assert_equal "Final response", internal_result.response
+            end
+
+            test "handle_message accumulates turn stats" do
+              message = {
+                type: "turn_end",
+                message: {
+                  role: "assistant",
+                  model: "claude-sonnet-4-20250514",
+                  usage: {
+                    input: 100,
+                    output: 50,
+                    cost: { total: 0.001 },
+                  },
+                },
+              }
+
+              @invocation.send(:handle_message, message)
+
+              internal_result = @invocation.instance_variable_get(:@result)
+              assert_equal 1, internal_result.stats.num_turns
+              assert_equal 100, internal_result.stats.usage.input_tokens
+              assert_equal 50, internal_result.stats.usage.output_tokens
+              assert_in_delta 0.001, internal_result.stats.usage.cost_usd
+              assert_equal 100, internal_result.stats.model_usage["claude-sonnet-4-20250514"].input_tokens
+              assert_equal 50, internal_result.stats.model_usage["claude-sonnet-4-20250514"].output_tokens
+            end
+
+            test "handle_message accumulates stats across multiple turns" do
+              turn1 = {
+                type: "turn_end",
+                message: {
+                  role: "assistant",
+                  model: "claude-sonnet-4-20250514",
+                  usage: { input: 100, output: 50, cost: { total: 0.001 } },
+                },
+              }
+              turn2 = {
+                type: "turn_end",
+                message: {
+                  role: "assistant",
+                  model: "claude-sonnet-4-20250514",
+                  usage: { input: 200, output: 75, cost: { total: 0.002 } },
+                },
+              }
+
+              @invocation.send(:handle_message, turn1)
+              @invocation.send(:handle_message, turn2)
+
+              internal_result = @invocation.instance_variable_get(:@result)
+              assert_equal 2, internal_result.stats.num_turns
+              assert_equal 300, internal_result.stats.usage.input_tokens
+              assert_equal 125, internal_result.stats.usage.output_tokens
+              assert_in_delta 0.003, internal_result.stats.usage.cost_usd
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Register :pi as a valid agent provider alongside :claude.

- Add Providers::Pi with Output class delegating to PiInvocation::Result
- Add PiInvocation with full lifecycle (start/run/complete/fail states)
- Build pi CLI command line: pi -p --mode json with model, system prompt,
  append system prompt, session, and custom command support
- Parse Pi's streaming JSON output (session, agent_end, turn_end,
  message_update types) to extract response, session ID, and usage stats
- Add comprehensive tests mirroring ClaudeInvocation test patterns

Pi's JSON streaming protocol differs from Claude Code's:
- Output flag: --mode json (vs --output-format stream-json)
- Non-interactive: -p (vs -p --verbose)
- Session resume: --session <path> (vs --fork-session --resume <id>)
- Result extraction from agent_end message (vs type: result)
- Usage stats from turn_end messages (vs modelUsage in result)