### PR TITLE
Clarify providers and env variables in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bin/roast execute analyze_codebase.rb
 
 ## Core Cogs
 
-- **`chat`** - Send prompts to cloud-based LLMs (OpenAI, Anthropic, Gemini, etc.)
+- **`chat`** - Send prompts to cloud-based LLMs (OpenAI & Anthropic)
 - **`agent`** - Run local coding agents with filesystem access (Claude Code CLI, etc.)
 - **`ruby`** - Execute custom Ruby code within workflows
 - **`cmd`** - Run shell commands and capture output
@@ -71,6 +71,17 @@ gem 'roast-ai'
 - Ruby 3.0+
 - API keys for your AI provider (OpenAI/Anthropic)
 - Claude Code CLI installed (for agent cog)
+
+## Configuration
+
+Roast currently supports two LLM providers for the `chat` cog: **OpenAI** and **Anthropic**.
+
+- Set `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY` in your environment.
+- Optionally set `OPENAI_API_BASE` or `ANTHROPIC_API_BASE` to override the default endpoint.
+
+The default model is set per-provider and can only be overridden inside a `config` block. See the [tutorial](https://github.com/Shopify/roast/blob/main/tutorial/01_your_first_workflow/README.md#adding-configuration) for examples.
+
+The `agent` cog is powered by the Claude Code CLI, which handles its own authentication.
 
 ## Getting Started
 

--- a/tutorial/01_your_first_workflow/README.md
+++ b/tutorial/01_your_first_workflow/README.md
@@ -125,14 +125,16 @@ end
 Common options you can set:
 
 - `model "name"` - Which LLM model to use
-    - OpenAI: "gpt-4o", "gpt-4o-mini", "gpt-4-turbo"
-    - Anthropic: "claude-3-5-sonnet-20241022", "claude-3-5-haiku-20241022"
+    - OpenAI: "gpt-4o-mini" (default), "gpt-4o", "gpt-4-turbo", etc.
+    - Anthropic: "claude-haiku-4-5" (default), "claude-sonnet-4-6", "claude-opus-4-7", etc.
 - `provider :name` - Which LLM provider
     - `:openai` or `:anthropic`
 - `show_prompt!` - Display the prompt being sent
 - `show_response!` - Display the response (on by default)
 - `show_stats!` - Display token usage statistics (on by default)
 - `no_display!` - Turn off all output (useful when you just want to pass the output to a subsequent cog)
+
+**Note:** Unlike the api key and api base url, the model is **not** environment-controlled. You must set it inside a `config` block (shown above). The same applies to `provider` and other DSL options.
 
 ## Running the Workflows
 

--- a/tutorial/04_configuration_options/README.md
+++ b/tutorial/04_configuration_options/README.md
@@ -45,7 +45,7 @@ config do
   end
 
   agent do
-    model "claude-3-5-haiku-20241022"
+    model "claude-haiku-4-5"
     provider :claude
   end
 end

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -14,7 +14,7 @@ run coding agents, process data, and so much more.
 
 - Ruby installed (3.4.2+)
 - Roast gem installed
-- API keys for your AI providers of choice (to use LLM chat)
+- API keys for your AI provider (see [Configuration](https://github.com/Shopify/roast/blob/main/README.md#configuration) for setup)
 - Claude Code CLI installed and configured (to use coding agents)
 
 ## How to Use This Tutorial


### PR DESCRIPTION
part of https://github.com/Shopify/roast/issues/882

## tldr;

Updated docs to add more clarification about providers and environment variables and fix minor inaccuracies.

## Main changes

Added "Configuration" section to main README.

Added clarification on tutorial 1's README and fixed some inaccuracies in the main README.

## Issues found

We still use some models that are now deprecated (such as `claude-3-5-haiku-20241022`).

It would be useful to have a way to periodically clean and replace deprecated models with new working models. This has been added as [an issue](https://github.com/Shopify/roast/issues/875)