### PR TITLE
Add a block type event

### DIFF
--- a/lib/roast/event.rb
+++ b/lib/roast/event.rb
@@ -24,6 +24,7 @@ module Roast
       :end,
       :stdout,
       :stderr,
+      :block,
     ].freeze #: Array[Symbol]
 
     #: Array[TaskContext::PathElement]

--- a/lib/roast/event_monitor.rb
+++ b/lib/roast/event_monitor.rb
@@ -6,6 +6,8 @@ module Roast
     extend self
     include Kernel
 
+    BLOCK_SEPARATOR = ("─" * 40).freeze #: String
+
     class EventMonitorError < StandardError; end
 
     class EventMonitorAlreadyStartedError < EventMonitorError; end
@@ -139,6 +141,14 @@ module Roast
         path_prefix = idx.zero? ? "#{path} ❯" : "#{"·" * path.length} ❙"
         Roast::Log.logger.info { "#{path_prefix} #{line.rstrip}" }
       end
+    end
+
+    #: (Event) -> void
+    def handle_block_event(event)
+      block = event[:block]
+      header = "[#{block[:header]}]"
+      content = block[:content]
+      Roast::Log.logger.info { "#{format_path(event)} #{header}↓\n#{BLOCK_SEPARATOR}\n#{content}\n#{BLOCK_SEPARATOR}" }
     end
 
     #: (Event) -> void

--- a/test/roast/event_monitor_test.rb
+++ b/test/roast/event_monitor_test.rb
@@ -437,6 +437,58 @@ module Roast
       OUTPUT
     end
 
+    test "handle_block_event does not output to console" do
+      event = Event.new([], { block: { header: "Header", content: "Content" } })
+
+      output = capture_io { EventMonitor.accept(event) }.first
+
+      assert_empty output
+    end
+
+    test "handle_block_event logs message at info level" do
+      event = Event.new([], { block: { header: "Header", content: "Content" } })
+
+      capture_io { EventMonitor.accept(event) }
+
+      assert_includes @logger_output.string, "Content"
+    end
+
+    test "handle_block_event includes header in output" do
+      event = Event.new([], { block: { header: "USER PROMPT", content: "Content" } })
+
+      EventMonitor.accept(event)
+
+      assert_includes @logger_output.string, "[USER PROMPT]"
+    end
+
+    test "handle_block_event includes content in output" do
+      event = Event.new([], { block: { header: "Header", content: "the body content" } })
+
+      EventMonitor.accept(event)
+
+      assert_includes @logger_output.string, "the body content"
+    end
+
+    test "handle_block_event renders header, separators, and content as a single block" do
+      cog = TestCogSupport::TestCog.new(:my_step, nil)
+      cog_el = TaskContext::PathElement.new(cog: cog)
+      em_el = mock_execution_manager_path_element
+
+      event = Event.new([em_el, cog_el], { block: { header: "USER PROMPT", content: "line 1\nline 2\nline 3" } })
+      EventMonitor.accept(event)
+
+      messages = @logger_output.string.gsub(/^.*? -- /, "")
+
+      assert_equal(<<~OUTPUT, messages)
+        test_cog(:my_step) [USER PROMPT]↓
+        #{EventMonitor::BLOCK_SEPARATOR}
+        line 1
+        line 2
+        line 3
+        #{EventMonitor::BLOCK_SEPARATOR}
+      OUTPUT
+    end
+
     test "handle_unknown_event logs unrecognized events at unknown level" do
       event = Event.new([], { custom_type: "data" })
       EventMonitor.accept(event)

--- a/test/roast/event_test.rb
+++ b/test/roast/event_test.rb
@@ -108,6 +108,12 @@ module Roast
       assert_equal :stderr, event.type
     end
 
+    test "type returns :block for block payload" do
+      event = Event.new([], { block: { header: "Header", content: "Content" } })
+
+      assert_equal :block, event.type
+    end
+
     test "type returns :unknown for unrecognized payload" do
       event = Event.new([], { custom: "data" })
 


### PR DESCRIPTION
Closes https://github.com/Shopify/roast/issues/904

tldr; Adds a new block event type, to allow for better formatting of prompt and response messages from chat and agent cogs.

The current formatting chosen is number 2 out of the 3 options I considered.

Different formatting choices we can have:

1\.  
![Screenshot 2026-05-28 at 10.55.59 AM.png](https://app.graphite.com/user-attachments/assets/506d3365-085b-4427-8a03-507419a370dc.png)

2\.  
![Screenshot 2026-05-28 at 10.55.07 AM.png](https://app.graphite.com/user-attachments/assets/9f5709c8-38e0-4fb7-b202-c81cbef75250.png)

3\.  
![Screenshot 2026-05-28 at 10.54.13 AM.png](https://app.graphite.com/user-attachments/assets/be221162-9cbf-4171-8204-cac9b8571497.png)