### PR TITLE
Support tilde (~) expansion in template paths

### DIFF
--- a/lib/roast/cog_input_manager.rb
+++ b/lib/roast/cog_input_manager.rb
@@ -177,11 +177,10 @@ module Roast
     # 5-7. Workflow directory prompts/: prompts/path, prompts/path.erb, prompts/path.md.erb
     # 8-10. Current directory: path, path.erb, path.md.erb
     # 11-13. Current directory prompts/: prompts/path, prompts/path.erb, prompts/path.md.erb
+    # 14-16. Tilde-expanded path: path, path.erb, path.md.erb
     #
     #: (String | Pathname, ?Hash) -> String
     def template(path, args = {})
-      # NOTE: Pathname does not expand ~ for home directory automatically.
-      # This is tracked in issue https://github.com/Shopify/roast/issues/663.
       path = Pathname.new(path) unless path.is_a?(Pathname)
 
       # Priority stack of places to look for a matching file
@@ -212,6 +211,15 @@ module Roast
       candidate_paths << pwd / "prompts" / "#{path}.erb"
       candidate_paths << pwd / "prompts" / "#{path}.md.erb"
 
+      # 14-16. Tilde expanded path
+      begin
+        expanded_path = Pathname.new(File.expand_path(path))
+        candidate_paths << expanded_path
+        candidate_paths << Pathname.new(File.expand_path("#{expanded_path}.erb"))
+        candidate_paths << Pathname.new(File.expand_path("#{expanded_path}.md.erb"))
+      rescue ArgumentError
+        # skip
+      end
       # Use the first path that exists
       resolved_path = candidate_paths.find(&:exist?)
 

--- a/lib/roast/cog_input_manager.rb
+++ b/lib/roast/cog_input_manager.rb
@@ -218,7 +218,8 @@ module Roast
         candidate_paths << Pathname.new(File.expand_path("#{expanded_path}.erb"))
         candidate_paths << Pathname.new(File.expand_path("#{expanded_path}.md.erb"))
       rescue ArgumentError
-        # skip
+        # File.expand_path raises when expanding ~something/foo (assuming "something" is not a real user).
+        # Nothing to do here, falls back to other candidate paths without tilde expansion.
       end
       # Use the first path that exists
       resolved_path = candidate_paths.find(&:exist?)

--- a/test/roast/cog_input_manager_test.rb
+++ b/test/roast/cog_input_manager_test.rb
@@ -67,6 +67,41 @@ module Roast
       assert_includes result, "This is a test template."
     end
 
+    test "template method expands user home directories" do
+      Tempfile.create(["temp_file", ".md.erb"], File.expand_path("tmp")) do |file|
+        File.write(file, <<~ERB)
+          Hello <%= name %>!
+          This is a test template.
+        ERB
+
+        manager = create_manager
+
+        tilde_path = "~/#{Pathname.new(File.expand_path(file)).relative_path_from(Dir.home)}"
+        result = manager.context.template(tilde_path, { name: "Full Path" })
+        assert_includes result, "Hello Full Path!"
+        assert_includes result, "This is a test template."
+      end
+    end
+
+    test "template method resolves file with literal tilde" do
+      Dir.mktmpdir do |temp_dir|
+        Dir.chdir(temp_dir) do
+          tilde_path = "~something/template.md.erb"
+          FileUtils.mkdir_p("~something")
+          File.write(tilde_path, <<~ERB)
+            Hello <%= name%>!
+            This is a test template.
+          ERB
+
+          manager = create_manager
+
+          result = manager.context.template(tilde_path, { name: "Full Path" })
+          assert_includes result, "Hello Full Path!"
+          assert_includes result, "This is a test template."
+        end
+      end
+    end
+
     private
 
     # Factory method to create a CogInputManager with realistic instances

--- a/test/roast/cog_input_manager_test.rb
+++ b/test/roast/cog_input_manager_test.rb
@@ -68,7 +68,7 @@ module Roast
     end
 
     test "template method expands user home directories" do
-      Tempfile.create(["temp_file", ".md.erb"], File.expand_path("tmp")) do |file|
+      Tempfile.create(["test_template_in_user_home", ".md.erb"], File.expand_path("tmp")) do |file|
         File.write(file, <<~ERB)
           Hello <%= name %>!
           This is a test template.
@@ -77,16 +77,16 @@ module Roast
         manager = create_manager
 
         tilde_path = "~/#{Pathname.new(File.expand_path(file)).relative_path_from(Dir.home)}"
-        result = manager.context.template(tilde_path, { name: "Full Path" })
-        assert_includes result, "Hello Full Path!"
+        result = manager.context.template(tilde_path, { name: "Relative Path From User Home" })
+        assert_includes result, "Hello Relative Path From User Home!"
         assert_includes result, "This is a test template."
       end
     end
 
-    test "template method resolves file with literal tilde" do
+    test "template method handles ~user reference to non-existent user gracefully" do
       Dir.mktmpdir do |temp_dir|
         Dir.chdir(temp_dir) do
-          tilde_path = "~something/template.md.erb"
+          tilde_path = "~something/test_template.md.erb"
           FileUtils.mkdir_p("~something")
           File.write(tilde_path, <<~ERB)
             Hello <%= name%>!
@@ -95,8 +95,46 @@ module Roast
 
           manager = create_manager
 
-          result = manager.context.template(tilde_path, { name: "Full Path" })
-          assert_includes result, "Hello Full Path!"
+          result = manager.context.template(tilde_path, { name: "Path With Non-Existent ~User Reference" })
+          assert_includes result, "Hello Path With Non-Existent ~User Reference!"
+          assert_includes result, "This is a test template."
+        end
+      end
+    end
+
+    test "template method resolves path where leading tilde refers to a literal subdirectory" do
+      Dir.mktmpdir do |temp_dir|
+        Dir.chdir(temp_dir) do
+          tilde_path = "~/test_template.md.erb"
+          FileUtils.mkdir_p("~")
+          File.write(tilde_path, <<~ERB)
+            Hello <%= name%>!
+            This is a test template.
+          ERB
+
+          manager = create_manager
+
+          result = manager.context.template(tilde_path, { name: "Path With Leading Literal Tilde" })
+          assert_includes result, "Hello Path With Leading Literal Tilde!"
+          assert_includes result, "This is a test template."
+        end
+      end
+    end
+
+    test "template method resolves path with literal tilde in the middle of the path" do
+      Dir.mktmpdir do |temp_dir|
+        Dir.chdir(temp_dir) do
+          tilde_path = "something/~/test_template.md.erb"
+          FileUtils.mkdir_p("something/~")
+          File.write(tilde_path, <<~ERB)
+            Hello <%= name%>!
+            This is a test template.
+          ERB
+
+          manager = create_manager
+
+          result = manager.context.template(tilde_path, { name: "Path With Literal Tilde In The Middle" })
+          assert_includes result, "Hello Path With Literal Tilde In The Middle!"
           assert_includes result, "This is a test template."
         end
       end


### PR DESCRIPTION
Fixes https://github.com/Shopify/roast/issues/663

Paths with a tilde currently do not get expanded in the CogInputManager#template. This PR fixes that.

Adds File.expand_path candidates to the template path resolver so that ~/foo and ~user/foo resolve correctly.

Rescue block makes sure we don't crash when expanding ~something/foo (assuming "something" is not a real user) and fall back to the other candidates instead.

Added test coverage