### PR TITLE
Add Pi message parsing infrastructure

### DIFF
--- a/lib/roast/cogs/agent/providers/pi/message.rb
+++ b/lib/roast/cogs/agent/providers/pi/message.rb
@@ -1,0 +1,93 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          # Base message class for parsing Pi's streaming JSON output
+          #
+          # Pi outputs newline-delimited JSON messages with a `type` field that determines
+          # the message kind. This class provides a factory for dispatching to the appropriate
+          # message subclass based on the type.
+          #
+          # Pi message types:
+          # - session: Initial session metadata (id, version, cwd)
+          # - agent_start: Agent execution has begun
+          # - agent_end: Agent execution is complete, contains full conversation
+          # - turn_start: A new turn (request/response cycle) has started
+          # - turn_end: A turn has completed, contains usage stats
+          # - message_start: A message (user or assistant) is starting
+          # - message_update: Streaming delta for an assistant message
+          # - message_end: A message is complete
+          # - tool_execution_start: A tool is being executed
+          # - tool_execution_end: A tool execution has completed
+          class Message
+            class << self
+              #: (String, ?raw_dump_file: Pathname?) -> Message?
+              def from_json(json, raw_dump_file: nil)
+                if raw_dump_file
+                  raw_dump_file.dirname.mkpath
+                  File.write(raw_dump_file.to_s, "#{json}\n", mode: "a")
+                end
+                from_hash(JSON.parse(json, symbolize_names: true))
+              end
+
+              #: (Hash[Symbol, untyped]) -> Message
+              def from_hash(hash)
+                type = hash.delete(:type)&.to_s
+                case type
+                when "session"
+                  Messages::SessionMessage.new(type:, hash:)
+                when "agent_start"
+                  Messages::AgentStartMessage.new(type:, hash:)
+                when "agent_end"
+                  Messages::AgentEndMessage.new(type:, hash:)
+                when "turn_start"
+                  Messages::TurnStartMessage.new(type:, hash:)
+                when "turn_end"
+                  Messages::TurnEndMessage.new(type:, hash:)
+                when "message_start"
+                  Messages::MessageStartMessage.new(type:, hash:)
+                when "message_update"
+                  Messages::MessageUpdateMessage.new(type:, hash:)
+                when "message_end"
+                  Messages::MessageEndMessage.new(type:, hash:)
+                when "tool_execution_start"
+                  Messages::ToolExecutionStartMessage.new(type:, hash:)
+                when "tool_execution_end"
+                  Messages::ToolExecutionEndMessage.new(type:, hash:)
+                else
+                  Messages::UnknownMessage.new(type:, hash:)
+                end
+              end
+            end
+
+            #: String?
+            attr_reader :type
+
+            #: Hash[Symbol, untyped]
+            attr_reader :unparsed
+
+            #: (type: String?, hash: Hash[Symbol, untyped]) -> void
+            def initialize(type:, hash:)
+              @type = type
+              @unparsed = hash
+            end
+
+            # Format this message for progress display
+            #
+            # Subclasses may override this to provide human-readable progress output.
+            # Returns nil by default (no output).
+            #
+            #: () -> String?
+            def format
+              nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/agent_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/agent_end_message.rb
@@ -1,0 +1,61 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Marks the end of agent execution and contains the full conversation
+            #
+            # The `messages` array contains all user and assistant messages from the conversation.
+            # The final assistant message's text content is used as the agent's response.
+            #
+            # Example:
+            #   {"type":"agent_end","messages":[{"role":"user",...},{"role":"assistant",...}]}
+            class AgentEndMessage < Message
+              #: Array[Hash[Symbol, untyped]]
+              attr_reader :messages
+
+              #: (type: String?, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @messages = hash.delete(:messages) || []
+                super(type:, hash:)
+              end
+
+              # Extract the final response text from the last assistant message
+              #
+              #: () -> String
+              def final_response
+                last_assistant = messages.reverse.find { |m| m[:role] == "assistant" }
+                return "" unless last_assistant
+
+                (last_assistant[:content] || [])
+                  .select { |c| c[:type] == "text" }
+                  .map { |c| c[:text] }
+                  .join
+              end
+
+              # Extract the model name from the last assistant message
+              #
+              #: () -> String?
+              def model
+                last_assistant = messages.reverse.find { |m| m[:role] == "assistant" }
+                last_assistant&.dig(:model)
+              end
+
+              # Extract the final usage from the last assistant message
+              #
+              #: () -> Hash[Symbol, untyped]?
+              def usage
+                last_assistant = messages.reverse.find { |m| m[:role] == "assistant" }
+                last_assistant&.dig(:usage)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/agent_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/agent_start_message.rb
@@ -1,0 +1,21 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Marks the beginning of agent execution
+            #
+            # Example:
+            #   {"type":"agent_start"}
+            class AgentStartMessage < Message
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/message_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/message_end_message.rb
@@ -1,0 +1,60 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Marks the end of a user or assistant message
+            #
+            # Contains the final state of the message including full content and usage.
+            #
+            # Example:
+            #   {"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"4"}],
+            #     "usage":{"input":3,"output":5,...}}}
+            class MessageEndMessage < Message
+              #: Hash[Symbol, untyped]?
+              attr_reader :message
+
+              #: (type: String?, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @message = hash.delete(:message)
+                super(type:, hash:)
+              end
+
+              # The role of the message (user or assistant)
+              #
+              #: () -> String?
+              def role
+                @message&.dig(:role)
+              end
+
+              # The model used (only present for assistant messages)
+              #
+              #: () -> String?
+              def model
+                @message&.dig(:model)
+              end
+
+              # The usage data (only present for assistant messages)
+              #
+              #: () -> Hash[Symbol, untyped]?
+              def usage
+                @message&.dig(:usage)
+              end
+
+              # The content array of the message
+              #
+              #: () -> Array[Hash[Symbol, untyped]]
+              def content
+                @message&.dig(:content) || []
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/message_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/message_start_message.rb
@@ -1,0 +1,44 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Marks the beginning of a user or assistant message
+            #
+            # Example:
+            #   {"type":"message_start","message":{"role":"user","content":[...]}}
+            #   {"type":"message_start","message":{"role":"assistant","content":[],"model":"..."}}
+            class MessageStartMessage < Message
+              #: Hash[Symbol, untyped]?
+              attr_reader :message
+
+              #: (type: String?, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @message = hash.delete(:message)
+                super(type:, hash:)
+              end
+
+              # The role of the message (user or assistant)
+              #
+              #: () -> String?
+              def role
+                @message&.dig(:role)
+              end
+
+              # The model used (only present for assistant messages)
+              #
+              #: () -> String?
+              def model
+                @message&.dig(:model)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/message_update_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/message_update_message.rb
@@ -1,0 +1,97 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Streaming update for an assistant message
+            #
+            # Contains an `assistantMessageEvent` with a sub-type indicating what kind of
+            # update is being streamed:
+            # - `text_start`: Beginning of a text content block
+            # - `text_delta`: Incremental text content
+            # - `text_end`: End of a text content block
+            # - `toolcall_start`: Beginning of a tool call
+            # - `toolcall_delta`: Incremental tool call arguments
+            # - `toolcall_end`: End of a tool call with complete arguments
+            #
+            # Example:
+            #   {"type":"message_update","assistantMessageEvent":{"type":"text_delta",
+            #     "contentIndex":0,"delta":"Hello"},"message":{...}}
+            class MessageUpdateMessage < Message
+              #: Hash[Symbol, untyped]?
+              attr_reader :assistant_message_event
+
+              #: Hash[Symbol, untyped]?
+              attr_reader :message
+
+              #: (type: String?, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @assistant_message_event = hash.delete(:assistantMessageEvent)
+                @message = hash.delete(:message)
+                super(type:, hash:)
+              end
+
+              # The sub-type of the assistant message event
+              #
+              # One of: text_start, text_delta, text_end, toolcall_start, toolcall_delta, toolcall_end
+              #
+              #: () -> String?
+              def event_type
+                @assistant_message_event&.dig(:type)
+              end
+
+              # The text delta content (for text_delta events)
+              #
+              #: () -> String?
+              def delta
+                @assistant_message_event&.dig(:delta)
+              end
+
+              # The content index this event applies to
+              #
+              #: () -> Integer?
+              def content_index
+                @assistant_message_event&.dig(:contentIndex)
+              end
+
+              # The complete tool call info (for toolcall_end events)
+              #
+              #: () -> Hash[Symbol, untyped]?
+              def tool_call
+                @assistant_message_event&.dig(:toolCall)
+              end
+
+              # The final text content (for text_end events)
+              #
+              #: () -> String?
+              def content
+                @assistant_message_event&.dig(:content)
+              end
+
+              # Format for progress display
+              #
+              #: () -> String?
+              def format
+                case event_type
+                when "text_delta"
+                  delta
+                when "toolcall_end"
+                  tc = tool_call
+                  return nil unless tc
+
+                  name = tc[:name]
+                  args = tc[:arguments]
+                  "TOOL: #{name} #{args.inspect}" if name
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/session_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/session_message.rb
@@ -1,0 +1,41 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Parses the initial session message from Pi
+            #
+            # Example:
+            #   {"type":"session","version":3,"id":"abc-123","timestamp":"...","cwd":"/path"}
+            class SessionMessage < Message
+              #: String?
+              attr_reader :session_id
+
+              #: Integer?
+              attr_reader :version
+
+              #: String?
+              attr_reader :cwd
+
+              #: String?
+              attr_reader :timestamp
+
+              #: (type: String?, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @session_id = hash.delete(:id)
+                @version = hash.delete(:version)
+                @cwd = hash.delete(:cwd)
+                @timestamp = hash.delete(:timestamp)
+                super(type:, hash:)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_execution_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_execution_end_message.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Marks the end of a tool execution
+            #
+            # Emitted when Pi has finished executing a tool call.
+            #
+            # Example:
+            #   {"type":"tool_execution_end"}
+            class ToolExecutionEndMessage < Message
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/tool_execution_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/tool_execution_start_message.rb
@@ -1,0 +1,23 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Marks the start of a tool execution
+            #
+            # Emitted when Pi begins executing a tool call.
+            #
+            # Example:
+            #   {"type":"tool_execution_start"}
+            class ToolExecutionStartMessage < Message
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/turn_end_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/turn_end_message.rb
@@ -1,0 +1,65 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Marks the end of a turn and contains usage statistics
+            #
+            # Each turn represents one complete request/response cycle. The message contains
+            # the final assistant message state and usage data for that turn.
+            #
+            # Example:
+            #   {"type":"turn_end","message":{"role":"assistant","model":"claude-opus-4-6",
+            #     "usage":{"input":3,"output":5,"cost":{"total":0.028}},...},"toolResults":[]}
+            class TurnEndMessage < Message
+              #: Hash[Symbol, untyped]?
+              attr_reader :message
+
+              #: Array[Hash[Symbol, untyped]]
+              attr_reader :tool_results
+
+              #: (type: String?, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                @message = hash.delete(:message)
+                @tool_results = hash.delete(:toolResults) || []
+                super(type:, hash:)
+              end
+
+              # The model used for this turn
+              #
+              #: () -> String?
+              def model
+                @message&.dig(:model)
+              end
+
+              # The usage data for this turn
+              #
+              #: () -> Hash[Symbol, untyped]?
+              def usage
+                @message&.dig(:usage)
+              end
+
+              # The content of the assistant message for this turn
+              #
+              #: () -> Array[Hash[Symbol, untyped]]
+              def content
+                @message&.dig(:content) || []
+              end
+
+              # The stop reason for this turn
+              #
+              #: () -> String?
+              def stop_reason
+                @message&.dig(:stopReason)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/turn_start_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/turn_start_message.rb
@@ -1,0 +1,21 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Marks the beginning of a new turn (request/response cycle)
+            #
+            # Example:
+            #   {"type":"turn_start"}
+            class TurnStartMessage < Message
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/messages/unknown_message.rb
+++ b/lib/roast/cogs/agent/providers/pi/messages/unknown_message.rb
@@ -1,0 +1,26 @@
+# typed: true
+# frozen_string_literal: true
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            # Catch-all for unrecognized Pi message types
+            class UnknownMessage < Message
+              #: Hash[Symbol, untyped]
+              attr_reader :raw
+
+              #: (type: String?, hash: Hash[Symbol, untyped]) -> void
+              def initialize(type:, hash:)
+                super(type:, hash:)
+                @raw = hash
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/roast/cogs/agent/providers/pi/pi_invocation.rb
+++ b/lib/roast/cogs/agent/providers/pi/pi_invocation.rb
@@ -105,65 +105,47 @@ module Roast
 
             #: (String) -> void
             def handle_stdout(line)
-              # TODO: implement message parsing in PR 2/3
               line = line.strip
               return if line.empty?
 
-              if @raw_dump_file
-                @raw_dump_file.dirname.mkpath
-                File.write(@raw_dump_file.to_s, "#{line}\n", mode: "a")
-              end
+              message = Message.from_json(line, raw_dump_file: @raw_dump_file)
+              return unless message
 
-              begin
-                parsed = JSON.parse(line, symbolize_names: true)
-                handle_message(parsed)
-              rescue JSON::ParserError
-                Roast::Log.warn("Failed to parse Pi output line: #{line}")
-              end
+              handle_message(message)
             end
 
-            #: (Hash[Symbol, untyped]) -> void
+            #: (Message) -> void
             def handle_message(message)
-              type = message[:type]&.to_s
-
-              case type
-              when "session"
-                @result.session = message[:id]
-              when "agent_end"
-                extract_result_from_agent_end(message)
-              when "turn_end"
+              case message
+              when Messages::SessionMessage
+                @result.session = message.session_id
+              when Messages::AgentEndMessage
+                @result.response = message.final_response
+                @result.success = true
+              when Messages::TurnEndMessage
                 accumulate_turn_stats(message)
-              when "message_update"
-                handle_message_update(message)
+              when Messages::MessageUpdateMessage
+                # Show progress for text deltas
+                formatted = message.format
+                puts formatted if formatted.present? && @show_progress
+              end
+
+              unless message.unparsed.blank?
+                Roast::Log.debug("Unhandled data in Pi #{message.type} message:")
+                Roast::Log.debug(JSON.pretty_generate(message.unparsed))
               end
             end
 
-            #: (Hash[Symbol, untyped]) -> void
-            def extract_result_from_agent_end(message)
-              messages = message[:messages] || []
-              last_assistant = messages.reverse.find { |m| m[:role] == "assistant" }
-              if last_assistant
-                text_parts = (last_assistant[:content] || [])
-                  .select { |c| c[:type] == "text" }
-                  .map { |c| c[:text] }
-                @result.response = text_parts.join
-              end
-              @result.success = true
-            end
-
-            #: (Hash[Symbol, untyped]) -> void
+            #: (Messages::TurnEndMessage) -> void
             def accumulate_turn_stats(message)
               @result.stats ||= Stats.new
               stats = @result.stats.not_nil!
               stats.num_turns = (stats.num_turns || 0) + 1
 
-              assistant_message = message[:message]
-              return unless assistant_message
-
-              usage = assistant_message[:usage]
+              usage = message.usage
               return unless usage
 
-              model = assistant_message[:model] || "unknown"
+              model = message.model || "unknown"
               model_usage = stats.model_usage[model] ||= Usage.new
               model_usage.input_tokens = (model_usage.input_tokens || 0) + (usage[:input] || 0)
               model_usage.output_tokens = (model_usage.output_tokens || 0) + (usage[:output] || 0)
@@ -176,18 +158,6 @@ module Roast
 
               stats.usage.input_tokens = (stats.usage.input_tokens || 0) + (usage[:input] || 0)
               stats.usage.output_tokens = (stats.usage.output_tokens || 0) + (usage[:output] || 0)
-            end
-
-            #: (Hash[Symbol, untyped]) -> void
-            def handle_message_update(message)
-              event = message[:assistantMessageEvent]
-              return unless event
-
-              case event[:type]
-              when "text_delta"
-                delta = event[:delta]
-                puts delta if delta && @show_progress
-              end
             end
 
             #: () -> Array[String]

--- a/test/roast/cogs/agent/providers/pi/message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/message_test.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          class MessageTest < ActiveSupport::TestCase
+            # from_json tests
+
+            test "from_json parses JSON and creates message" do
+              json = '{"type": "session", "id": "abc-123", "version": 3}'
+              message = Message.from_json(json)
+
+              assert_kind_of Messages::SessionMessage, message
+              assert_equal "abc-123", message.session_id
+            end
+
+            test "from_json writes to raw dump file when provided" do
+              Dir.mktmpdir do |dir|
+                dump_file = Pathname.new(File.join(dir, "dump.log"))
+                json = '{"type": "agent_start"}'
+                Message.from_json(json, raw_dump_file: dump_file)
+
+                assert dump_file.exist?
+                assert_equal "#{json}\n", dump_file.read
+              end
+            end
+
+            test "from_json appends to raw dump file" do
+              Dir.mktmpdir do |dir|
+                dump_file = Pathname.new(File.join(dir, "dump.log"))
+                Message.from_json('{"type": "agent_start"}', raw_dump_file: dump_file)
+                Message.from_json('{"type": "agent_end", "messages": []}', raw_dump_file: dump_file)
+
+                lines = dump_file.readlines
+                assert_equal 2, lines.length
+              end
+            end
+
+            # from_hash dispatch tests
+
+            test "from_hash with session type creates SessionMessage" do
+              hash = { type: "session", id: "abc", version: 3 }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::SessionMessage, message
+            end
+
+            test "from_hash with agent_start type creates AgentStartMessage" do
+              hash = { type: "agent_start" }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::AgentStartMessage, message
+            end
+
+            test "from_hash with agent_end type creates AgentEndMessage" do
+              hash = { type: "agent_end", messages: [] }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::AgentEndMessage, message
+            end
+
+            test "from_hash with turn_start type creates TurnStartMessage" do
+              hash = { type: "turn_start" }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::TurnStartMessage, message
+            end
+
+            test "from_hash with turn_end type creates TurnEndMessage" do
+              hash = { type: "turn_end", message: {} }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::TurnEndMessage, message
+            end
+
+            test "from_hash with message_start type creates MessageStartMessage" do
+              hash = { type: "message_start", message: { role: "user" } }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::MessageStartMessage, message
+            end
+
+            test "from_hash with message_update type creates MessageUpdateMessage" do
+              hash = { type: "message_update", assistantMessageEvent: { type: "text_delta" } }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::MessageUpdateMessage, message
+            end
+
+            test "from_hash with message_end type creates MessageEndMessage" do
+              hash = { type: "message_end", message: { role: "assistant" } }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::MessageEndMessage, message
+            end
+
+            test "from_hash with tool_execution_start type creates ToolExecutionStartMessage" do
+              hash = { type: "tool_execution_start" }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::ToolExecutionStartMessage, message
+            end
+
+            test "from_hash with tool_execution_end type creates ToolExecutionEndMessage" do
+              hash = { type: "tool_execution_end" }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::ToolExecutionEndMessage, message
+            end
+
+            test "from_hash with unknown type creates UnknownMessage" do
+              hash = { type: "something_new", foo: "bar" }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::UnknownMessage, message
+            end
+
+            test "from_hash with nil type creates UnknownMessage" do
+              hash = { type: nil, foo: "bar" }
+              message = Message.from_hash(hash)
+
+              assert_kind_of Messages::UnknownMessage, message
+            end
+
+            test "from_hash removes type from hash" do
+              hash = { type: "session", id: "abc" }
+              Message.from_hash(hash)
+
+              refute hash.key?(:type)
+            end
+
+            # Base message tests
+
+            test "initialize sets type" do
+              message = Message.new(type: "test", hash: {})
+
+              assert_equal "test", message.type
+            end
+
+            test "initialize stores remaining hash in unparsed" do
+              hash = { foo: "bar", baz: 123 }
+              message = Message.new(type: "test", hash:)
+
+              assert_equal "bar", message.unparsed[:foo]
+              assert_equal 123, message.unparsed[:baz]
+            end
+
+            test "initialize with empty hash creates empty unparsed" do
+              message = Message.new(type: "test", hash: {})
+
+              assert_equal({}, message.unparsed)
+            end
+
+            test "format returns nil by default" do
+              message = Message.new(type: "test", hash: {})
+
+              assert_nil message.format
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/agent_end_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/agent_end_message_test.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class AgentEndMessageTest < ActiveSupport::TestCase
+              test "initialize extracts messages array" do
+                hash = {
+                  messages: [
+                    { role: "user", content: [{ type: "text", text: "Hello" }] },
+                    { role: "assistant", content: [{ type: "text", text: "Hi!" }] },
+                  ],
+                }
+                message = AgentEndMessage.new(type: "agent_end", hash:)
+
+                assert_equal 2, message.messages.length
+              end
+
+              test "initialize defaults messages to empty array" do
+                message = AgentEndMessage.new(type: "agent_end", hash: {})
+
+                assert_equal [], message.messages
+              end
+
+              test "initialize removes messages from hash" do
+                hash = { messages: [] }
+                AgentEndMessage.new(type: "agent_end", hash:)
+
+                refute hash.key?(:messages)
+              end
+
+              test "final_response extracts text from last assistant message" do
+                hash = {
+                  messages: [
+                    { role: "user", content: [{ type: "text", text: "Hello" }] },
+                    { role: "assistant", content: [{ type: "text", text: "Hi there!" }] },
+                  ],
+                }
+                message = AgentEndMessage.new(type: "agent_end", hash:)
+
+                assert_equal "Hi there!", message.final_response
+              end
+
+              test "final_response returns last assistant message when multiple exist" do
+                hash = {
+                  messages: [
+                    { role: "user", content: [{ type: "text", text: "Hello" }] },
+                    { role: "assistant", content: [{ type: "toolCall", name: "read" }] },
+                    { role: "assistant", content: [{ type: "text", text: "Final answer" }] },
+                  ],
+                }
+                message = AgentEndMessage.new(type: "agent_end", hash:)
+
+                assert_equal "Final answer", message.final_response
+              end
+
+              test "final_response joins multiple text blocks" do
+                hash = {
+                  messages: [
+                    {
+                      role: "assistant",
+                      content: [
+                        { type: "text", text: "Part 1" },
+                        { type: "text", text: " Part 2" },
+                      ],
+                    },
+                  ],
+                }
+                message = AgentEndMessage.new(type: "agent_end", hash:)
+
+                assert_equal "Part 1 Part 2", message.final_response
+              end
+
+              test "final_response ignores non-text content" do
+                hash = {
+                  messages: [
+                    {
+                      role: "assistant",
+                      content: [
+                        { type: "toolCall", name: "read", arguments: {} },
+                        { type: "text", text: "Done" },
+                      ],
+                    },
+                  ],
+                }
+                message = AgentEndMessage.new(type: "agent_end", hash:)
+
+                assert_equal "Done", message.final_response
+              end
+
+              test "final_response returns empty string when no assistant messages" do
+                hash = {
+                  messages: [
+                    { role: "user", content: [{ type: "text", text: "Hello" }] },
+                  ],
+                }
+                message = AgentEndMessage.new(type: "agent_end", hash:)
+
+                assert_equal "", message.final_response
+              end
+
+              test "final_response returns empty string when no messages" do
+                message = AgentEndMessage.new(type: "agent_end", hash: {})
+
+                assert_equal "", message.final_response
+              end
+
+              test "model extracts model from last assistant message" do
+                hash = {
+                  messages: [
+                    { role: "assistant", model: "claude-opus-4-6", content: [] },
+                  ],
+                }
+                message = AgentEndMessage.new(type: "agent_end", hash:)
+
+                assert_equal "claude-opus-4-6", message.model
+              end
+
+              test "model returns nil when no assistant messages" do
+                message = AgentEndMessage.new(type: "agent_end", hash: {})
+
+                assert_nil message.model
+              end
+
+              test "usage extracts usage from last assistant message" do
+                hash = {
+                  messages: [
+                    {
+                      role: "assistant",
+                      usage: { input: 10, output: 5, cost: { total: 0.001 } },
+                      content: [],
+                    },
+                  ],
+                }
+                message = AgentEndMessage.new(type: "agent_end", hash:)
+
+                assert_equal 10, message.usage[:input]
+                assert_equal 5, message.usage[:output]
+              end
+
+              test "usage returns nil when no assistant messages" do
+                message = AgentEndMessage.new(type: "agent_end", hash: {})
+
+                assert_nil message.usage
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/agent_start_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/agent_start_message_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class AgentStartMessageTest < ActiveSupport::TestCase
+              test "initialize creates message with type" do
+                message = AgentStartMessage.new(type: "agent_start", hash: {})
+
+                assert_equal "agent_start", message.type
+              end
+
+              test "initialize stores unparsed fields" do
+                hash = { extra: "data" }
+                message = AgentStartMessage.new(type: "agent_start", hash:)
+
+                assert_equal "data", message.unparsed[:extra]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/message_end_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/message_end_message_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class MessageEndMessageTest < ActiveSupport::TestCase
+              test "initialize extracts message" do
+                hash = { message: { role: "assistant", content: [] } }
+                message = MessageEndMessage.new(type: "message_end", hash:)
+
+                assert_equal "assistant", message.message[:role]
+              end
+
+              test "initialize removes message from hash" do
+                hash = { message: { role: "user" } }
+                MessageEndMessage.new(type: "message_end", hash:)
+
+                refute hash.key?(:message)
+              end
+
+              test "role returns role from message" do
+                hash = { message: { role: "user" } }
+                message = MessageEndMessage.new(type: "message_end", hash:)
+
+                assert_equal "user", message.role
+              end
+
+              test "role returns nil when message is nil" do
+                message = MessageEndMessage.new(type: "message_end", hash: {})
+
+                assert_nil message.role
+              end
+
+              test "model returns model from assistant message" do
+                hash = { message: { role: "assistant", model: "claude-opus-4-6" } }
+                message = MessageEndMessage.new(type: "message_end", hash:)
+
+                assert_equal "claude-opus-4-6", message.model
+              end
+
+              test "usage returns usage from assistant message" do
+                hash = {
+                  message: {
+                    role: "assistant",
+                    usage: { input: 3, output: 5, cost: { total: 0.028 } },
+                  },
+                }
+                message = MessageEndMessage.new(type: "message_end", hash:)
+
+                assert_equal 3, message.usage[:input]
+                assert_equal 5, message.usage[:output]
+              end
+
+              test "usage returns nil when message is nil" do
+                message = MessageEndMessage.new(type: "message_end", hash: {})
+
+                assert_nil message.usage
+              end
+
+              test "content returns content array" do
+                hash = {
+                  message: {
+                    content: [{ type: "text", text: "Hello" }],
+                  },
+                }
+                message = MessageEndMessage.new(type: "message_end", hash:)
+
+                assert_equal 1, message.content.length
+                assert_equal "Hello", message.content.first[:text]
+              end
+
+              test "content returns empty array when message is nil" do
+                message = MessageEndMessage.new(type: "message_end", hash: {})
+
+                assert_equal [], message.content
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/message_start_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/message_start_message_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class MessageStartMessageTest < ActiveSupport::TestCase
+              test "initialize extracts message" do
+                hash = { message: { role: "user", content: [] } }
+                message = MessageStartMessage.new(type: "message_start", hash:)
+
+                assert_equal "user", message.message[:role]
+              end
+
+              test "initialize removes message from hash" do
+                hash = { message: { role: "user" } }
+                MessageStartMessage.new(type: "message_start", hash:)
+
+                refute hash.key?(:message)
+              end
+
+              test "role returns role from message" do
+                hash = { message: { role: "assistant" } }
+                message = MessageStartMessage.new(type: "message_start", hash:)
+
+                assert_equal "assistant", message.role
+              end
+
+              test "role returns nil when message is nil" do
+                message = MessageStartMessage.new(type: "message_start", hash: {})
+
+                assert_nil message.role
+              end
+
+              test "model returns model from message" do
+                hash = { message: { role: "assistant", model: "claude-opus-4-6" } }
+                message = MessageStartMessage.new(type: "message_start", hash:)
+
+                assert_equal "claude-opus-4-6", message.model
+              end
+
+              test "model returns nil for user messages" do
+                hash = { message: { role: "user" } }
+                message = MessageStartMessage.new(type: "message_start", hash:)
+
+                assert_nil message.model
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/message_update_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/message_update_message_test.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class MessageUpdateMessageTest < ActiveSupport::TestCase
+              test "initialize extracts assistantMessageEvent" do
+                hash = {
+                  assistantMessageEvent: { type: "text_delta", delta: "Hello" },
+                  message: { role: "assistant" },
+                }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_equal "text_delta", message.assistant_message_event[:type]
+              end
+
+              test "initialize extracts message" do
+                hash = {
+                  assistantMessageEvent: { type: "text_delta" },
+                  message: { role: "assistant", model: "claude-opus-4-6" },
+                }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_equal "assistant", message.message[:role]
+              end
+
+              test "initialize removes parsed fields from hash" do
+                hash = {
+                  assistantMessageEvent: { type: "text_delta" },
+                  message: { role: "assistant" },
+                }
+                MessageUpdateMessage.new(type: "message_update", hash:)
+
+                refute hash.key?(:assistantMessageEvent)
+                refute hash.key?(:message)
+              end
+
+              test "event_type returns type from assistant_message_event" do
+                hash = { assistantMessageEvent: { type: "text_delta" } }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_equal "text_delta", message.event_type
+              end
+
+              test "event_type returns nil when no event" do
+                message = MessageUpdateMessage.new(type: "message_update", hash: {})
+
+                assert_nil message.event_type
+              end
+
+              test "delta returns delta from assistant_message_event" do
+                hash = { assistantMessageEvent: { type: "text_delta", delta: "Hello world" } }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_equal "Hello world", message.delta
+              end
+
+              test "delta returns nil for non-delta events" do
+                hash = { assistantMessageEvent: { type: "text_start" } }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_nil message.delta
+              end
+
+              test "content_index returns contentIndex" do
+                hash = { assistantMessageEvent: { type: "text_delta", contentIndex: 0 } }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_equal 0, message.content_index
+              end
+
+              test "tool_call returns toolCall from toolcall_end event" do
+                hash = {
+                  assistantMessageEvent: {
+                    type: "toolcall_end",
+                    toolCall: { type: "toolCall", name: "read", arguments: { path: "/tmp/test.txt" } },
+                  },
+                }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_equal "read", message.tool_call[:name]
+                assert_equal "/tmp/test.txt", message.tool_call[:arguments][:path]
+              end
+
+              test "content returns content from text_end event" do
+                hash = {
+                  assistantMessageEvent: { type: "text_end", content: "Full text" },
+                }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_equal "Full text", message.content
+              end
+
+              # format tests
+
+              test "format returns delta for text_delta events" do
+                hash = { assistantMessageEvent: { type: "text_delta", delta: "Hello" } }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_equal "Hello", message.format
+              end
+
+              test "format returns tool info for toolcall_end events" do
+                hash = {
+                  assistantMessageEvent: {
+                    type: "toolcall_end",
+                    toolCall: { name: "bash", arguments: { command: "ls" } },
+                  },
+                }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                result = message.format
+                assert_includes result, "TOOL: bash"
+                assert_includes result, "command"
+              end
+
+              test "format returns nil for text_start events" do
+                hash = { assistantMessageEvent: { type: "text_start" } }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_nil message.format
+              end
+
+              test "format returns nil for text_end events" do
+                hash = { assistantMessageEvent: { type: "text_end", content: "done" } }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_nil message.format
+              end
+
+              test "format returns nil for toolcall_start events" do
+                hash = { assistantMessageEvent: { type: "toolcall_start" } }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_nil message.format
+              end
+
+              test "format returns nil for toolcall_delta events" do
+                hash = { assistantMessageEvent: { type: "toolcall_delta", delta: "{" } }
+                message = MessageUpdateMessage.new(type: "message_update", hash:)
+
+                assert_nil message.format
+              end
+
+              test "format returns nil when no event" do
+                message = MessageUpdateMessage.new(type: "message_update", hash: {})
+
+                assert_nil message.format
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/session_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/session_message_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class SessionMessageTest < ActiveSupport::TestCase
+              test "initialize sets session_id from id field" do
+                hash = { id: "abc-123", version: 3, cwd: "/tmp", timestamp: "2026-01-01T00:00:00Z" }
+                message = SessionMessage.new(type: "session", hash:)
+
+                assert_equal "abc-123", message.session_id
+              end
+
+              test "initialize sets version" do
+                hash = { id: "abc", version: 3 }
+                message = SessionMessage.new(type: "session", hash:)
+
+                assert_equal 3, message.version
+              end
+
+              test "initialize sets cwd" do
+                hash = { id: "abc", cwd: "/home/user" }
+                message = SessionMessage.new(type: "session", hash:)
+
+                assert_equal "/home/user", message.cwd
+              end
+
+              test "initialize sets timestamp" do
+                hash = { id: "abc", timestamp: "2026-01-01T00:00:00Z" }
+                message = SessionMessage.new(type: "session", hash:)
+
+                assert_equal "2026-01-01T00:00:00Z", message.timestamp
+              end
+
+              test "initialize removes parsed fields from hash" do
+                hash = { id: "abc", version: 3, cwd: "/tmp", timestamp: "2026-01-01T00:00:00Z" }
+                SessionMessage.new(type: "session", hash:)
+
+                refute hash.key?(:id)
+                refute hash.key?(:version)
+                refute hash.key?(:cwd)
+                refute hash.key?(:timestamp)
+              end
+
+              test "initialize handles missing fields" do
+                hash = {}
+                message = SessionMessage.new(type: "session", hash:)
+
+                assert_nil message.session_id
+                assert_nil message.version
+                assert_nil message.cwd
+                assert_nil message.timestamp
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/tool_execution_end_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/tool_execution_end_message_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolExecutionEndMessageTest < ActiveSupport::TestCase
+              test "initialize creates message with type" do
+                message = ToolExecutionEndMessage.new(type: "tool_execution_end", hash: {})
+
+                assert_equal "tool_execution_end", message.type
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/tool_execution_start_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/tool_execution_start_message_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class ToolExecutionStartMessageTest < ActiveSupport::TestCase
+              test "initialize creates message with type" do
+                message = ToolExecutionStartMessage.new(type: "tool_execution_start", hash: {})
+
+                assert_equal "tool_execution_start", message.type
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/turn_end_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/turn_end_message_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TurnEndMessageTest < ActiveSupport::TestCase
+              test "initialize extracts message" do
+                hash = {
+                  message: { role: "assistant", model: "claude-opus-4-6", content: [] },
+                }
+                message = TurnEndMessage.new(type: "turn_end", hash:)
+
+                assert_equal "assistant", message.message[:role]
+              end
+
+              test "initialize extracts tool_results" do
+                hash = {
+                  message: {},
+                  toolResults: [{ id: "123", content: "ok" }],
+                }
+                message = TurnEndMessage.new(type: "turn_end", hash:)
+
+                assert_equal 1, message.tool_results.length
+              end
+
+              test "initialize defaults tool_results to empty array" do
+                hash = { message: {} }
+                message = TurnEndMessage.new(type: "turn_end", hash:)
+
+                assert_equal [], message.tool_results
+              end
+
+              test "initialize removes parsed fields from hash" do
+                hash = { message: {}, toolResults: [] }
+                TurnEndMessage.new(type: "turn_end", hash:)
+
+                refute hash.key?(:message)
+                refute hash.key?(:toolResults)
+              end
+
+              test "model returns model from message" do
+                hash = {
+                  message: { model: "claude-opus-4-6" },
+                }
+                message = TurnEndMessage.new(type: "turn_end", hash:)
+
+                assert_equal "claude-opus-4-6", message.model
+              end
+
+              test "model returns nil when message is nil" do
+                message = TurnEndMessage.new(type: "turn_end", hash: {})
+
+                assert_nil message.model
+              end
+
+              test "usage returns usage from message" do
+                hash = {
+                  message: {
+                    usage: { input: 100, output: 50, cost: { total: 0.01 } },
+                  },
+                }
+                message = TurnEndMessage.new(type: "turn_end", hash:)
+
+                assert_equal 100, message.usage[:input]
+                assert_equal 50, message.usage[:output]
+              end
+
+              test "usage returns nil when message is nil" do
+                message = TurnEndMessage.new(type: "turn_end", hash: {})
+
+                assert_nil message.usage
+              end
+
+              test "content returns content array from message" do
+                hash = {
+                  message: {
+                    content: [{ type: "text", text: "Hello" }],
+                  },
+                }
+                message = TurnEndMessage.new(type: "turn_end", hash:)
+
+                assert_equal 1, message.content.length
+                assert_equal "text", message.content.first[:type]
+              end
+
+              test "content returns empty array when message is nil" do
+                message = TurnEndMessage.new(type: "turn_end", hash: {})
+
+                assert_equal [], message.content
+              end
+
+              test "stop_reason returns stopReason from message" do
+                hash = {
+                  message: { stopReason: "stop" },
+                }
+                message = TurnEndMessage.new(type: "turn_end", hash:)
+
+                assert_equal "stop", message.stop_reason
+              end
+
+              test "stop_reason returns nil when message is nil" do
+                message = TurnEndMessage.new(type: "turn_end", hash: {})
+
+                assert_nil message.stop_reason
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/turn_start_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/turn_start_message_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class TurnStartMessageTest < ActiveSupport::TestCase
+              test "initialize creates message with type" do
+                message = TurnStartMessage.new(type: "turn_start", hash: {})
+
+                assert_equal "turn_start", message.type
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/messages/unknown_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/unknown_message_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class Agent < Cog
+      module Providers
+        class Pi < Provider
+          module Messages
+            class UnknownMessageTest < ActiveSupport::TestCase
+              test "initialize stores hash in raw" do
+                hash = { foo: "bar", baz: 123 }
+                message = UnknownMessage.new(type: "unknown", hash: hash.dup)
+
+                assert_equal "bar", message.raw[:foo]
+                assert_equal 123, message.raw[:baz]
+              end
+
+              test "raw is the same object as hash" do
+                hash = { test: "value" }
+                message = UnknownMessage.new(type: "unknown", hash:)
+
+                assert_same hash, message.raw
+              end
+
+              test "type is preserved" do
+                message = UnknownMessage.new(type: "new_type", hash: {})
+
+                assert_equal "new_type", message.type
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/roast/cogs/agent/providers/pi/pi_invocation_test.rb
+++ b/test/roast/cogs/agent/providers/pi/pi_invocation_test.rb
@@ -231,7 +231,10 @@ module Roast
             # Message handling tests
 
             test "handle_message extracts session id from session message" do
-              message = { type: "session", id: "abc-123", version: 3 }
+              message = Messages::SessionMessage.new(
+                type: "session",
+                hash: { id: "abc-123", version: 3 },
+              )
 
               @invocation.send(:handle_message, message)
 
@@ -240,13 +243,15 @@ module Roast
             end
 
             test "handle_message extracts response from agent_end message" do
-              message = {
+              message = Messages::AgentEndMessage.new(
                 type: "agent_end",
-                messages: [
-                  { role: "user", content: [{ type: "text", text: "Hello" }] },
-                  { role: "assistant", content: [{ type: "text", text: "Hi there!" }] },
-                ],
-              }
+                hash: {
+                  messages: [
+                    { role: "user", content: [{ type: "text", text: "Hello" }] },
+                    { role: "assistant", content: [{ type: "text", text: "Hi there!" }] },
+                  ],
+                },
+              )
 
               @invocation.send(:handle_message, message)
 
@@ -256,14 +261,16 @@ module Roast
             end
 
             test "handle_message extracts response from last assistant message in agent_end" do
-              message = {
+              message = Messages::AgentEndMessage.new(
                 type: "agent_end",
-                messages: [
-                  { role: "user", content: [{ type: "text", text: "Hello" }] },
-                  { role: "assistant", content: [{ type: "toolCall", name: "read", arguments: {} }] },
-                  { role: "assistant", content: [{ type: "text", text: "Final response" }] },
-                ],
-              }
+                hash: {
+                  messages: [
+                    { role: "user", content: [{ type: "text", text: "Hello" }] },
+                    { role: "assistant", content: [{ type: "toolCall", name: "read", arguments: {} }] },
+                    { role: "assistant", content: [{ type: "text", text: "Final response" }] },
+                  ],
+                },
+              )
 
               @invocation.send(:handle_message, message)
 
@@ -272,18 +279,20 @@ module Roast
             end
 
             test "handle_message accumulates turn stats" do
-              message = {
+              message = Messages::TurnEndMessage.new(
                 type: "turn_end",
-                message: {
-                  role: "assistant",
-                  model: "claude-sonnet-4-20250514",
-                  usage: {
-                    input: 100,
-                    output: 50,
-                    cost: { total: 0.001 },
+                hash: {
+                  message: {
+                    role: "assistant",
+                    model: "claude-sonnet-4-20250514",
+                    usage: {
+                      input: 100,
+                      output: 50,
+                      cost: { total: 0.001 },
+                    },
                   },
                 },
-              }
+              )
 
               @invocation.send(:handle_message, message)
 
@@ -297,22 +306,26 @@ module Roast
             end
 
             test "handle_message accumulates stats across multiple turns" do
-              turn1 = {
+              turn1 = Messages::TurnEndMessage.new(
                 type: "turn_end",
-                message: {
-                  role: "assistant",
-                  model: "claude-sonnet-4-20250514",
-                  usage: { input: 100, output: 50, cost: { total: 0.001 } },
+                hash: {
+                  message: {
+                    role: "assistant",
+                    model: "claude-sonnet-4-20250514",
+                    usage: { input: 100, output: 50, cost: { total: 0.001 } },
+                  },
                 },
-              }
-              turn2 = {
+              )
+              turn2 = Messages::TurnEndMessage.new(
                 type: "turn_end",
-                message: {
-                  role: "assistant",
-                  model: "claude-sonnet-4-20250514",
-                  usage: { input: 200, output: 75, cost: { total: 0.002 } },
+                hash: {
+                  message: {
+                    role: "assistant",
+                    model: "claude-sonnet-4-20250514",
+                    usage: { input: 200, output: 75, cost: { total: 0.002 } },
+                  },
                 },
-              }
+              )
 
               @invocation.send(:handle_message, turn1)
               @invocation.send(:handle_message, turn2)


### PR DESCRIPTION
Parse Pi's streaming JSON protocol into structured message objects,
mirroring the Claude provider's message architecture.

Message types implemented:
- SessionMessage: Initial session metadata (id, version, cwd)
- AgentStartMessage: Agent execution has begun
- AgentEndMessage: Agent execution complete with full conversation;
  extracts final response, model, and usage from last assistant message
- TurnStartMessage: New request/response cycle started
- TurnEndMessage: Turn complete with usage stats per model
- MessageStartMessage: User or assistant message starting
- MessageUpdateMessage: Streaming deltas (text_delta, text_start/end,
  toolcall_start/delta/end) with format() for progress display
- MessageEndMessage: Message complete with final content and usage
- ToolExecutionStartMessage / ToolExecutionEndMessage: Tool execution
- UnknownMessage: Catch-all for unrecognized types

The Message base class provides a from_json/from_hash factory that
dispatches to the appropriate subclass. PiInvocation now uses the
Message classes instead of raw hash parsing.

91 new tests (119 total Pi provider tests), full suite passes (985).