### PR TITLE
fix use_default_model! to fall back to provider default

### DIFF
--- a/lib/roast/cogs/chat/config.rb
+++ b/lib/roast/cogs/chat/config.rb
@@ -171,7 +171,7 @@ module Roast
         #
         #: () -> void
         def use_default_model!
-          @values[:model] = nil
+          @values.delete(:model)
         end
 
         # Get the validated, configured value of the model the cog is configured to use when running the agent

--- a/test/roast/cogs/chat/config_test.rb
+++ b/test/roast/cogs/chat/config_test.rb
@@ -105,13 +105,11 @@ module Roast
           assert_equal "gpt-4", @config.valid_model
         end
 
-        test "use_default_model! clears model value" do
+        test "use_default_model! resets model to provider default" do
           @config.model("gpt-4")
           @config.use_default_model!
 
-          # use_default_model! sets value to nil, which valid_model returns
-          # (nil means use provider's default at runtime)
-          assert_nil @config.valid_model
+          assert_equal Config::PROVIDERS.dig(:openai, :default_model), @config.valid_model
         end
 
         test "valid_model returns default when not set" do


### PR DESCRIPTION
`use_default_model!` used to make the model value nil, which made the model use the RubyLLM default model instead of the one in PROVIDERS