### PR TITLE
Add 'templates' as template search path

### DIFF
--- a/examples/simple_chat.rb
+++ b/examples/simple_chat.rb
@@ -21,6 +21,6 @@ execute do
   # Ask a question with a template prompt. You can pass variables to it as you would an ERB template
   chat { template("examples/prompts/simple_prompt.md.erb", { lake_answer: chat!(:lake).response }) }
 
-  # Shorthand template syntax - searches prompts/ directory automatically
+  # Shorthand template syntax - searches prompts/ and templates/ directories automatically
   chat { template("simple_prompt", { lake_answer: chat!(:lake).response }) }
 end

--- a/lib/roast/cog_input_manager.rb
+++ b/lib/roast/cog_input_manager.rb
@@ -159,7 +159,7 @@ module Roast
     # Supports both relative shorthand paths like "greeting" and full absolute paths.
     #
     # @param path [String, Pathname] The template path to resolve. Can be:
-    #   - Shorthand name: "greeting" -> searches for prompts/greeting.md.erb
+    #   - Shorthand name: "greeting" -> searches for prompts/greeting.md.erb or templates/greeting.md.erb
     #   - With extension: "template.erb" -> searches for template.erb
     #   - Absolute path: "/full/path/to/template.erb" -> uses as-is
     # @param args [Hash] Template variables for ERB interpolation
@@ -175,9 +175,11 @@ module Roast
     # 1. Absolute path as-is (if absolute)
     # 2-4. Workflow directory: path, path.erb, path.md.erb
     # 5-7. Workflow directory prompts/: prompts/path, prompts/path.erb, prompts/path.md.erb
-    # 8-10. Current directory: path, path.erb, path.md.erb
-    # 11-13. Current directory prompts/: prompts/path, prompts/path.erb, prompts/path.md.erb
-    # 14-16. Tilde-expanded path: path, path.erb, path.md.erb
+    # 8-10. Workflow directory templates/: templates/path, templates/path.erb, templates/path.md.erb
+    # 11-13. Current directory: path, path.erb, path.md.erb
+    # 14-16. Current directory prompts/: prompts/path, prompts/path.erb, prompts/path.md.erb
+    # 17-19. Current directory templates/: templates/path, templates/path.erb, templates/path.md.erb
+    # 20-22. Tilde-expanded path: path, path.erb, path.md.erb
     #
     #: (String | Pathname, ?Hash) -> String
     def template(path, args = {})
@@ -200,18 +202,28 @@ module Roast
       candidate_paths << workflow_dir / "prompts" / "#{path}.erb"
       candidate_paths << workflow_dir / "prompts" / "#{path}.md.erb"
 
-      # 8-10. Relative to current working directory
+      # 8-10. Relative to workflow directory templates folder
+      candidate_paths << workflow_dir / "templates" / path
+      candidate_paths << workflow_dir / "templates" / "#{path}.erb"
+      candidate_paths << workflow_dir / "templates" / "#{path}.md.erb"
+
+      # 11-13. Relative to current working directory
       pwd = Pathname.pwd
       candidate_paths << pwd / path
       candidate_paths << pwd / "#{path}.erb"
       candidate_paths << pwd / "#{path}.md.erb"
 
-      # 11-13. Relative to current working directory prompts folder
+      # 14-16. Relative to current working directory prompts folder
       candidate_paths << pwd / "prompts" / path
       candidate_paths << pwd / "prompts" / "#{path}.erb"
       candidate_paths << pwd / "prompts" / "#{path}.md.erb"
 
-      # 14-16. Tilde expanded path
+      # 17-19. Relative to current working directory templates folder
+      candidate_paths << pwd / "templates" / path
+      candidate_paths << pwd / "templates" / "#{path}.erb"
+      candidate_paths << pwd / "templates" / "#{path}.md.erb"
+
+      # 20-22. Tilde expanded path
       begin
         expanded_path = Pathname.new(File.expand_path(path))
         candidate_paths << expanded_path

--- a/test/roast/cog_input_manager_test.rb
+++ b/test/roast/cog_input_manager_test.rb
@@ -12,14 +12,14 @@ module Roast
       @templates_dir = File.join(@workflow_dir, "templates")
       FileUtils.mkdir_p(@templates_dir)
 
-      @template_path = File.join(@prompts_dir, "test_template.md.erb")
-      File.write(@template_path, <<~ERB)
+      @template_in_prompts_dir = File.join(@prompts_dir, "test_template.md.erb")
+      File.write(@template_in_prompts_dir, <<~ERB)
         Hello <%= name %>!
         This is a test template.
       ERB
 
-      @another_template_path = File.join(@templates_dir, "another_template.md.erb")
-      File.write(@another_template_path, <<~ERB)
+      @template_in_templates_dir = File.join(@templates_dir, "another_template.md.erb")
+      File.write(@template_in_templates_dir, <<~ERB)
         Hello <%= name %>!
         This is a test template.
       ERB
@@ -92,7 +92,7 @@ module Roast
     test "template method works with absolute path" do
       manager = create_manager
 
-      absolute_path = Pathname.new(@template_path).realpath
+      absolute_path = Pathname.new(@template_in_prompts_dir).realpath
       result = manager.context.template(absolute_path, { name: "Full Path" })
       assert_includes result, "Hello Full Path!"
       assert_includes result, "This is a test template."

--- a/test/roast/cog_input_manager_test.rb
+++ b/test/roast/cog_input_manager_test.rb
@@ -9,9 +9,17 @@ module Roast
       @workflow_dir = File.join(@temp_dir, "workflow")
       @prompts_dir = File.join(@workflow_dir, "prompts")
       FileUtils.mkdir_p(@prompts_dir)
+      @templates_dir = File.join(@workflow_dir, "templates")
+      FileUtils.mkdir_p(@templates_dir)
 
       @template_path = File.join(@prompts_dir, "test_template.md.erb")
       File.write(@template_path, <<~ERB)
+        Hello <%= name %>!
+        This is a test template.
+      ERB
+
+      @another_template_path = File.join(@templates_dir, "another_template.md.erb")
+      File.write(@another_template_path, <<~ERB)
         Hello <%= name %>!
         This is a test template.
       ERB
@@ -24,7 +32,7 @@ module Roast
       FileUtils.rm_rf(@temp_dir) if @temp_dir && File.exist?(@temp_dir)
     end
 
-    test "template method resolves shorthand paths relative to workflow directory" do
+    test "template method resolves shorthand paths in 'prompts' directory relative to workflow directory" do
       manager = create_manager(workflow_dir: Pathname.new(@workflow_dir))
 
       Dir.chdir(@temp_dir) do
@@ -34,7 +42,17 @@ module Roast
       end
     end
 
-    test "template method falls back to current working directory" do
+    test "template method resolves shorthand paths in 'templates' directory relative to workflow directory" do
+      manager = create_manager(workflow_dir: Pathname.new(@workflow_dir))
+
+      Dir.chdir(@temp_dir) do
+        result = manager.context.template("another_template", { name: "Templates Dir" })
+        assert_includes result, "Hello Templates Dir!"
+        assert_includes result, "This is a test template."
+      end
+    end
+
+    test "template method falls back to 'prompts' directory in current working directory" do
       other_workflow_dir = File.join(@temp_dir, "other_workflow")
       FileUtils.mkdir_p(other_workflow_dir)
 
@@ -43,6 +61,19 @@ module Roast
       Dir.chdir(@workflow_dir) do
         result = manager.context.template("test_template", { name: "Fallback" })
         assert_includes result, "Hello Fallback!"
+        assert_includes result, "This is a test template."
+      end
+    end
+
+    test "template method falls back to 'templates' directory in current working directory" do
+      other_workflow_dir = File.join(@temp_dir, "other_workflow")
+      FileUtils.mkdir_p(other_workflow_dir)
+
+      manager = create_manager(workflow_dir: Pathname.new(other_workflow_dir))
+
+      Dir.chdir(@workflow_dir) do
+        result = manager.context.template("another_template", { name: "Templates Dir" })
+        assert_includes result, "Hello Templates Dir!"
         assert_includes result, "This is a test template."
       end
     end


### PR DESCRIPTION
Closes https://github.com/Shopify/roast/issues/870

tldr; Adds 'templates' directory as an additional search path for the template method.

## Changes made

Added the 'templates' directory with all 3 file extensions as search paths for the template method. Searches the Workflow directory but falls back to the working directory if no match is found, following the pattern for the 'prompts' directory.

Changed the wording on some of the comments to reflect the change.

## Tests

Added the creation of a 'templates' directory to the setup of the test, as well as two tests: one for the search on the workflow directory and one for the fallback to the current working directory.

Previously the test names did not specify which search path they were testing, since there was only one ('prompts'). I changed the title of the tests to reflect the addition of a second search path.