### PR TITLE
[PROTOTYPE] Improve formatting of agent prompt and response outputs

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/claude_invocation.rb
+++ b/lib/roast/cogs/agent/providers/claude/claude_invocation.rb
@@ -77,7 +77,7 @@ module Roast
               raise ClaudeAlreadyStartedError if started?
 
               @started = true
-              puts "[USER PROMPT] #{@prompt}" if @show_prompt
+              Event << { block: { header: "USER PROMPT", content: @prompt } } if @show_prompt
               _stdout, stderr, status = CommandRunner.execute(
                 command_line,
                 working_directory: @working_directory,
@@ -87,7 +87,7 @@ module Roast
 
               if status.success?
                 @completed = true
-                puts "[AGENT RESPONSE] #{@result.response}" if @show_response
+                Event << { block: { header: "AGENT RESPONSE", content: @result.response } } if @show_response
               else
                 @failed = true
                 @result.success = false

--- a/lib/roast/event.rb
+++ b/lib/roast/event.rb
@@ -24,6 +24,7 @@ module Roast
       :end,
       :stdout,
       :stderr,
+      :block,
     ].freeze #: Array[Symbol]
 
     #: Array[TaskContext::PathElement]

--- a/lib/roast/event_monitor.rb
+++ b/lib/roast/event_monitor.rb
@@ -130,6 +130,15 @@ module Roast
     end
 
     #: (Event) -> void
+    def handle_block_event(event)
+      block = event[:block]
+      header = "[#{block[:header]}]"
+      content = block[:content]
+      separator = "-" * 40
+      Roast::Log.logger.info { "#{format_path(event)} ↓\n\n#{header}\n#{separator}\n#{content}\n#{separator}" }
+    end
+
+    #: (Event) -> void
     def handle_unknown_event(event)
       Roast::Log.logger.unknown(event.inspect)
     end


### PR DESCRIPTION
Part of the exploration for https://github.com/Shopify/roast/issues/896



Prototype for creating a new event type for long multi-line messages and applying it to prompts and response messages for agent cogs.

This is just to demonstrate the functionality and proposed implementation.

Old formatting:  
![image.png](https://app.graphite.com/user-attachments/assets/cfcfc41a-5ee0-4b38-b649-2a867e7317b5.png)

New formatting:  
![image.png](https://app.graphite.com/user-attachments/assets/2c21e3bf-e7d4-4efa-862b-930e3f352267.png)