### PR TITLE
use block events for llm stats

### DIFF
--- a/lib/roast/cogs/agent.rb
+++ b/lib/roast/cogs/agent.rb
@@ -48,8 +48,9 @@ module Roast
       #: (Input) -> Output
       def execute(input)
         output = provider.invoke(input)
-        puts "[AGENT STATS] #{output.stats}" if config.show_stats?
-        puts "Session ID: #{output.session}" if config.show_stats?
+        if config.show_stats?
+          Event << { block: { header: "AGENT STATS", content: "#{output.stats}\nSession ID: #{output.session}" } }
+        end
         output
       end
 

--- a/lib/roast/cogs/chat.rb
+++ b/lib/roast/cogs/chat.rb
@@ -53,11 +53,11 @@ module Roast
         end
         if config.show_stats?
           temperature = chat.instance_variable_get(:@temperature)
-          puts "[LLM STATS]"
-          puts "\tModel: #{response.model_id}"
-          puts "\tTemperature: #{format("%0.2f", temperature)}" if temperature
-          puts "\tInput Tokens: #{response.input_tokens}"
-          puts "\tOutput Tokens: #{response.output_tokens}"
+          lines = ["Model: #{response.model_id}"]
+          lines << "Temperature: #{format("%0.2f", temperature)}" if temperature
+          lines << "Input Tokens: #{response.input_tokens}"
+          lines << "Output Tokens: #{response.output_tokens}"
+          Event << { block: { header: "LLM STATS", content: lines.join("\n") } }
         end
 
         Output.new(Session.from_chat(chat), response.content)

--- a/test/examples/functional/roast_examples_test.rb
+++ b/test/examples/functional/roast_examples_test.rb
@@ -114,11 +114,14 @@ module Examples
           ────────────────────────────────────────
           12 - 5 = 7
           ────────────────────────────────────────
-          [AGENT STATS] Turns: 3
+          [AGENT STATS]
+          ────────────────────────────────────────
+          Turns: 3
           Duration: 6 seconds
           Cost (USD): $0.0747
           Tokens (claude-haiku-4-5-20251001): 27 in, 198 out
           Session ID: 51c68f29-7210-4c12-852f-0c169f621488
+          ────────────────────────────────────────
           ((2 + 2) * 3) - 5 = 7
         STDOUT
         assert_equal expected_stdout, logged_stdout
@@ -637,11 +640,14 @@ module Examples
           Ancient waters vast and deep,
           World's largest lake gleams.
           ────────────────────────────────────────
-          [AGENT STATS] Turns: 1
+          [AGENT STATS]
+          ────────────────────────────────────────
+          Turns: 1
           Duration: 4 seconds
           Cost (USD): $0.050913
           Tokens (claude-haiku-4-5-20251001): 9 in, 385 out
           Session ID: 6d6782cf-d193-4fc7-b5f4-414bc0cfcd3a
+          ────────────────────────────────────────
         STDOUT
         assert_equal expected_stdout, logged_stdout
         assert_empty logged_stderr
@@ -688,11 +694,14 @@ module Examples
           Ancient waters vast and deep,
           World's largest lake gleams.
           ────────────────────────────────────────
-          [AGENT STATS] Turns: 1
+          [AGENT STATS]
+          ────────────────────────────────────────
+          Turns: 1
           Duration: 0 seconds
           Cost (USD): $0.024634
           Tokens (claude-haiku-4-5-20251001): 9 in, 25 out
           Session ID: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+          ────────────────────────────────────────
         STDOUT
         assert_equal expected_stdout, logged_stdout
         assert_empty logged_stderr


### PR DESCRIPTION
close https://github.com/Shopify/roast/issues/908

Current LLM stats output (after "Repeat log prefix on each line of multi-line output" is merged):![Screenshot 2026-05-28 at 10.45.31 AM.png](https://app.graphite.com/user-attachments/assets/a906b2f1-2690-486e-810b-bca753fc007d.png)

Proposed new LLM stats output:![image.png](https://app.graphite.com/user-attachments/assets/90f24106-093a-4dde-a799-929f37d5c286.png)

