### PR TITLE
Add Pi provider documentation and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,41 @@ bin/roast execute analyze_codebase.rb
 ## Core Cogs
 
 - **`chat`** - Send prompts to cloud-based LLMs (OpenAI, Anthropic, Gemini, etc.)
-- **`agent`** - Run local coding agents with filesystem access (Claude Code CLI, etc.)
+- **`agent`** - Run local coding agents with filesystem access (Claude Code, Pi, etc.)
 - **`ruby`** - Execute custom Ruby code within workflows
 - **`cmd`** - Run shell commands and capture output
 - **`map`** - Process collections in serial or parallel
 - **`repeat`** - Iterate until conditions are met
 - **`call`** - Invoke reusable workflow scopes
+
+## Agent Providers
+
+The `agent` cog supports multiple coding agent backends. Configure the provider in your workflow's `config` block:
+
+```ruby
+# Use Claude Code (default)
+config do
+  agent do
+    provider :claude
+    model "haiku"
+  end
+end
+
+# Use Pi
+config do
+  agent do
+    provider :pi
+    model "sonnet"
+  end
+end
+```
+
+| Provider | CLI | Install |
+|---|---|---|
+| `:claude` (default) | `claude` | [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) |
+| `:pi` | `pi` | [Pi](https://github.com/Shopify/pi) |
+
+Both providers support: `model`, `command`, `append_system_prompt`, `replace_system_prompt`, `working_directory`, session management, and all display options (`show_prompt!`, `show_progress!`, `show_response!`, `show_stats!`).
 
 ## Installation
 
@@ -70,7 +99,7 @@ gem 'roast-ai'
 
 - Ruby 3.0+
 - API keys for your AI provider (OpenAI/Anthropic)
-- Claude Code CLI installed (for agent cog)
+- A coding agent CLI installed (for agent cog): [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) and/or [Pi](https://github.com/Shopify/pi)
 
 ## Getting Started
 

--- a/docs/AGENT_STEPS.md
+++ b/docs/AGENT_STEPS.md
@@ -1,6 +1,6 @@
 # Agent Steps in Roast
 
-Agent steps provide a way to send prompts directly to a coding agent (like Claude Code) without going through the standard LLM translation layer. This document explains when and how to use agent steps effectively.
+Agent steps provide a way to send prompts directly to a coding agent (like Claude Code or Pi) without going through the standard LLM translation layer. This document explains when and how to use agent steps effectively.
 
 ## What are Agent Steps?
 

--- a/examples/pi_agent_sessions.rb
+++ b/examples/pi_agent_sessions.rb
@@ -1,0 +1,24 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::Workflow
+
+# This example demonstrates session management with the Pi coding agent.
+# The first agent establishes a fact, and the second agent resumes
+# from that session to recall it.
+
+config do
+  agent do
+    provider :pi
+    model "sonnet"
+    dump_raw_agent_messages_to "tmp/pi-messages.log"
+  end
+end
+
+execute do
+  agent(:one) { "The magic word is 'pomegranate'" }
+  agent(:two) do |my|
+    my.session = agent!(:one).session
+    "What is the magic word?"
+  end
+end

--- a/tutorial/04_configuration_options/README.md
+++ b/tutorial/04_configuration_options/README.md
@@ -46,13 +46,13 @@ config do
 
   agent do
     model "claude-3-5-haiku-20241022"
-    provider :claude
+    provider :claude  # or :pi for the Pi coding agent
   end
 end
 ```
 
 Now all `chat` cogs use "gpt-4o-mini" and all `agent` cogs use Claude Code with the "haiku" model (unless you override
-them individually).
+them individually). You can also use `provider :pi` to use the Pi coding agent instead.
 
 ## Per-Step Configuration
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -15,7 +15,7 @@ run coding agents, process data, and so much more.
 - Ruby installed (3.4.2+)
 - Roast gem installed
 - API keys for your AI providers of choice (to use LLM chat)
-- Claude Code CLI installed and configured (to use coding agents)
+- A coding agent CLI installed and configured (to use coding agents): Claude Code and/or Pi
 
 ## How to Use This Tutorial
 


### PR DESCRIPTION
Document Pi as a supported agent provider across the project:

README.md:
- Add 'Agent Providers' section with config examples for both
  Claude Code and Pi, plus comparison table
- Update Core Cogs description to mention Pi
- Update Requirements to list both agent CLIs

Examples:
- Add pi_agent_sessions.rb showing session resume with Pi
  (mirrors agent_sessions.rb pattern)

Tutorial:
- Update prerequisites to mention Pi alongside Claude Code
- Update chapter 4 (Configuration) to show provider :pi option

Docs:
- Update AGENT_STEPS.md to mention Pi alongside Claude Code