### PR TITLE
fix(map): stop queued parallel iterations after failure

### DIFF
--- a/lib/roast/execution_manager.rb
+++ b/lib/roast/execution_manager.rb
@@ -92,6 +92,7 @@ module Roast
       Sync do |sync_task|
         sync_task.annotate("ExecutionManager #{@scope}")
         TaskContext.begin_execution_manager(self)
+        execution_exception = false
         @cog_stack.each do |cog|
           cog_config = @config_manager.config_for(cog.class, cog.name)
           cog_task = cog.run!(
@@ -107,9 +108,12 @@ module Roast
         # noinspection RubyArgCount
         @barrier.wait { |task| wait_for_task_with_exception_handling(task) }
         compute_final_output # eagerly compute the final output (so it, too, can 'break!' subsequent executions in a loop)
+      rescue ControlFlow::FailCog
+        execution_exception = true
+        raise
       ensure
         @barrier.stop
-        compute_final_output
+        compute_final_output unless execution_exception
         TaskContext.end
         @running = false
       end

--- a/lib/roast/system_cogs/map.rb
+++ b/lib/roast/system_cogs/map.rb
@@ -307,17 +307,26 @@ module Roast
           barrier = Async::Barrier.new
           semaphore = Async::Semaphore.new(max_parallel_tasks, parent: barrier) if max_parallel_tasks.present?
           ems = {}
-          input.items.map.with_index do |item, index|
-            (semaphore || barrier).async(finished: false) do |task|
-              task.annotate("Map Invocation #{index + input.initial_index}")
-              ems[index] = em = create_execution_manager_for_map_item(run, item, index + input.initial_index)
-              em.prepare!
-              em.run!
-            rescue ControlFlow::Next
-              # TODO: do something with the message passed to next!
-              # proceed to next iteration
-            end
-          end #: Array[Async::Task]
+          barrier.async(finished: false) do |producer_task|
+            input.items.map.with_index do |item, index|
+              (semaphore || barrier).async(finished: false) do |task|
+                task.annotate("Map Invocation #{index + input.initial_index}")
+                ems[index] = em = create_execution_manager_for_map_item(run, item, index + input.initial_index)
+                em.prepare!
+                em.run!
+              rescue ControlFlow::Next
+                # TODO: do something with the message passed to next!
+                # proceed to next iteration
+              rescue ControlFlow::Break
+                # TODO: do something with the message passed to break!
+                producer_task.stop
+                raise
+              rescue StandardError => e
+                producer_task.stop
+                raise e
+              end
+            end #: Array[Async::Task]
+          end
 
           # Wait on the tasks in their completion order, so that an exception in a task will be raised as soon as it occurs
           # noinspection RubyArgCount

--- a/test/roast/system_cogs/map_test.rb
+++ b/test/roast/system_cogs/map_test.rb
@@ -395,6 +395,50 @@ module Roast
         assert_equal "B", results[1].value
         assert_equal "C", results[2].value
       end
+
+      test "parallel map aborts pending iterations when an iteration fails and abort_on_failure is enabled" do
+        started_items = []
+
+        config_proc = proc do
+          global { abort_on_failure! }
+          map(:my_map) { parallel 2 }
+        end
+        config_manager = ConfigManager.new(@registry, [config_proc])
+        config_manager.prepare!
+
+        exec_procs = {
+          nil => [proc {
+            map(:my_map, run: :parallel_failure) { ["slow", "fail", "later_1", "later_2"] }
+            outputs { collect(map(:my_map)) }
+          }],
+          parallel_failure: [proc {
+            test_cog(:step) do |_input, scope, _index|
+              started_items << scope
+
+              case scope
+              when "slow"
+                sleep 0.2
+                scope.upcase
+              when "fail"
+                raise ControlFlow::FailCog, "boom"
+              else
+                scope.upcase
+              end
+            end
+          }],
+        }
+        manager = ExecutionManager.new(
+          @registry, config_manager, exec_procs, @workflow_context
+        )
+        manager.prepare!
+
+        error = assert_raises(ControlFlow::FailCog) do
+          manager.run!
+        end
+
+        assert_equal "boom", error.message
+        assert_equal ["fail", "slow"], started_items.sort
+      end
     end
   end
 end


### PR DESCRIPTION
## What

When `map` runs in parallel with `abort_on_failure` enabled, a failing iteration can still allow later iterations to start. The failing task aborts, but the producer keeps feeding more work through the semaphore before the failure is observed.

## Fix

Wrap parallel map scheduling in a producer task and stop that producer as soon as an iteration raises `Break` or any other aborting error. This keeps `Async::Semaphore` for bounded concurrency while preventing queued iterations from being scheduled after a failure.

Also avoid recomputing final output during `ExecutionManager` unwind when a `FailCog` is already propagating, so the original failure is preserved instead of being masked by a follow-on output error.

## Test

Add a regression test covering a parallel map with global `abort_on_failure!`, asserting that:
- the original `FailCog` is raised
- later queued iterations never start after the failure
