### PR TITLE
Internal workflow to see docs impact from committed modifications

### DIFF
--- a/internal/workflows/maintenance/branch_docs_impact.rb
+++ b/internal/workflows/maintenance/branch_docs_impact.rb
@@ -3,6 +3,13 @@
 
 #: self as Roast::Workflow
 
+# Gets the committed diff of the current branch vs origin/main, then analyzes it for potential
+# documentation impacts, and optionally applies fixes. This is meant to be run as a pre-merge check, to
+# catch any potential documentation issues before they get merged into main.
+#
+# Accepts a `--fix` flag to apply any suggested fixes in place. Otherwise, it just reports the analysis
+# and recommended fixes without applying them.
+
 config do
   agent do
     provider :claude
@@ -19,15 +26,13 @@ end
 execute do
   cmd(:diff) do
     merge_base = %x(git merge-base origin/main HEAD).strip
-    diff = %x(git diff --cached #{merge_base})
-    if diff.strip.empty?
-      warn "no staged or committed changes vs origin/main"
-      skip!
-    end
-    "git diff --cached #{merge_base}"
+    fail!("could not determine merge-base with origin/main — run `git fetch origin main` first") if merge_base.empty?
+    "git diff #{merge_base} HEAD"
   end
 
   agent(:analyzer) do
+    skip! if cmd!(:diff).text.strip.empty?
+    fail!("diff too large (#{cmd!(:diff).text.bytesize} bytes) to analyze — narrow the branch or exclude generated files") if cmd!(:diff).text.bytesize > 500_000
     <<~PROMPT
       You are checking whether a git diff makes any existing documentation stale.
 
@@ -54,10 +59,11 @@ execute do
   end
 
   chat(:report) do
+    skip! if cmd!(:diff).text.strip.empty?
     <<~PROMPT
       Based on the following analysis, summarize the impact of the changes in this branch on the project's documentation.
       Highlight any significant improvements or regressions, and provide recommendations for any additional documentation updates that may be necessary.
-      Do not unecessarily suggest updates if they are not needed.
+      Do not suggest updates that are not needed.
       Do not be verbose. Be super concise.
 
       Analysis:
@@ -67,6 +73,8 @@ execute do
 
   agent(:fixer) do
     skip! unless arg?(:fix)
+    skip! if cmd!(:diff).text.strip.empty?
+    skip! if agent!(:analyzer).response.strip == "No documentation impact."
     <<~PROMPT
       Apply the documentation fixes suggested in the analysis below. Edit the
       affected files in place. Do not modify any code files; docs only.
@@ -76,11 +84,14 @@ execute do
   end
 
   ruby(:output) do
-    files = cmd!(:diff).text.scan(%r{^diff --git a/\S+ b/(\S+)}).flatten
-
-    puts "Files considered (#{files.size}):"
-    files.each { |f| puts "  #{f}" }
-    puts agent!(:analyzer).response
-    puts(agent?(:fixer) ? "Fixes applied." : "(Run with -- fix to apply suggested edits.)")
+    if cmd!(:diff).text.strip.empty?
+      puts "No changes vs origin/main — nothing to analyze."
+    else
+      files = cmd!(:diff).out.scan(%r{^diff --git a/.+ b/(.+)$}).flatten
+      puts "Files considered (#{files.size}):"
+      files.each { |f| puts "  #{f}" }
+      puts "ANALYSIS:\n#{chat!(:report).response}"
+      puts(agent?(:fixer) ? "Fixes applied." : "(Next time, run with `-- fix` to auto-apply suggested edits)")
+    end
   end
 end

--- a/internal/workflows/maintenance/branch_docs_impact.rb
+++ b/internal/workflows/maintenance/branch_docs_impact.rb
@@ -1,0 +1,64 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::Workflow
+
+config do
+end
+
+execute do
+  cmd(:diff) do
+    current = %x(git rev-parse --abbrev-ref HEAD).strip
+    if current == "main"
+      warn "on main, nothing to compare"
+      skip!
+    end
+    merge_base = %x(git merge-base origin/main HEAD).strip
+    diff = %x(git diff #{merge_base})
+    if diff.strip.empty?
+      warn "no diff vs origin/main — stage or commit your changes first"
+      skip!
+    end
+    "git diff #{merge_base}"
+  end
+
+  agent(:analyzer) do
+    <<~PROMPT
+      Analyze how the following git diff affects existing documentation.
+
+      DO NOT run git, bash, or any other commands. The diff is the ONLY input.
+      DO NOT investigate the branch state, untracked files, or commit history.
+      Work only from the diff below.
+
+      --- DIFF START ---
+      #{cmd!(:diff).text}
+      --- DIFF END ---
+
+      For each documentation file in this repo that the diff affects, report:
+      1. The doc file path
+      2. What in the diff makes it stale
+      3. The specific edit needed to bring it back in sync
+    PROMPT
+  end
+
+  chat do
+    <<~PROMPT
+      Based on the following analysis, summarize the impact of the changes in this branch on the project's documentation.
+      Highlight any significant improvements or regressions, and provide recommendations for any additional documentation updates that may be necessary.
+      Do not unecessarily suggest updates if they are not needed.
+
+      Analysis:
+      #{agent!(:analyzer).response}
+    PROMPT
+  end
+
+  agent(:fixer) do
+    skip! unless arg?(:fix)
+    <<~PROMPT
+      Apply the documentation fixes suggested in the analysis below. Edit the
+      affected files in place. Do not modify any code files; docs only.
+
+      #{agent!(:analyzer).response}
+    PROMPT
+  end
+end

--- a/internal/workflows/maintenance/branch_docs_impact.rb
+++ b/internal/workflows/maintenance/branch_docs_impact.rb
@@ -4,48 +4,61 @@
 #: self as Roast::Workflow
 
 config do
+  agent do
+    provider :claude
+    model "claude-opus-4-7"
+    quiet!
+  end
+  chat do
+    provider :openai
+    model "gpt-5"
+    quiet!
+  end
 end
 
 execute do
   cmd(:diff) do
-    current = %x(git rev-parse --abbrev-ref HEAD).strip
-    if current == "main"
-      warn "on main, nothing to compare"
-      skip!
-    end
     merge_base = %x(git merge-base origin/main HEAD).strip
-    diff = %x(git diff #{merge_base})
+    diff = %x(git diff --cached #{merge_base})
     if diff.strip.empty?
-      warn "no diff vs origin/main — stage or commit your changes first"
+      warn "no staged or committed changes vs origin/main"
       skip!
     end
-    "git diff #{merge_base}"
+    "git diff --cached #{merge_base}"
   end
 
   agent(:analyzer) do
     <<~PROMPT
-      Analyze how the following git diff affects existing documentation.
+      You are checking whether a git diff makes any existing documentation stale.
 
-      DO NOT run git, bash, or any other commands. The diff is the ONLY input.
-      DO NOT investigate the branch state, untracked files, or commit history.
-      Work only from the diff below.
+      Rules:
+      - Use ONLY the diff below. Do not run any commands.
+      - Be thorough about finding real issues — do not be conservative.
+      - But do NOT speculate about docs you cannot see in the diff.
+      - No markdown headers, no preamble, no caveats, no "limitations" sections.
+
+      Output format — pick exactly one:
+
+      If nothing in the diff affects existing docs, output a single line:
+        No documentation impact.
+
+      Otherwise, output one block per affected doc, separated by blank lines:
+        <doc/path.md>
+        Stale because: <one sentence>
+        Fix: <one sentence>
 
       --- DIFF START ---
       #{cmd!(:diff).text}
       --- DIFF END ---
-
-      For each documentation file in this repo that the diff affects, report:
-      1. The doc file path
-      2. What in the diff makes it stale
-      3. The specific edit needed to bring it back in sync
     PROMPT
   end
 
-  chat do
+  chat(:report) do
     <<~PROMPT
       Based on the following analysis, summarize the impact of the changes in this branch on the project's documentation.
       Highlight any significant improvements or regressions, and provide recommendations for any additional documentation updates that may be necessary.
       Do not unecessarily suggest updates if they are not needed.
+      Do not be verbose. Be super concise.
 
       Analysis:
       #{agent!(:analyzer).response}
@@ -60,5 +73,14 @@ execute do
 
       #{agent!(:analyzer).response}
     PROMPT
+  end
+
+  ruby(:output) do
+    files = cmd!(:diff).text.scan(%r{^diff --git a/\S+ b/(\S+)}).flatten
+
+    puts "Files considered (#{files.size}):"
+    files.each { |f| puts "  #{f}" }
+    puts agent!(:analyzer).response
+    puts(agent?(:fixer) ? "Fixes applied." : "(Run with -- fix to apply suggested edits.)")
   end
 end


### PR DESCRIPTION
tldr; Adds a workflow that takes committed changes on a branch, and analyzes their impact on Roast's docs.   
  
If the `-- fix` argument is passed, automatic fixes will be applied.   
  
This was placed under internal/workflows/maintenance