### PR TITLE
Tag log messages with originating stream

### DIFF
--- a/examples/custom_logging.rb
+++ b/examples/custom_logging.rb
@@ -12,9 +12,11 @@
 # Log to standard output, always at the DEBUG level
 Roast::Log.logger = Logger.new($stdout).tap { |logger| logger.level = ::Logger::DEBUG }
 
-# Format log lines in a particular way
+# Format log lines in a particular way. `msg` may be a String or a
+# Roast::Log::Message (stdout/stderr output is wrapped to carry its type),
+# so normalise with #to_s before formatting.
 Roast::Log.logger.formatter = proc do |severity, time, progname, msg|
-  "#{severity[0..0]}, #{msg.strip} (at #{time})\n"
+  "#{severity[0..0]}, #{msg.to_s.strip} (at #{time})\n"
 end
 
 

--- a/lib/roast/event_monitor.rb
+++ b/lib/roast/event_monitor.rb
@@ -130,7 +130,12 @@ module Roast
       path = format_path(event)
       event[:stderr].lines.each_with_index do |line, idx|
         path_prefix = idx.zero? ? "#{path} ❯❯" : "#{"·" * path.length} ❙❙"
-        Roast::Log.logger.warn { "#{path_prefix} #{line.rstrip}" }
+        Roast::Log.logger.warn do
+          Roast::Log::Message.new(
+            type: :stderr,
+            text: "#{path_prefix} #{line.rstrip}",
+          )
+        end
       end
     end
 
@@ -139,7 +144,12 @@ module Roast
       path = format_path(event)
       event[:stdout].lines.each_with_index do |line, idx|
         path_prefix = idx.zero? ? "#{path} ❯" : "#{"·" * path.length} ❙"
-        Roast::Log.logger.info { "#{path_prefix} #{line.rstrip}" }
+        Roast::Log.logger.info do
+          Roast::Log::Message.new(
+            type: :stdout,
+            text: "#{path_prefix} #{line.rstrip}",
+          )
+        end
       end
     end
 

--- a/lib/roast/log.rb
+++ b/lib/roast/log.rb
@@ -21,6 +21,27 @@ module Roast
     extend self
     include Kernel
 
+    # A log message paired with its originating type, so downstream handlers
+    # (e.g. the formatter) can render or route it by type.
+    class Message
+      #: Symbol
+      attr_reader :type
+
+      #: String
+      attr_reader :text
+
+      #: (type: Symbol, text: String) -> void
+      def initialize(type:, text:)
+        @type = type
+        @text = text
+      end
+
+      #: () -> String
+      def to_s
+        text
+      end
+    end
+
     LOG_LEVELS = {
       DEBUG: ::Logger::DEBUG,
       INFO: ::Logger::INFO,

--- a/lib/roast/log_formatter.rb
+++ b/lib/roast/log_formatter.rb
@@ -15,22 +15,22 @@ module Roast
     end
 
     def call(severity, time, _progname, msg)
+      type = msg.is_a?(Roast::Log::Message) ? msg.type : nil
       line = if @tty
         format(TTY_FORMAT, severity, msg2str(msg))
       else
         format(NON_TTY_FORMAT, severity, time.strftime(DATETIME_FORMAT), severity, msg2str(msg))
       end
-      colourize(severity, line)
+      colourize(severity, type, line)
     end
 
     private
 
-    #: (String, String) -> String
-    def colourize(severity, line)
-      if line.include?("❯❯") || line.include?("❙❙") # standard error lines
-        @rainbow.wrap(line).yellow
-      elsif line.include?("❯") || line.include?("❙") # standard output lines
-        @rainbow.wrap(line)
+    #: (String, Symbol?, String) -> String
+    def colourize(severity, type, line)
+      case type
+      when :stderr then @rainbow.wrap(line).yellow
+      when :stdout then @rainbow.wrap(line)
       else
         case severity
         when "ERROR", "FATAL" then @rainbow.wrap(line).red
@@ -47,6 +47,8 @@ module Roast
       msg = case msg
       when ::String
         msg.strip
+      when Roast::Log::Message
+        msg.text.strip
       else
         msg
       end

--- a/test/roast/log_formatter_test.rb
+++ b/test/roast/log_formatter_test.rb
@@ -187,11 +187,12 @@ module Roast
       assert_match(/(\e\[38;5;214m)|(\e\[38;2;\d+;\d+\d+)/, result)
     end
 
-    test "stderr marker lines are yellow in TTY mode" do
+    test "stderr type messages are yellow in TTY mode" do
       formatter = LogFormatter.new(tty: true)
       time = Time.new(2026, 1, 1)
+      msg = Roast::Log::Message.new(type: :stderr, text: "path ❯❯ some error output")
 
-      result = formatter.call("INFO", time, nil, "path ❯❯ some error output")
+      result = formatter.call("INFO", time, nil, msg)
 
       assert_match ANSI_PATTERN, result
       # \e[33m = yellow
@@ -202,8 +203,9 @@ module Roast
     test "stderr continuation lines are yellow in TTY mode" do
       formatter = LogFormatter.new(tty: true)
       time = Time.new(2026, 1, 1)
+      msg = Roast::Log::Message.new(type: :stderr, text: "···· ❙❙ other line of some error output")
 
-      result = formatter.call("INFO", time, nil, "···· ❙❙ other line of some error output")
+      result = formatter.call("INFO", time, nil, msg)
 
       assert_match ANSI_PATTERN, result
       # \e[33m = yellow
@@ -211,11 +213,12 @@ module Roast
       assert_includes result, "❙❙"
     end
 
-    test "stdout marker lines are not colourized in TTY mode" do
+    test "stdout type messages are not colourized in TTY mode" do
       formatter = LogFormatter.new(tty: true)
       time = Time.new(2026, 1, 1)
+      msg = Roast::Log::Message.new(type: :stdout, text: "path ❯ some output")
 
-      result = formatter.call("INFO", time, nil, "path ❯ some output")
+      result = formatter.call("INFO", time, nil, msg)
 
       # Should not have colour codes (stdout lines are wrapped but no colour method called)
       refute_match ANSI_PATTERN, result
@@ -225,30 +228,33 @@ module Roast
     test "stdout continuation lines are not colourized in TTY mode" do
       formatter = LogFormatter.new(tty: true)
       time = Time.new(2026, 1, 1)
+      msg = Roast::Log::Message.new(type: :stdout, text: "···· ❙ other line of some output")
 
-      result = formatter.call("INFO", time, nil, "···· ❙ other line of some output")
+      result = formatter.call("INFO", time, nil, msg)
 
       refute_match ANSI_PATTERN, result
       assert_includes result, "❙"
     end
 
-    test "stderr marker takes precedence over severity colour" do
+    test "stderr type takes precedence over severity colour" do
       formatter = LogFormatter.new(tty: true)
       time = Time.new(2026, 1, 1)
+      msg = Roast::Log::Message.new(type: :stderr, text: "path ❯❯ error output")
 
-      # Even though ERROR would normally be red, ❯❯ should make it yellow
-      result = formatter.call("ERROR", time, nil, "path ❯❯ error output")
+      # Even though ERROR would normally be red, :stderr should make it yellow
+      result = formatter.call("ERROR", time, nil, msg)
 
       assert_match(/\e\[33m/, result) # yellow
       refute_match(/\e\[31m/, result) # not red
     end
 
-    test "stdout marker takes precedence over severity colour" do
+    test "stdout type takes precedence over severity colour" do
       formatter = LogFormatter.new(tty: true)
       time = Time.new(2026, 1, 1)
+      msg = Roast::Log::Message.new(type: :stdout, text: "path ❯ warn output")
 
-      # Even though WARN would normally be orange, ❯ should pass through uncoloured
-      result = formatter.call("WARN", time, nil, "path ❯ warn output")
+      # Even though WARN would normally be orange, :stdout should pass through uncoloured
+      result = formatter.call("WARN", time, nil, msg)
 
       refute_match ANSI_PATTERN, result
     end


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/909

Refactors the log messages with a `type `attribute so that LogFormatter#colourize becomes more robust and tests assess the colourize method properly.

Adds .to_s to CustomLogging because we previously only had strings as messages, but we now have either a string or a Roast::Log::Message, so we need to normalize using .to_s so that we output only the text of the message rather than the entire object.