### PR TITLE
Repeat log prefix on each line of multi-line output

### DIFF
--- a/lib/roast/event_monitor.rb
+++ b/lib/roast/event_monitor.rb
@@ -116,17 +116,29 @@ module Roast
 
     #: (Event) -> void
     def handle_log_event(event)
-      Roast::Log.logger.add(event.log_severity, "#{format_path(event)} #{event.log_message}")
+      path = format_path(event)
+      event.log_message.lines.each_with_index do |line, idx|
+        path_prefix = idx.zero? ? path : "·" * path.length
+        Roast::Log.logger.add(event.log_severity, "#{path_prefix} #{line.rstrip}")
+      end
     end
 
     #: (Event) -> void
     def handle_stderr_event(event)
-      Roast::Log.logger.warn { "#{format_path(event)} ❯❯ #{event[:stderr]}" }
+      path = format_path(event)
+      event[:stderr].lines.each_with_index do |line, idx|
+        path_prefix = idx.zero? ? "#{path} ❯❯" : "#{"·" * path.length} ❙❙"
+        Roast::Log.logger.warn { "#{path_prefix} #{line.rstrip}" }
+      end
     end
 
     #: (Event) -> void
     def handle_stdout_event(event)
-      Roast::Log.logger.info { "#{format_path(event)} ❯ #{event[:stdout]}" }
+      path = format_path(event)
+      event[:stdout].lines.each_with_index do |line, idx|
+        path_prefix = idx.zero? ? "#{path} ❯" : "#{"·" * path.length} ❙"
+        Roast::Log.logger.info { "#{path_prefix} #{line.rstrip}" }
+      end
     end
 
     #: (Event) -> void

--- a/lib/roast/log_formatter.rb
+++ b/lib/roast/log_formatter.rb
@@ -27,9 +27,9 @@ module Roast
 
     #: (String, String) -> String
     def colourize(severity, line)
-      if line.include?("❯❯") # standard error lines
+      if line.include?("❯❯") || line.include?("❙❙") # standard error lines
         @rainbow.wrap(line).yellow
-      elsif line.include?("❯") # standard output lines
+      elsif line.include?("❯") || line.include?("❙") # standard output lines
         @rainbow.wrap(line)
       else
         case severity

--- a/test/roast/event_monitor_test.rb
+++ b/test/roast/event_monitor_test.rb
@@ -188,14 +188,16 @@ module Roast
 
       event = Event.new([em_el, cog_el], { info: "line 1\nline 2\nline 3" })
       EventMonitor.accept(event)
-      lines = @logger_output.string.lines
-      prefix = "test_cog(:my_step)"
 
-      assert_equal 1, lines.count { |line| line.include?(prefix) }
-      assert_includes lines.find { |line| line.include?("line 1") }, prefix
-      refute_includes lines.find { |line| line.include?("line 2") }, prefix
-      refute_includes lines.find { |line| line.include?("line 3") }, prefix
-      assert_equal 2, lines.count { |line| line.include?("·") }
+      messages = @logger_output.string.gsub(/^.*? -- /, "")
+      prefix = "test_cog(:my_step)"
+      continuation_prefix = "·" * prefix.length
+
+      assert_equal(<<~OUTPUT, messages)
+        #{prefix} line 1
+        #{continuation_prefix} line 2
+        #{continuation_prefix} line 3
+      OUTPUT
     end
 
     test "handle_begin_event logs cog begin events" do
@@ -388,15 +390,16 @@ module Roast
 
       event = Event.new([em_el, cog_el], { stdout: "line 1\nline 2\nline 3" })
       EventMonitor.accept(event)
-      lines = @logger_output.string.lines
-      prefix = "test_cog(:my_step)"
 
-      assert_equal 1, lines.count { |line| line.include?(prefix) }
-      assert_includes lines.find { |line| line.include?("line 1") }, prefix
-      refute_includes lines.find { |line| line.include?("line 2") }, prefix
-      refute_includes lines.find { |line| line.include?("line 3") }, prefix
-      assert_equal 1, lines.count { |line| line.include?(" ❯ ") }
-      assert_equal 2, lines.count { |line| line.include?(" ❙ ") }
+      messages = @logger_output.string.gsub(/^.*? -- /, "")
+      prefix = "test_cog(:my_step)"
+      continuation_prefix = "·" * prefix.length
+
+      assert_equal(<<~OUTPUT, messages)
+        #{prefix} ❯ line 1
+        #{continuation_prefix} ❙ line 2
+        #{continuation_prefix} ❙ line 3
+      OUTPUT
     end
 
     test "handle_stderr_event does not output to console" do
@@ -422,15 +425,16 @@ module Roast
 
       event = Event.new([em_el, cog_el], { stderr: "line 1\nline 2\nline 3" })
       EventMonitor.accept(event)
-      lines = @logger_output.string.lines
-      prefix = "test_cog(:my_step)"
 
-      assert_equal 1, lines.count { |line| line.include?(prefix) }
-      assert_includes lines.find { |line| line.include?("line 1") }, prefix
-      refute_includes lines.find { |line| line.include?("line 2") }, prefix
-      refute_includes lines.find { |line| line.include?("line 3") }, prefix
-      assert_equal 1, lines.count { |line| line.include?(" ❯❯ ") }
-      assert_equal 2, lines.count { |line| line.include?(" ❙❙ ") }
+      messages = @logger_output.string.gsub(/^.*? -- /, "")
+      prefix = "test_cog(:my_step)"
+      continuation_prefix = "·" * prefix.length
+
+      assert_equal(<<~OUTPUT, messages)
+        #{prefix} ❯❯ line 1
+        #{continuation_prefix} ❙❙ line 2
+        #{continuation_prefix} ❙❙ line 3
+      OUTPUT
     end
 
     test "handle_unknown_event logs unrecognized events at unknown level" do

--- a/test/roast/event_monitor_test.rb
+++ b/test/roast/event_monitor_test.rb
@@ -181,6 +181,23 @@ module Roast
       assert_includes @logger_output.string, "something went wrong"
     end
 
+    test "handle_log_event prefixes first line and indents subsequent lines" do
+      cog = TestCogSupport::TestCog.new(:my_step, nil)
+      cog_el = TaskContext::PathElement.new(cog: cog)
+      em_el = mock_execution_manager_path_element
+
+      event = Event.new([em_el, cog_el], { info: "line 1\nline 2\nline 3" })
+      EventMonitor.accept(event)
+      lines = @logger_output.string.lines
+      prefix = "test_cog(:my_step)"
+
+      assert_equal 1, lines.count { |line| line.include?(prefix) }
+      assert_includes lines.find { |line| line.include?("line 1") }, prefix
+      refute_includes lines.find { |line| line.include?("line 2") }, prefix
+      refute_includes lines.find { |line| line.include?("line 3") }, prefix
+      assert_equal 2, lines.count { |line| line.include?("·") }
+    end
+
     test "handle_begin_event logs cog begin events" do
       cog = TestCogSupport::TestCog.new(:step1, nil)
       cog_el = TaskContext::PathElement.new(cog: cog)
@@ -364,6 +381,24 @@ module Roast
       assert_includes @logger_output.string, "hello stdout"
     end
 
+    test "handle_stdout_event prefixes first line and indents subsequent lines" do
+      cog = TestCogSupport::TestCog.new(:my_step, nil)
+      cog_el = TaskContext::PathElement.new(cog: cog)
+      em_el = mock_execution_manager_path_element
+
+      event = Event.new([em_el, cog_el], { stdout: "line 1\nline 2\nline 3" })
+      EventMonitor.accept(event)
+      lines = @logger_output.string.lines
+      prefix = "test_cog(:my_step)"
+
+      assert_equal 1, lines.count { |line| line.include?(prefix) }
+      assert_includes lines.find { |line| line.include?("line 1") }, prefix
+      refute_includes lines.find { |line| line.include?("line 2") }, prefix
+      refute_includes lines.find { |line| line.include?("line 3") }, prefix
+      assert_equal 1, lines.count { |line| line.include?(" ❯ ") }
+      assert_equal 2, lines.count { |line| line.include?(" ❙ ") }
+    end
+
     test "handle_stderr_event does not output to console" do
       event = Event.new([], { stderr: "hello stderr" })
 
@@ -378,6 +413,24 @@ module Roast
       capture_io { EventMonitor.accept(event) }
 
       assert_includes @logger_output.string, "hello stderr"
+    end
+
+    test "handle_stderr_event prefixes first line and indents subsequent lines" do
+      cog = TestCogSupport::TestCog.new(:my_step, nil)
+      cog_el = TaskContext::PathElement.new(cog: cog)
+      em_el = mock_execution_manager_path_element
+
+      event = Event.new([em_el, cog_el], { stderr: "line 1\nline 2\nline 3" })
+      EventMonitor.accept(event)
+      lines = @logger_output.string.lines
+      prefix = "test_cog(:my_step)"
+
+      assert_equal 1, lines.count { |line| line.include?(prefix) }
+      assert_includes lines.find { |line| line.include?("line 1") }, prefix
+      refute_includes lines.find { |line| line.include?("line 2") }, prefix
+      refute_includes lines.find { |line| line.include?("line 3") }, prefix
+      assert_equal 1, lines.count { |line| line.include?(" ❯❯ ") }
+      assert_equal 2, lines.count { |line| line.include?(" ❙❙ ") }
     end
 
     test "handle_unknown_event logs unrecognized events at unknown level" do

--- a/test/roast/log_formatter_test.rb
+++ b/test/roast/log_formatter_test.rb
@@ -199,6 +199,18 @@ module Roast
       assert_includes result, "❯❯"
     end
 
+    test "stderr continuation lines are yellow in TTY mode" do
+      formatter = LogFormatter.new(tty: true)
+      time = Time.new(2026, 1, 1)
+
+      result = formatter.call("INFO", time, nil, "···· ❙❙ other line of some error output")
+
+      assert_match ANSI_PATTERN, result
+      # \e[33m = yellow
+      assert_match(/\e\[33m/, result)
+      assert_includes result, "❙❙"
+    end
+
     test "stdout marker lines are not colourized in TTY mode" do
       formatter = LogFormatter.new(tty: true)
       time = Time.new(2026, 1, 1)
@@ -208,6 +220,16 @@ module Roast
       # Should not have colour codes (stdout lines are wrapped but no colour method called)
       refute_match ANSI_PATTERN, result
       assert_includes result, "❯"
+    end
+
+    test "stdout continuation lines are not colourized in TTY mode" do
+      formatter = LogFormatter.new(tty: true)
+      time = Time.new(2026, 1, 1)
+
+      result = formatter.call("INFO", time, nil, "···· ❙ other line of some output")
+
+      refute_match ANSI_PATTERN, result
+      assert_includes result, "❙"
     end
 
     test "stderr marker takes precedence over severity colour" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -129,7 +129,7 @@ def run_cog(cog, config: nil, scope_value: nil, scope_index: 0)
   cog
 end
 
-# Extract original stdout/stderr content from log output by parsing ❯ and ❯❯ markers.
+# Extract original stdout/stderr content from log output by parsing ❯/❯❯ and ❙/❙❙ line markers.
 # Handles multiline log entries by treating non-log-prefix lines as continuations.
 #
 #: (?logger_output: String) -> [String, String]
@@ -142,12 +142,12 @@ def original_streams_from_logger_output(logger_output: @logger_output.string)
 
   all_lines.each do |line|
     if line.match?(log_prefix_pattern)
-      if line.include?(" ❯❯")
+      if line.include?(" ❯❯") || line.include?(" ❙❙")
         current_stream = :stderr
-        stderr_lines << line.sub(/^.*❯❯ ?/, "")
-      elsif line.include?(" ❯")
+        stderr_lines << line.sub(/^.*(❯❯|❙❙) ?/, "")
+      elsif line.include?(" ❯") || line.include?(" ❙")
         current_stream = :stdout
-        stdout_lines << line.sub(/^.*❯ ?/, "")
+        stdout_lines << line.sub(/^.*(❯|❙) ?/, "")
       else
         current_stream = nil
       end


### PR DESCRIPTION
fixes https://github.com/Shopify/roast/issues/876

The goal of this PR is to clean up the output of workflow runs by making it easier to read and understand which lines are part of which action.

## Examples

Old terminal output                                                                New terminal output:  
![image.png](https://app.graphite.com/user-attachments/assets/201b308b-46e3-4945-89ab-269cc4f76ed0.png)             ![image.png](https://app.graphite.com/user-attachments/assets/847d34b7-0830-4251-a41c-1269a761e47b.png)

Old log output                                                                        New log output  
![image.png](https://app.graphite.com/user-attachments/assets/a09578dd-0438-4d9b-951d-75fcbcd8c7b0.png)                     ![image.png](https://app.graphite.com/user-attachments/assets/f367ac1c-1e46-4969-8ae9-46f352b07272.png)

Note: went with dots on continuation lines instead of whitespace so the "missing" prefix reads as intentional rather than looking like a rendering glitch or a dropped line. It also avoids touching `msg2str`, which strips leading/trailing whitespace. Any future `.strip` added elsewhere in the pipeline could also silently collapse a whitespace prefix.