### PR TITLE
Extract Roast::Testing::TestCase as public API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,12 +55,13 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-multipart (1.1.1)
+    faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
-    faraday-retry (2.3.2)
+    faraday-retry (2.4.0)
       faraday (~> 2.0)
+    ffi (1.17.2)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     fiber-annotation (0.2.0)
@@ -98,7 +99,7 @@ GEM
     marcel (1.1.0)
     method_source (1.1.0)
     metrics (0.15.0)
-    minitest (5.25.5)
+    minitest (5.27.0)
     minitest-rg (5.3.0)
       minitest (~> 5.0)
     mocha (2.7.1)
@@ -214,7 +215,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
     vcr (6.3.1)
       base64

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,91 @@
+# Testing Your Roast Workflows
+
+`Roast::Testing::TestCase` provides sandbox isolation and optional VCR recording/playback for testing workflows.
+
+## Quick Start
+
+```ruby
+# test/workflows/my_workflow_test.rb
+require "roast"
+require "roast/testing/test_case"
+require "minitest/autorun"
+
+class MyWorkflowTest < Roast::Testing::TestCase
+  self.workflow_dir = File.expand_path("../../workflows", __dir__)
+
+  test "my workflow runs successfully" do
+    stdout, stderr = in_sandbox(:my_workflow) do
+      Roast::Workflow.from_file("workflows/my_workflow.rb", EMPTY_PARAMS)
+    end
+    assert_empty stderr
+  end
+end
+```
+
+## Sandbox Isolation
+
+`in_sandbox` creates a temp directory, copies `workflow_dir` **into** it (preserving the basename), and captures stdout/stderr. Temp paths in output are replaced with `/fake-testing-dir`.
+
+Paths passed to `Workflow.from_file` should include the directory name (e.g. `"workflows/my_workflow.rb"` when `workflow_dir` points to a `workflows/` directory).
+
+`EMPTY_PARAMS` is a frozen `WorkflowParams` with no targets or arguments.
+
+## VCR Recording (Optional)
+
+Add `vcr` and `webmock` to your Gemfile and require them before `roast/testing/test_case`. TestCase auto-configures VCR with filtered API keys, cookies, and cassettes in `test/fixtures/vcr_cassettes/`.
+
+```bash
+# Record (only "true" enables recording)
+RECORD_VCR=true OPENAI_API_KEY=sk-... bundle exec ruby -Itest test/workflows/my_test.rb
+
+# Replay (default — no credentials needed)
+bundle exec ruby -Itest test/workflows/my_test.rb
+```
+
+Without VCR in your Gemfile, tests run live against real APIs.
+
+> **Note:** VCR has a single global `cassette_library_dir`. Configure VCR in your own `test_helper.rb` before loading `Roast::Testing::TestCase` if you need per-class cassette directories.
+
+## Agent Testing (Optional)
+
+For workflows invoking external commands (e.g. Claude CLI), use `use_command_runner_fixtures` to stub `CommandRunner.execute` with fixture files. Requires the `mocha` gem.
+
+```ruby
+# Reads test/fixtures/my_agent.stdout.txt and .stderr.txt
+use_command_runner_fixtures(
+  { fixture: "my_agent", expected_args: ["claude", "--chat"] }
+)
+```
+
+For multi-invocation workflows, pass multiple specs:
+
+```ruby
+use_command_runner_fixtures(
+  { fixture: "agent_turn_1", expected_stdin_content: "Hello" },
+  { fixture: "agent_turn_2", expected_stdin_content: "Follow up" },
+)
+```
+
+Each spec accepts: `:fixture`, `:exit_code` (default 0), `:expected_args`, `:expected_working_directory`, `:expected_timeout`, `:expected_stdin_content`.
+
+## Configuration
+
+```ruby
+class MyWorkflowTest < Roast::Testing::TestCase
+  self.workflow_dir = "/path/to/workflows"       # required; copied into sandbox
+  self.sandbox_root = "/tmp/my_sandboxes"         # default: tmp/sandboxes
+  self.fixture_dir = "test/my_fixtures"           # default: test/fixtures
+  self.api_key_env_var = "ANTHROPIC_API_KEY"      # default: OPENAI_API_KEY
+  self.api_base_env_var = "ANTHROPIC_API_BASE"    # default: OPENAI_API_BASE
+  self.fake_api_key = "test-key"                  # default: my-token
+  self.fake_api_base = "http://localhost:4000"    # default: http://mytestingproxy.local/v1
+end
+```
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `RECORD_VCR=true` | Record VCR cassettes with real API credentials |
+| `PRESERVE_SANDBOX=true` | Keep sandbox temp dirs after tests (for debugging) |
+| `CI=true` | Print captured stdout/stderr to console |

--- a/examples/test/example_workflow_test.rb
+++ b/examples/test/example_workflow_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+# Example test file for Roast workflows.
+#
+# This demonstrates how to use Roast::Testing::TestCase to write tests
+# for your own workflows. Copy and adapt this to your project.
+#
+# Run with:
+#   bundle exec ruby -Itest examples/test/example_workflow_test.rb
+
+require_relative "test_helper"
+
+class ExampleWorkflowTest < Roast::Testing::TestCase
+  # Point to the directory containing your workflow files.
+  # Everything in this directory gets copied into an isolated sandbox for each test.
+  self.workflow_dir = File.expand_path("..", __dir__)
+
+  # -----------------------------------------------------------
+  # Capturing log output
+  # -----------------------------------------------------------
+  #
+  # Roast logs workflow execution via Roast::Log (which writes to $stderr).
+  # To capture and assert on log output, redirect the logger to a StringIO.
+  #
+  setup do
+    @log_output = StringIO.new
+    Roast::Log.logger = Logger.new(@log_output)
+  end
+
+  teardown do
+    Roast::Log.reset!
+  end
+
+  # -----------------------------------------------------------
+  # Basic test: run a workflow and verify it completes
+  # -----------------------------------------------------------
+  #
+  # `in_sandbox` does the following:
+  #   1. Creates a temp directory
+  #   2. Copies your workflow_dir contents into it
+  #   3. Sets up fake API credentials (for VCR playback)
+  #   4. Wraps the block in a VCR cassette (if VCR is loaded)
+  #   5. Returns [stdout, stderr] with temp paths sanitized
+  #
+  test "ruby_cog workflow runs successfully" do
+    in_sandbox(:ruby_cog) do
+      Roast::Workflow.from_file("examples/ruby_cog.rb", EMPTY_PARAMS)
+    end
+
+    # Check log output for completion
+    assert_match(/Workflow Complete/, @log_output.string)
+  end
+
+  # -----------------------------------------------------------
+  # Testing with parameters
+  # -----------------------------------------------------------
+  #
+  # Use Roast::WorkflowParams to pass targets and arguments to your workflow.
+  # EMPTY_PARAMS is a convenience constant for workflows that don't need any.
+  #
+  test "workflow accepts custom parameters" do
+    params = Roast::WorkflowParams.new(
+      [],           # targets - files or items to process
+      [],           # positional args
+      {},           # keyword args
+    )
+
+    in_sandbox(:params_test) do
+      Roast::Workflow.from_file("examples/ruby_cog.rb", params)
+    end
+
+    assert_match(/Workflow Complete/, @log_output.string)
+    # No ERROR-level entries in the log
+    refute_match(/ERROR/, @log_output.string)
+  end
+
+  # -----------------------------------------------------------
+  # Testing workflows that use shell commands
+  # -----------------------------------------------------------
+  #
+  # Workflows using `cmd` cogs run shell commands. These run normally
+  # inside the sandbox. The sandbox is a temp directory, so commands
+  # won't affect your real files.
+  #
+  test "shell workflow runs commands in sandbox" do
+    in_sandbox(:shell_test) do
+      Roast::Workflow.from_file("examples/shell_sanitization.rb", EMPTY_PARAMS)
+    end
+
+    assert_match(/Workflow Complete/, @log_output.string)
+  end
+
+  # -----------------------------------------------------------
+  # Testing that errors are raised properly
+  # -----------------------------------------------------------
+  #
+  # Use standard Minitest assertions to verify error handling.
+  #
+  test "nonexistent workflow raises error" do
+    assert_raises(Errno::ENOENT) do
+      in_sandbox(:error_test) do
+        Roast::Workflow.from_file("examples/does_not_exist.rb", EMPTY_PARAMS)
+      end
+    end
+  end
+end

--- a/examples/test/test_helper.rb
+++ b/examples/test/test_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Example test_helper.rb for testing Roast workflows.
+#
+# Copy this file into your project's test/ directory and adjust paths as needed.
+
+# Only needed when developing/testing Roast itself from source.
+# If you installed Roast as a gem, `require "roast"` works without this.
+$LOAD_PATH.unshift(File.expand_path("../../lib", __dir__))
+
+require "roast"
+require "minitest/autorun"
+
+# Optional: Uncomment the following lines if you want VCR recording/playback.
+# This lets you record real API responses once, then replay them for fast, offline tests.
+#
+# require "vcr"
+# require "webmock"
+
+require "roast/testing/test_case"

--- a/lib/roast.rb
+++ b/lib/roast.rb
@@ -42,6 +42,7 @@ require "zeitwerk"
 # Set up Zeitwerk autoloader
 loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/roast-ai.rb")
+loader.ignore("#{__dir__}/roast/testing")
 loader.inflector.inflect("cli" => "CLI")
 loader.setup
 

--- a/lib/roast/testing/test_case.rb
+++ b/lib/roast/testing/test_case.rb
@@ -1,0 +1,278 @@
+# typed: false
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+require "active_support/test_case"
+
+module Roast
+  module Testing
+    # Base test class for writing tests against Roast workflows.
+    #
+    # Provides sandbox isolation, optional VCR recording/playback for HTTP requests,
+    # and helpers for testing agent transcript fixtures.
+    #
+    # The sandbox copies your +workflow_dir+ INTO a temp directory as a subdirectory,
+    # preserving its basename. For example, if +workflow_dir+ is +/home/me/my_project/workflows+,
+    # the sandbox will contain +<tmpdir>/workflows/...+. Paths passed to +Workflow.from_file+
+    # should include this directory name (e.g. +"workflows/my_workflow.rb"+).
+    #
+    # Usage:
+    #   require "roast/testing/test_case"
+    #
+    #   class MyWorkflowTest < Roast::Testing::TestCase
+    #     # Point to your workflow directory
+    #     self.workflow_dir = "path/to/my/workflows"
+    #
+    #     test "my workflow runs" do
+    #       stdout, stderr = in_sandbox(:my_workflow) do
+    #         Roast::Workflow.from_file("workflows/my_workflow.rb", EMPTY_PARAMS)
+    #       end
+    #       assert_empty stderr
+    #     end
+    #   end
+    class TestCase < ActiveSupport::TestCase
+      EMPTY_PARAMS = Roast::WorkflowParams.new([].freeze, [].freeze, {}.freeze).freeze
+
+      class_attribute :workflow_dir, default: nil
+      class_attribute :cassette_library_dir, default: nil
+      class_attribute :sandbox_root, default: nil
+      class_attribute :api_key_env_var, default: "OPENAI_API_KEY"
+      class_attribute :api_base_env_var, default: "OPENAI_API_BASE"
+      class_attribute :fake_api_key, default: "my-token"
+      class_attribute :fake_api_base, default: "http://mytestingproxy.local/v1"
+      class_attribute :fixture_dir, default: nil
+
+      setup do
+        Roast::EventMonitor.reset! if defined?(Roast::EventMonitor)
+      end
+
+      teardown do
+        verify_command_runner_fixtures!
+        Roast::EventMonitor.reset! if defined?(Roast::EventMonitor)
+      end
+
+      # Run a block inside an isolated sandbox directory with optional VCR cassette wrapping.
+      #
+      # Copies workflow_dir INTO a temp directory (preserving the directory basename),
+      # sets up fake API credentials (or real ones when recording), and wraps the block
+      # in a VCR cassette if VCR is available.
+      #
+      # @param workflow_id [Symbol, String] identifier used for the sandbox subdirectory and VCR cassette name
+      # @return [Array<String>] [stdout, stderr] captured output with temp paths sanitized
+      def in_sandbox(workflow_id, &block)
+        source_path = resolve_workflow_dir
+        tmpdir_root = resolve_sandbox_root
+        tmpdir = nil
+
+        FileUtils.mkdir_p(tmpdir_root)
+
+        out, err = capture_io do
+          recording = ENV["RECORD_VCR"] == "true"
+
+          with_env(api_key_env_var, recording ? ENV[api_key_env_var] : fake_api_key) do
+            with_env(api_base_env_var, recording ? ENV[api_base_env_var] : fake_api_base) do
+              in_tmpdir(workflow_id.to_s, tmpdir_root) do |sandbox_dir|
+                tmpdir = sandbox_dir
+                FileUtils.cp_r(source_path, sandbox_dir)
+
+                with_vcr_cassette(workflow_id, recording: recording, &block)
+              end
+            end
+          end
+        end
+
+        # Replace random temp directory path with a standardized value
+        if tmpdir
+          out.gsub!(tmpdir, "/fake-testing-dir")
+          err.gsub!(tmpdir, "/fake-testing-dir")
+        end
+
+        if ENV["CI"]
+          puts "========= STDOUT ========="
+          puts out
+          puts "========= STDERR ========="
+          puts err
+          puts "========= ====== ========="
+        end
+
+        [out, err]
+      end
+
+      # Set up mocks for CommandRunner.execute that replay from fixture files.
+      #
+      # Supports multiple sequential invocations. Each spec hash should contain:
+      #   - :fixture [String] — base name for fixture files (looks for .stdout.txt/.stdout.log and .stderr.txt/.stderr.log)
+      #   - :exit_code [Integer] — simulated exit code (default: 0)
+      #   - :expected_args [Array<String>, nil] — if set, asserts CommandRunner args match
+      #   - :expected_working_directory [String, Pathname, nil] — if set, asserts working_directory matches
+      #   - :expected_timeout [Integer, Float, nil] — if set, asserts timeout matches
+      #   - :expected_stdin_content [String, nil] — if set, asserts stdin_content matches
+      #
+      # Requires the `mocha` gem to be loaded.
+      #
+      # NOTE: Expected-value assertions (expected_args, etc.) are validated after each
+      # call returns, not inside Mocha's +with+ block. This ensures assertion failures
+      # surface as normal Minitest failures rather than being swallowed by Mocha as
+      # "unexpected invocation" errors.
+      #
+      # @param specs [Array<Hash>] one or more fixture specifications
+      def use_command_runner_fixtures(*specs)
+        unless defined?(Mocha)
+          raise "use_command_runner_fixtures requires the 'mocha' gem. Add it to your Gemfile."
+        end
+
+        call_index = 0
+        recorded_calls = []
+
+        loaded = specs.map.with_index do |spec, i|
+          fixture_name = spec.fetch(:fixture)
+          exit_code = spec.fetch(:exit_code, 0)
+
+          stdout_fixture = load_fixture_file(fixture_name, :stdout)
+          stderr_fixture = load_fixture_file(fixture_name, :stderr)
+
+          mock_status = mock("process_status_#{i}")
+          mock_status.stubs(exitstatus: exit_code, success?: exit_code == 0, signaled?: false)
+
+          { spec:, stdout: stdout_fixture, stderr: stderr_fixture, status: mock_status }
+        end
+
+        expectation = Roast::CommandRunner.stubs(:execute).with do |args, **kwargs|
+          if call_index >= loaded.size
+            raise "CommandRunner.execute called #{call_index + 1} times, but only #{loaded.size} fixture(s) were provided"
+          end
+
+          entry = loaded[call_index]
+          call_index += 1
+
+          # Record the call for post-hoc assertion (avoids Mocha swallowing assertion errors)
+          recorded_calls << { args: args, kwargs: kwargs, spec: entry[:spec] }
+
+          entry[:stdout].each_line { |line| kwargs[:stdout_handler]&.call(line) }
+          entry[:stderr].each_line { |line| kwargs[:stderr_handler]&.call(line) }
+
+          true
+        end
+
+        loaded.each_with_index do |entry, i|
+          ret = [entry[:stdout], entry[:stderr], entry[:status]]
+          expectation = i == 0 ? expectation.returns(ret) : expectation.then.returns(ret)
+        end
+
+        # Return the recorded_calls array so callers can assert on call details after
+        # execution. The teardown hook validates expectations automatically.
+        @_command_runner_recorded_calls = recorded_calls
+        @_command_runner_specs = loaded
+      end
+
+      # Validate recorded CommandRunner calls against expectations.
+      # Called automatically in teardown, or can be called manually after running a workflow.
+      def verify_command_runner_fixtures!
+        return unless @_command_runner_recorded_calls
+
+        @_command_runner_recorded_calls.each_with_index do |call, i|
+          s = call[:spec]
+          invocation = i + 1
+
+          assert_equal(s[:expected_args], call[:args], "CommandRunner args mismatch (invocation #{invocation})") if s[:expected_args]
+          assert_equal(s[:expected_working_directory], call[:kwargs][:working_directory], "CommandRunner working_directory mismatch (invocation #{invocation})") if s[:expected_working_directory]
+          assert_equal(s[:expected_timeout], call[:kwargs][:timeout], "CommandRunner timeout mismatch (invocation #{invocation})") if s[:expected_timeout]
+          assert_equal(s[:expected_stdin_content], call[:kwargs][:stdin_content], "CommandRunner stdin_content mismatch (invocation #{invocation})") if s[:expected_stdin_content]
+        end
+      ensure
+        @_command_runner_recorded_calls = nil
+        @_command_runner_specs = nil
+      end
+
+      private
+
+      def resolve_workflow_dir
+        dir = workflow_dir || File.join(Dir.pwd, "examples")
+        raise ArgumentError, "Workflow directory not found: #{dir}" unless Dir.exist?(dir)
+
+        dir
+      end
+
+      def resolve_sandbox_root
+        sandbox_root || File.join(Dir.pwd, "tmp/sandboxes")
+      end
+
+      def fixture_path(filename)
+        dir = fixture_dir || File.join(Dir.pwd, "test/fixtures")
+        File.join(dir, filename)
+      end
+
+      # Load a fixture file, trying multiple extensions.
+      def load_fixture_file(fixture_name, stream)
+        extensions = stream == :stdout ? [".stdout.txt", ".stdout.log"] : [".stderr.txt", ".stderr.log"]
+        extensions.each do |ext|
+          path = fixture_path("#{fixture_name}#{ext}")
+          return File.read(path) if File.exist?(path)
+        end
+        ""
+      end
+
+      def with_vcr_cassette(workflow_id, recording: nil, &block)
+        if defined?(VCR)
+          configure_vcr_once
+          VCR.use_cassette(workflow_id.to_s, record: recording ? :all : :none, &block)
+        else
+          yield
+        end
+      end
+
+      VCR_MUTEX = Mutex.new
+
+      def configure_vcr_once
+        VCR_MUTEX.synchronize do
+          return if Roast::Testing::TestCase.instance_variable_get(:@vcr_configured)
+
+          api_key_replacement = fake_api_key
+          api_base_replacement = fake_api_base
+          cassette_dir = cassette_library_dir || File.join(Dir.pwd, "test/fixtures/vcr_cassettes")
+
+          VCR.configure do |config|
+            config.cassette_library_dir = cassette_dir
+            config.hook_into(:webmock) if defined?(WebMock)
+
+            config.filter_sensitive_data("#{api_base_replacement}/chat/completions") do |interaction|
+              interaction.request.uri
+            end
+
+            config.filter_sensitive_data(api_key_replacement) do |interaction|
+              interaction.request.headers["Authorization"]&.first
+            end
+
+            config.filter_sensitive_data("<FILTERED>") do |interaction|
+              interaction.request.headers["Set-Cookie"]
+            end
+
+            config.filter_sensitive_data("<FILTERED>") do |interaction|
+              interaction.response.headers["Set-Cookie"]
+            end
+          end
+
+          Roast::Testing::TestCase.instance_variable_set(:@vcr_configured, true)
+        end
+      end
+
+      def with_env(key, value)
+        original = ENV[key]
+        ENV[key] = value
+        yield
+      ensure
+        ENV[key] = original
+      end
+
+      def in_tmpdir(prefix, tmpdir_root, &block)
+        if ENV["PRESERVE_SANDBOX"]
+          dir = Dir.mktmpdir(prefix, tmpdir_root)
+          yield(dir)
+        else
+          Dir.mktmpdir(prefix, tmpdir_root, &block)
+        end
+      end
+    end
+  end
+end

--- a/test/examples/functional/roast_examples_test.rb
+++ b/test/examples/functional/roast_examples_test.rb
@@ -5,17 +5,7 @@ require "test_helper"
 # This test suite validates the example workflows in `examples/`.
 module Examples
   module Functional
-    EMPTY_PARAMS = Roast::WorkflowParams.new([], [], {})
-
     class RoastExamplesTest < FunctionalTest
-      setup do
-        Roast::EventMonitor.reset!
-      end
-
-      teardown do
-        Roast::EventMonitor.reset!
-      end
-
       test "agent_with_multiple_prompts.rb workflow runs successfully" do
         use_command_runner_fixtures(
           {

--- a/test/examples/support/functional_test.rb
+++ b/test/examples/support/functional_test.rb
@@ -1,61 +1,11 @@
 # frozen_string_literal: true
 
+require "roast/testing/test_case"
+
 module Examples
-  class FunctionalTest < ActiveSupport::TestCase
-    # Set up a temporary sandbox directory with all the examples
-    # Parameter workflow_id is an arbitrary namespace/subdirectory within the sandbox
-    # Returns an array of strings [stdio_output, stderr_output]
-    def in_sandbox(workflow_id, &block)
-      root_project_path = Dir.pwd
-      examples_source_path = File.join(root_project_path, "examples")
-
-      tmpdir_root = File.join(root_project_path, "tmp/sandboxes")
-      tmpdir = nil
-
-      FileUtils.mkdir_p(tmpdir_root) unless Dir.exist?(tmpdir_root)
-
-      out, err = capture_io do
-        # Set up test environment variables for VCR playback
-        # When recording (RECORD_VCR=true), uses real credentials from environment
-        # When playing back, uses fake credentials (VCR intercepts all requests)
-        recording = ENV["RECORD_VCR"]
-
-        with_env("OPENAI_API_KEY", recording ? ENV["OPENAI_API_KEY"] : "my-token") do
-          with_env("OPENAI_API_BASE", recording ? ENV["OPENAI_API_BASE"] : "http://mytestingproxy.local/v1") do
-            in_tmpdir(workflow_id.to_s, tmpdir_root) do |workflow_dir|
-              tmpdir = workflow_dir
-              FileUtils.cp_r(examples_source_path, workflow_dir)
-
-              VCR.use_cassette(workflow_id.to_s, record: recording ? :all : :none) do
-                block.call
-              end
-            end
-          end
-        end
-      end
-
-      # Replace random temp directory path with a standardized value (for easier assertions)
-      path_regex = Regexp.new(tmpdir)
-      out.gsub!(path_regex, "/fake-testing-dir")
-      err.gsub!(path_regex, "/fake-testing-dir")
-
-      if ENV["CI"]
-        puts "========= STDOUT ========="
-        puts out
-        puts "========= STDERR ========="
-        puts err
-        puts "========= ====== ========="
-      end
-      [out, err]
-    end
-
-    def in_tmpdir(prefix, tmpdir_root, &block)
-      if ENV["PRESERVE_SANDBOX"]
-        dir = Dir.mktmpdir(prefix, tmpdir_root)
-        block.call(dir)
-      else
-        Dir.mktmpdir(prefix, tmpdir_root, &block)
-      end
-    end
+  # Thin wrapper around Roast::Testing::TestCase for internal example tests.
+  # New tests should use Roast::Testing::TestCase directly.
+  class FunctionalTest < Roast::Testing::TestCase
+    self.workflow_dir = File.join(Dir.pwd, "examples")
   end
 end

--- a/test/fixtures/testing/cmd_fixture_second.stdout.txt
+++ b/test/fixtures/testing/cmd_fixture_second.stdout.txt
@@ -1,0 +1,1 @@
+second fixture stdout

--- a/test/fixtures/testing/cmd_fixture_test.stderr.txt
+++ b/test/fixtures/testing/cmd_fixture_test.stderr.txt
@@ -1,0 +1,1 @@
+fixture stderr line 1

--- a/test/fixtures/testing/cmd_fixture_test.stdout.txt
+++ b/test/fixtures/testing/cmd_fixture_test.stdout.txt
@@ -1,0 +1,2 @@
+fixture stdout line 1
+fixture stdout line 2

--- a/test/fixtures/testing/hello_workflow.rb
+++ b/test/fixtures/testing/hello_workflow.rb
@@ -1,0 +1,8 @@
+# typed: false
+# frozen_string_literal: true
+
+#: self as Roast::Workflow
+
+execute do
+  cmd(:hello) { "echo hello from sandbox" }
+end

--- a/test/roast/testing/test_case_test.rb
+++ b/test/roast/testing/test_case_test.rb
@@ -1,0 +1,323 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "roast/testing/test_case"
+
+module Roast
+  module Testing
+    class TestCaseUnitTest < ActiveSupport::TestCase
+      test "EMPTY_PARAMS is frozen" do
+        assert_predicate TestCase::EMPTY_PARAMS, :frozen?
+      end
+
+      test "EMPTY_PARAMS has empty arrays and hash" do
+        params = TestCase::EMPTY_PARAMS
+        assert_empty params.targets
+        assert_empty params.args
+        assert_empty params.kwargs
+      end
+
+      test "resolve_workflow_dir raises ArgumentError for missing directory" do
+        klass = Class.new(TestCase) do
+          self.workflow_dir = "/nonexistent/path/that/does/not/exist"
+        end
+        instance = klass.new("test")
+        assert_raises(ArgumentError) { instance.send(:resolve_workflow_dir) }
+      end
+
+      test "resolve_workflow_dir uses workflow_dir when set and exists" do
+        klass = Class.new(TestCase) do
+          self.workflow_dir = Dir.pwd
+        end
+        instance = klass.new("test")
+        assert_equal(Dir.pwd, instance.send(:resolve_workflow_dir))
+      end
+
+      test "resolve_sandbox_root uses sandbox_root when set" do
+        klass = Class.new(TestCase) do
+          self.sandbox_root = "/custom/sandbox"
+        end
+        instance = klass.new("test")
+        assert_equal("/custom/sandbox", instance.send(:resolve_sandbox_root))
+      end
+
+      test "resolve_sandbox_root defaults to tmp/sandboxes" do
+        instance = TestCase.new("test")
+        assert_equal(File.join(Dir.pwd, "tmp/sandboxes"), instance.send(:resolve_sandbox_root))
+      end
+
+      test "fixture_path uses fixture_dir when set" do
+        klass = Class.new(TestCase) do
+          self.fixture_dir = "/custom/fixtures"
+        end
+        instance = klass.new("test")
+        assert_equal("/custom/fixtures/my_file.txt", instance.send(:fixture_path, "my_file.txt"))
+      end
+
+      test "fixture_path defaults to test/fixtures" do
+        instance = TestCase.new("test")
+        assert_equal(File.join(Dir.pwd, "test/fixtures/my_file.txt"), instance.send(:fixture_path, "my_file.txt"))
+      end
+
+      test "load_fixture_file returns empty string when no fixture files exist" do
+        klass = Class.new(TestCase) do
+          self.fixture_dir = "/nonexistent"
+        end
+        instance = klass.new("test")
+        assert_equal("", instance.send(:load_fixture_file, "missing_fixture", :stdout))
+        assert_equal("", instance.send(:load_fixture_file, "missing_fixture", :stderr))
+      end
+
+      test "load_fixture_file reads stdout fixture" do
+        instance = TestCase.new("test")
+        result = instance.send(:load_fixture_file, "agent_transcripts/simple_agent", :stdout)
+        refute_empty result
+      end
+
+      test "with_env temporarily sets and restores environment variable" do
+        original = ENV["ROAST_TEST_CASE_TEST_VAR"]
+        ENV["ROAST_TEST_CASE_TEST_VAR"] = "original_value"
+
+        instance = TestCase.new("test")
+        instance.send(:with_env, "ROAST_TEST_CASE_TEST_VAR", "temporary_value") do
+          assert_equal("temporary_value", ENV["ROAST_TEST_CASE_TEST_VAR"])
+        end
+        assert_equal("original_value", ENV["ROAST_TEST_CASE_TEST_VAR"])
+      ensure
+        ENV["ROAST_TEST_CASE_TEST_VAR"] = original
+      end
+
+      test "with_env restores nil when variable was unset" do
+        ENV.delete("ROAST_TEST_CASE_UNSET_VAR")
+        instance = TestCase.new("test")
+
+        instance.send(:with_env, "ROAST_TEST_CASE_UNSET_VAR", "temp") do
+          assert_equal("temp", ENV["ROAST_TEST_CASE_UNSET_VAR"])
+        end
+        assert_nil(ENV["ROAST_TEST_CASE_UNSET_VAR"])
+      end
+
+      test "with_env restores original value even on exception" do
+        ENV["ROAST_TEST_CASE_RESTORE_VAR"] = "keep_me"
+        instance = TestCase.new("test")
+
+        assert_raises(RuntimeError) do
+          instance.send(:with_env, "ROAST_TEST_CASE_RESTORE_VAR", "temp") do
+            raise "boom"
+          end
+        end
+        assert_equal("keep_me", ENV["ROAST_TEST_CASE_RESTORE_VAR"])
+      ensure
+        ENV.delete("ROAST_TEST_CASE_RESTORE_VAR")
+      end
+
+      test "in_tmpdir creates temporary directory and yields it" do
+        instance = TestCase.new("test")
+        yielded_dir = nil
+
+        instance.send(:in_tmpdir, "test_prefix", Dir.tmpdir) do |dir|
+          yielded_dir = dir
+          assert(Dir.exist?(dir))
+          assert_includes(dir, "test_prefix")
+        end
+
+        refute(Dir.exist?(yielded_dir))
+      end
+
+      test "in_tmpdir with PRESERVE_SANDBOX keeps directory" do
+        instance = TestCase.new("test")
+        yielded_dir = nil
+
+        original = ENV["PRESERVE_SANDBOX"]
+        ENV["PRESERVE_SANDBOX"] = "true"
+        begin
+          instance.send(:in_tmpdir, "preserve_test", Dir.tmpdir) do |dir|
+            yielded_dir = dir
+          end
+        ensure
+          ENV["PRESERVE_SANDBOX"] = original
+        end
+
+        assert(Dir.exist?(yielded_dir))
+        FileUtils.rm_rf(yielded_dir)
+      end
+
+      test "class attributes have correct defaults" do
+        assert_nil(TestCase.workflow_dir)
+        assert_nil(TestCase.cassette_library_dir)
+        assert_nil(TestCase.sandbox_root)
+        assert_equal("OPENAI_API_KEY", TestCase.api_key_env_var)
+        assert_equal("OPENAI_API_BASE", TestCase.api_base_env_var)
+        assert_equal("my-token", TestCase.fake_api_key)
+        assert_equal("http://mytestingproxy.local/v1", TestCase.fake_api_base)
+        assert_nil(TestCase.fixture_dir)
+      end
+
+      test "class attributes are inheritable" do
+        klass = Class.new(TestCase) do
+          self.workflow_dir = "/custom"
+          self.fixture_dir = "/custom_fixtures"
+        end
+
+        assert_equal("/custom", klass.workflow_dir)
+        assert_equal("/custom_fixtures", klass.fixture_dir)
+        assert_nil(TestCase.workflow_dir)
+        assert_nil(TestCase.fixture_dir)
+      end
+
+      test "configure_vcr_once guard is anchored on TestCase base class" do
+        # The guard uses Roast::Testing::TestCase (not self.class) to prevent
+        # duplicate VCR configuration from subclasses. Verify by checking that
+        # a subclass does NOT have its own @vcr_configured ivar — only the base does.
+        subclass = Class.new(TestCase)
+        refute(
+          subclass.instance_variable_defined?(:@vcr_configured),
+          "Subclass should NOT have its own @vcr_configured ivar",
+        )
+      end
+    end
+
+    # Integration tests for in_sandbox — uses a real workflow directory
+    class TestCaseInSandboxTest < TestCase
+      self.workflow_dir = File.join(Dir.pwd, "test/fixtures/testing")
+      self.sandbox_root = File.join(Dir.tmpdir, "roast_test_sandboxes_#{Process.pid}")
+
+      teardown do
+        FileUtils.rm_rf(self.class.sandbox_root) if Dir.exist?(self.class.sandbox_root)
+      end
+
+      test "in_sandbox returns stdout and stderr as strings" do
+        out, err = in_sandbox(:basic_test) do
+          $stdout.print("hello stdout")
+          $stderr.print("hello stderr")
+        end
+
+        assert_instance_of(String, out)
+        assert_instance_of(String, err)
+        assert_includes(out, "hello stdout")
+        assert_includes(err, "hello stderr")
+      end
+
+      test "in_sandbox sanitizes temp directory paths in output" do
+        # We need to print the actual sandbox tmpdir path to test sanitization.
+        # The sandbox_root is known, so we find the sandbox subdir via it.
+        sandbox_root = self.class.sandbox_root
+        sandbox_subdir = nil
+
+        out, _err = in_sandbox(:path_sanitization) do
+          # Find the sandbox dir that was just created under sandbox_root
+          dirs = Dir.glob("#{sandbox_root}/path_sanitization*")
+          sandbox_subdir = dirs.first
+          $stdout.print(sandbox_subdir) if sandbox_subdir
+        end
+
+        # The real temp path should be replaced with /fake-testing-dir
+        assert_includes(out, "/fake-testing-dir")
+        refute_includes(out, sandbox_root) if sandbox_subdir
+      end
+
+      test "in_sandbox copies workflow_dir into sandbox as subdirectory" do
+        sandbox_root = self.class.sandbox_root
+
+        in_sandbox(:copy_test) do
+          # Find the sandbox dir under sandbox_root
+          dirs = Dir.glob("#{sandbox_root}/copy_test*")
+          sandbox_dir = dirs.first
+          assert(sandbox_dir, "Expected sandbox directory to exist under #{sandbox_root}")
+
+          # workflow_dir is test/fixtures/testing, so cp_r creates testing/ inside sandbox
+          copied = File.join(sandbox_dir, "testing", "hello_workflow.rb")
+          assert(File.exist?(copied), "Expected hello_workflow.rb at #{copied}")
+        end
+      end
+
+      test "in_sandbox sets fake API credentials during playback" do
+        in_sandbox(:env_test) do
+          assert_equal("my-token", ENV["OPENAI_API_KEY"])
+          assert_equal("http://mytestingproxy.local/v1", ENV["OPENAI_API_BASE"])
+        end
+      end
+
+      test "in_sandbox cleans up sandbox directory after test" do
+        sandbox_root = self.class.sandbox_root
+        sandbox_subdir = nil
+
+        in_sandbox(:cleanup_test) do
+          dirs = Dir.glob("#{sandbox_root}/cleanup_test*")
+          sandbox_subdir = dirs.first
+          assert(sandbox_subdir && Dir.exist?(sandbox_subdir), "Sandbox should exist during block")
+        end
+
+        # After in_sandbox returns, the temp dir should be cleaned up
+        assert(sandbox_subdir, "Should have captured sandbox path")
+        refute(Dir.exist?(sandbox_subdir), "Sandbox directory should be cleaned up after in_sandbox")
+      end
+    end
+
+    # Integration tests for use_command_runner_fixtures
+    class TestCaseCommandRunnerTest < TestCase
+      self.workflow_dir = File.join(Dir.pwd, "test/fixtures/testing")
+      self.fixture_dir = File.join(Dir.pwd, "test/fixtures/testing")
+
+      test "use_command_runner_fixtures replays single fixture" do
+        use_command_runner_fixtures({ fixture: "cmd_fixture_test" })
+
+        stdout_lines = []
+        stderr_lines = []
+        stdout, _stderr, status = Roast::CommandRunner.execute(
+          ["echo", "test"],
+          stdout_handler: ->(line) { stdout_lines << line },
+          stderr_handler: ->(line) { stderr_lines << line },
+        )
+
+        assert_predicate(status, :success?)
+        assert_includes(stdout, "fixture stdout line 1")
+        assert_equal(["fixture stderr line 1\n"], stderr_lines)
+      end
+
+      test "use_command_runner_fixtures replays sequential fixtures" do
+        use_command_runner_fixtures(
+          { fixture: "cmd_fixture_test" },
+          { fixture: "cmd_fixture_second" },
+        )
+
+        # First call
+        stdout1, _stderr1, _status1 = Roast::CommandRunner.execute(
+          ["first"],
+          stdout_handler: ->(_line) {},
+          stderr_handler: ->(_line) {},
+        )
+        assert_includes(stdout1, "fixture stdout line 1")
+
+        # Second call
+        stdout2, _stderr2, _status2 = Roast::CommandRunner.execute(
+          ["second"],
+          stdout_handler: ->(_line) {},
+          stderr_handler: ->(_line) {},
+        )
+        assert_includes(stdout2, "second fixture stdout")
+      end
+
+      test "use_command_runner_fixtures raises on excess calls" do
+        use_command_runner_fixtures({ fixture: "cmd_fixture_test" })
+
+        # First call succeeds
+        Roast::CommandRunner.execute(
+          ["ok"],
+          stdout_handler: ->(_line) {},
+          stderr_handler: ->(_line) {},
+        )
+
+        # Second call should raise
+        error = assert_raises(RuntimeError) do
+          Roast::CommandRunner.execute(
+            ["too_many"],
+            stdout_handler: ->(_line) {},
+            stderr_handler: ->(_line) {},
+          )
+        end
+        assert_match(/called 2 times.*only 1 fixture/, error.message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extracts the internal VCR testing infrastructure into a public `Roast::Testing::TestCase` base class, so any Roast user can write reliable, isolated tests for their workflows. Previously this testing infrastructure was private to the Roast repo's own example tests.

Closes https://github.com/Shopify/roast/issues/835

## Approach

- **New public API**: `lib/roast/testing/test_case.rb` — a base test class inheriting from `ActiveSupport::TestCase` with configurable `workflow_dir`, `cassette_library_dir`, `sandbox_root`, `fixture_dir`, and API credential settings
- **Sandbox isolation**: `in_sandbox` creates a temp directory, copies workflow files as a subdirectory (preserving basename), sets up fake/real API credentials, and optionally wraps in a VCR cassette
- **VCR optional**: Uses `defined?(VCR)` guards — works without VCR installed, auto-configures VCR if present. VCR configuration is guarded with a Mutex on the base `TestCase` class (not subclasses) to prevent duplicate `filter_sensitive_data` entries
- **Agent testing**: `use_command_runner_fixtures` (plural) replays command runner output from fixture files, supporting multiple sequential invocations. Assertions are validated in teardown (not inside Mocha's `with` block) to avoid assertion swallowing
- **Mocha guard**: Raises a helpful error if `mocha` is not loaded
- **RECORD_VCR**: Tightened to `== "true"` (won't trigger on `"false"` or other truthy strings)
- **Zeitwerk ignore**: `lib/roast/testing/` is excluded from autoloading — explicit `require "roast/testing/test_case"` is the intentional API
- **Backward compatible**: Internal `Examples::FunctionalTest` is now a thin wrapper around `Roast::Testing::TestCase`
- **Documentation**: `docs/TESTING.md` with comprehensive guide including sandbox nesting behavior, VCR recording, agent testing, configuration reference
- **Unit + integration tests**: `test/roast/testing/test_case_test.rb` covers configuration defaults, path resolution, env var management, sandbox lifecycle, `in_sandbox` (happy path, path sanitization, directory copying, env setup, cleanup), and `use_command_runner_fixtures` (single fixture, sequential fixtures, over-call error)

Co-authored-by: Claude <noreply@anthropic.com>
Orchestrated-by: ae <noreply@shopify.com>
