### PR TITLE
Add gemini as a supported provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bin/roast execute analyze_codebase.rb
 
 ## Core Cogs
 
-- **`chat`** - Send prompts to cloud-based LLMs (OpenAI, Anthropic & Perplexity)
+- **`chat`** - Send prompts to cloud-based LLMs (OpenAI, Anthropic, Perplexity & Gemini)
 - **`agent`** - Run local coding agents with filesystem access (Claude Code CLI, etc.)
 - **`ruby`** - Execute custom Ruby code within workflows
 - **`cmd`** - Run shell commands and capture output
@@ -69,15 +69,15 @@ gem 'roast-ai'
 ## Requirements
 
 - Ruby 3.0+
-- API keys for your AI provider (OpenAI, Anthropic & Perplexity)
+- API keys for your AI provider (OpenAI, Anthropic, Perplexity & Gemini)
 - Claude Code CLI installed (for agent cog)
 
 ## Configuration
 
-Roast currently supports three LLM providers for the `chat` cog: **OpenAI**, **Anthropic** and **Perplexity**.
+Roast currently supports four LLM providers for the `chat` cog: **OpenAI**, **Anthropic**, **Perplexity** and **Gemini**.
 
-- Set `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY` and/or `PERPLEXITY_API_KEY` in your environment.
-- Optionally set `OPENAI_API_BASE` or `ANTHROPIC_API_BASE` to override the default endpoint. Perplexity does not support base URL override.
+- Set `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `PERPLEXITY_API_KEY` and/or `GEMINI_API_KEY` in your environment.
+- Optionally set `OPENAI_API_BASE`, `ANTHROPIC_API_BASE` and/or `GEMINI_API_BASE` to override the default endpoint. Perplexity does not support base URL override.
 
 The default model is set per-provider and can only be overridden inside a `config` block. See the [tutorial](https://github.com/Shopify/roast/blob/main/tutorial/01_your_first_workflow/README.md#adding-configuration) for examples.
 

--- a/lib/roast/cogs/chat.rb
+++ b/lib/roast/cogs/chat.rb
@@ -79,6 +79,9 @@ module Roast
             context.anthropic_api_base = config.valid_base_url
           when :perplexity
             context.perplexity_api_key = config.valid_api_key!
+          when :gemini
+            context.gemini_api_key = config.valid_api_key!
+            context.gemini_api_base = config.valid_base_url
           end
         end
       end

--- a/lib/roast/cogs/chat/config.rb
+++ b/lib/roast/cogs/chat/config.rb
@@ -22,6 +22,12 @@ module Roast
             api_key_env_var: "PERPLEXITY_API_KEY",
             default_model: "sonar",
           },
+          gemini: {
+            api_key_env_var: "GEMINI_API_KEY",
+            base_url_env_var: "GEMINI_API_BASE",
+            default_base_url: "https://generativelanguage.googleapis.com/v1beta",
+            default_model: "gemini-3.1-flash-lite",
+          },
         }.freeze #: Hash[Symbol, Hash[Symbol, String]]
 
         # Configure the cog to use a specified API provider when invoking the llm
@@ -87,6 +93,7 @@ module Roast
         # - OpenAI Provider: OPENAI_API_KEY
         # - Anthropic Provider: ANTHROPIC_API_KEY
         # - Perplexity Provider: PERPLEXITY_API_KEY
+        # - Gemini Provider: GEMINI_API_KEY
         #
         # #### See Also
         # - `api_key`
@@ -105,6 +112,7 @@ module Roast
         # - OpenAI Provider: OPENAI_API_KEY
         # - Anthropic Provider: ANTHROPIC_API_KEY
         # - Perplexity Provider: PERPLEXITY_API_KEY
+        # - Gemini Provider: GEMINI_API_KEY
         #
         # #### See Also
         # - `api_key`
@@ -141,6 +149,7 @@ module Roast
         # #### Environment Variables
         # - OpenAI Provider: OPENAI_API_BASE
         # - Anthropic Provider: ANTHROPIC_API_BASE
+        # - Gemini Provider: GEMINI_API_BASE
         #
         # #### See Also
         # - `base_url`
@@ -155,6 +164,7 @@ module Roast
         # #### Environment Variables
         # - OpenAI Provider: OPENAI_API_BASE
         # - Anthropic Provider: ANTHROPIC_API_BASE
+        # - Gemini Provider: GEMINI_API_BASE
         #
         # #### See Also
         # - `base_url`

--- a/test/roast/cogs/chat/config_test.rb
+++ b/test/roast/cogs/chat/config_test.rb
@@ -38,6 +38,11 @@ module Roast
           assert_equal :perplexity, @config.valid_provider!
         end
 
+        test "valid_provider! accepts and sets :gemini" do
+          @config.provider(:gemini)
+          assert_equal :gemini, @config.valid_provider!
+        end
+
         test "valid_provider! raises on invalid provider" do
           @config.provider(:invalid_provider)
 
@@ -97,6 +102,13 @@ module Roast
           end
         end
 
+        test "valid_api_key! reads from gemini environment variable when provider is gemini" do
+          @config.provider(:gemini)
+          with_env("GEMINI_API_KEY", "gemini-env-key") do
+            assert_equal "gemini-env-key", @config.valid_api_key!
+          end
+        end
+
         # Base URL configuration tests
         test "base_url sets base url value" do
           @config.base_url("https://custom.api.com/v1")
@@ -125,6 +137,13 @@ module Roast
           end
         end
 
+        test "valid_base_url returns gemini default base url when provider is gemini" do
+          @config.provider(:gemini)
+          with_env("GEMINI_API_BASE", nil) do
+            assert_equal "https://generativelanguage.googleapis.com/v1beta", @config.valid_base_url
+          end
+        end
+
         test "valid_base_url reads ANTHROPIC_API_BASE when provider is anthropic" do
           @config.provider(:anthropic)
           with_env("ANTHROPIC_API_BASE", "https://env.anthropic.com/v1") do
@@ -136,6 +155,13 @@ module Roast
           @config.provider(:openai)
           with_env("OPENAI_API_BASE", "https://env.openai.com/v1") do
             assert_equal "https://env.openai.com/v1", @config.valid_base_url
+          end
+        end
+
+        test "valid_base_url reads GEMINI_API_BASE when provider is gemini" do
+          @config.provider(:gemini)
+          with_env("GEMINI_API_BASE", "https://generativelanguage.googleapis.com/v1") do
+            assert_equal "https://generativelanguage.googleapis.com/v1", @config.valid_base_url
           end
         end
 
@@ -166,6 +192,11 @@ module Roast
         test "valid_model returns perplexity default model when provider is perplexity" do
           @config.provider(:perplexity)
           assert_equal "sonar", @config.valid_model
+        end
+
+        test "valid_model returns gemini default model when provider is gemini" do
+          @config.provider(:gemini)
+          assert_equal "gemini-3.1-flash-lite", @config.valid_model
         end
 
         # Temperature configuration tests

--- a/tutorial/01_your_first_workflow/README.md
+++ b/tutorial/01_your_first_workflow/README.md
@@ -106,7 +106,7 @@ block:
 config do
   chat do
     model "gpt-4o-mini" # Use OpenAI's fast model
-    provider :openai # Use OpenAI (can also be :anthropic or :perplexity)
+    provider :openai # Use OpenAI (can also be :anthropic, :perplexity or :gemini)
     show_prompt! # Display the prompt before sending
   end
 end
@@ -128,8 +128,9 @@ Common options you can set:
     - OpenAI: "gpt-4o-mini" (default), "gpt-4o", "gpt-4-turbo", etc.
     - Anthropic: "claude-haiku-4-5" (default), "claude-sonnet-4-6", "claude-opus-4-7", etc.
     - Perplexity: "sonar" (default), "sonar-pro", "sonar-deep-research", etc.
+    - Gemini: "gemini-3.1-flash-lite" (default), "gemini-3-flash-preview", "gemini-3.1-pro-preview", etc.
 - `provider :name` - Which LLM provider
-    - `:openai`, `:anthropic` or `:perplexity`
+    - `:openai`, `:anthropic`, `:perplexity` or `:gemini`
 - `show_prompt!` - Display the prompt being sent
 - `show_response!` - Display the response (on by default)
 - `show_stats!` - Display token usage statistics (on by default)

--- a/tutorial/01_your_first_workflow/configured_chat.rb
+++ b/tutorial/01_your_first_workflow/configured_chat.rb
@@ -10,7 +10,7 @@ config do
   # Configure all chat cogs in this workflow
   chat do
     model "gpt-4o-mini"      # Use OpenAI's fast, cost-effective model
-    provider :openai         # Use OpenAI (alternative: :anthropic or :perplexity)
+    provider :openai         # Use OpenAI (alternative: :anthropic, :perplexity or :gemini)
     show_prompt!             # Display the prompt before sending it
     show_response!           # Display the response (this is the default)
     show_stats!              # Display token usage statistics (default)


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/886

## Tophatting 🎩

#### To tophat the Gemini provider:

Pull the branch

```bash
git fetch && git checkout 05-14/add-gemini-as-a-supported-provider 
bundle install
```

Export your gemini key

```bash
export GEMINI_API_KEY="..."
```

Save this workflow as tophat.rb

```ruby
# typed: true
# frozen_string_literal: true

#: self as Roast::Workflow

config do
  chat do
    provider :gemini
    show_response!
    show_stats!
  end
end

execute do
  chat do
    "Reply with exactly three words: a greeting."
  end
end
```

Run it

```bash
bin/roast execute tophat.rb
```

**Expected:** a greeting from the model, followed by token stats showing the right model ID (`gemini-3.1-flash-lite`).

Reply in thread with ✅ if it works or paste the error if not.

Thanks!