### PR TITLE
Add perplexity as a supported provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bin/roast execute analyze_codebase.rb
 
 ## Core Cogs
 
-- **`chat`** - Send prompts to cloud-based LLMs (OpenAI & Anthropic)
+- **`chat`** - Send prompts to cloud-based LLMs (OpenAI, Anthropic & Perplexity)
 - **`agent`** - Run local coding agents with filesystem access (Claude Code CLI, etc.)
 - **`ruby`** - Execute custom Ruby code within workflows
 - **`cmd`** - Run shell commands and capture output
@@ -69,15 +69,15 @@ gem 'roast-ai'
 ## Requirements
 
 - Ruby 3.0+
-- API keys for your AI provider (OpenAI/Anthropic)
+- API keys for your AI provider (OpenAI, Anthropic & Perplexity)
 - Claude Code CLI installed (for agent cog)
 
 ## Configuration
 
-Roast currently supports two LLM providers for the `chat` cog: **OpenAI** and **Anthropic**.
+Roast currently supports three LLM providers for the `chat` cog: **OpenAI**, **Anthropic** and **Perplexity**.
 
-- Set `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY` in your environment.
-- Optionally set `OPENAI_API_BASE` or `ANTHROPIC_API_BASE` to override the default endpoint.
+- Set `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY` and/or `PERPLEXITY_API_KEY` in your environment.
+- Optionally set `OPENAI_API_BASE` or `ANTHROPIC_API_BASE` to override the default endpoint. Perplexity does not support base URL override.
 
 The default model is set per-provider and can only be overridden inside a `config` block. See the [tutorial](https://github.com/Shopify/roast/blob/main/tutorial/01_your_first_workflow/README.md#adding-configuration) for examples.
 

--- a/lib/roast/cogs/chat.rb
+++ b/lib/roast/cogs/chat.rb
@@ -77,6 +77,8 @@ module Roast
           when :anthropic
             context.anthropic_api_key = config.valid_api_key!
             context.anthropic_api_base = config.valid_base_url
+          when :perplexity
+            context.perplexity_api_key = config.valid_api_key!
           end
         end
       end

--- a/lib/roast/cogs/chat/config.rb
+++ b/lib/roast/cogs/chat/config.rb
@@ -18,6 +18,10 @@ module Roast
             default_base_url: "https://api.anthropic.com",
             default_model: "claude-haiku-4-5",
           },
+          perplexity: {
+            api_key_env_var: "PERPLEXITY_API_KEY",
+            default_model: "sonar",
+          },
         }.freeze #: Hash[Symbol, Hash[Symbol, String]]
 
         # Configure the cog to use a specified API provider when invoking the llm
@@ -82,6 +86,7 @@ module Roast
         # #### Environment Variables
         # - OpenAI Provider: OPENAI_API_KEY
         # - Anthropic Provider: ANTHROPIC_API_KEY
+        # - Perplexity Provider: PERPLEXITY_API_KEY
         #
         # #### See Also
         # - `api_key`
@@ -99,6 +104,7 @@ module Roast
         # #### Environment Variables
         # - OpenAI Provider: OPENAI_API_KEY
         # - Anthropic Provider: ANTHROPIC_API_KEY
+        # - Perplexity Provider: PERPLEXITY_API_KEY
         #
         # #### See Also
         # - `api_key`

--- a/test/roast/cogs/chat/config_test.rb
+++ b/test/roast/cogs/chat/config_test.rb
@@ -33,6 +33,11 @@ module Roast
           assert_equal :anthropic, @config.valid_provider!
         end
 
+        test "valid_provider! accepts and sets :perplexity" do
+          @config.provider(:perplexity)
+          assert_equal :perplexity, @config.valid_provider!
+        end
+
         test "valid_provider! raises on invalid provider" do
           @config.provider(:invalid_provider)
 
@@ -82,6 +87,13 @@ module Roast
           @config.provider(:openai)
           with_env("OPENAI_API_KEY", "openai-env-key") do
             assert_equal "openai-env-key", @config.valid_api_key!
+          end
+        end
+
+        test "valid_api_key! reads from perplexity environment variable when provider is perplexity" do
+          @config.provider(:perplexity)
+          with_env("PERPLEXITY_API_KEY", "perplexity-env-key") do
+            assert_equal "perplexity-env-key", @config.valid_api_key!
           end
         end
 
@@ -149,6 +161,11 @@ module Roast
         test "valid_model returns openai default model when provider is openai" do
           @config.provider(:openai)
           assert_equal "gpt-4o-mini", @config.valid_model
+        end
+
+        test "valid_model returns perplexity default model when provider is perplexity" do
+          @config.provider(:perplexity)
+          assert_equal "sonar", @config.valid_model
         end
 
         # Temperature configuration tests

--- a/tutorial/01_your_first_workflow/README.md
+++ b/tutorial/01_your_first_workflow/README.md
@@ -106,7 +106,7 @@ block:
 config do
   chat do
     model "gpt-4o-mini" # Use OpenAI's fast model
-    provider :openai # Use OpenAI (can also be :anthropic)
+    provider :openai # Use OpenAI (can also be :anthropic or :perplexity)
     show_prompt! # Display the prompt before sending
   end
 end
@@ -127,8 +127,9 @@ Common options you can set:
 - `model "name"` - Which LLM model to use
     - OpenAI: "gpt-4o-mini" (default), "gpt-4o", "gpt-4-turbo", etc.
     - Anthropic: "claude-haiku-4-5" (default), "claude-sonnet-4-6", "claude-opus-4-7", etc.
+    - Perplexity: "sonar" (default), "sonar-pro", "sonar-deep-research", etc.
 - `provider :name` - Which LLM provider
-    - `:openai` or `:anthropic`
+    - `:openai`, `:anthropic` or `:perplexity`
 - `show_prompt!` - Display the prompt being sent
 - `show_response!` - Display the response (on by default)
 - `show_stats!` - Display token usage statistics (on by default)

--- a/tutorial/01_your_first_workflow/configured_chat.rb
+++ b/tutorial/01_your_first_workflow/configured_chat.rb
@@ -10,7 +10,7 @@ config do
   # Configure all chat cogs in this workflow
   chat do
     model "gpt-4o-mini"      # Use OpenAI's fast, cost-effective model
-    provider :openai         # Use OpenAI (alternative: :anthropic)
+    provider :openai         # Use OpenAI (alternative: :anthropic or :perplexity)
     show_prompt!             # Display the prompt before sending it
     show_response!           # Display the response (this is the default)
     show_stats!              # Display token usage statistics (default)


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/885

## Tophatting 🎩

#### To tophat the Perplexity provider:

Pull the branch

```bash
git fetch && git checkout 05-14/add-perplexity-as-a-supported-provider 
bundle install
```

Export your perplexity key

```bash
export PERPLEXITY_API_KEY="..."
```

Save this workflow as tophat.rb

```ruby
# typed: true
# frozen_string_literal: true

#: self as Roast::Workflow

config do
  chat do
    provider :perplexity
    show_response!
    show_stats!
  end
end

execute do
  chat do
    "Reply with exactly three words: a greeting."
  end
end
```

Run it

```bash
bin/roast execute tophat.rb
```

**Expected:** a greeting from the model, followed by token stats showing the right model ID (`sonar`).

Reply in thread with ✅ if it works or paste the error if not.

Thanks!