### PR TITLE
Restructure test classes for better RubyMine compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,10 @@ Sorbet/FalseSigil:
     - "examples/**/*"
     - "lib/roast/sorbet_runtime_stub.rb"
 
+Style/ClassAndModuleChildren:
+  Exclude:
+    - 'test/**/*.rb'
+
 Style/MethodCallWithArgsParentheses:
   Enabled: true
   Exclude:

--- a/test/roast/cog/config_test.rb
+++ b/test/roast/cog/config_test.rb
@@ -3,242 +3,240 @@
 require "test_helper"
 
 module Roast
-  class Cog
-    class ConfigTest < ActiveSupport::TestCase
-      def setup
-        @config = Config.new
+  class Cog::ConfigTest < ActiveSupport::TestCase
+    def setup
+      @config = Cog::Config.new
+    end
+
+    test "initialize accepts initial hash" do
+      config = Cog::Config.new({ key: "value", another: 42 })
+
+      assert_equal "value", config.values[:key]
+      assert_equal 42, config.values[:another]
+    end
+
+    test "validate! does nothing by default" do
+      assert_nothing_raised do
+        @config.validate!
+      end
+    end
+
+    test "[]= sets a value" do
+      @config[:key] = "value"
+
+      assert_equal "value", @config.values[:key]
+    end
+
+    test "[] gets a value" do
+      @config[:key] = "value"
+
+      assert_equal "value", @config[:key]
+    end
+
+    test "[] returns nil for non-existent key" do
+      assert_nil @config[:non_existent]
+    end
+
+    test "merge creates new config with combined values" do
+      @config[:key1] = "value1"
+      @config[:key2] = "value2"
+
+      other = Cog::Config.new({ key2: "overridden", key3: "value3" })
+      merged = @config.merge(other)
+
+      assert_equal "value1", merged[:key1]
+      assert_equal "overridden", merged[:key2]
+      assert_equal "value3", merged[:key3]
+    end
+
+    test "merge does not modify original config" do
+      @config[:key] = "original"
+      other = Cog::Config.new({ key: "new" })
+
+      @config.merge(other)
+
+      assert_equal "original", @config[:key]
+    end
+
+    test "async! sets async to true" do
+      @config.async!
+
+      assert @config.async?
+    end
+
+    test "no_async! sets async to false" do
+      @config.async!
+      @config.no_async!
+
+      refute @config.async?
+    end
+
+    test "sync! is alias for no_async!" do
+      @config.async!
+      @config.sync!
+
+      refute @config.async?
+    end
+
+    test "async? returns false by default" do
+      refute @config.async?
+    end
+
+    test "abort_on_failure! sets abort_on_failure to true" do
+      @config.abort_on_failure!
+
+      assert @config.abort_on_failure?
+    end
+
+    test "no_abort_on_failure! sets abort_on_failure to false" do
+      @config.abort_on_failure!
+      @config.no_abort_on_failure!
+
+      refute @config.abort_on_failure?
+    end
+
+    test "continue_on_failure! is alias for no_abort_on_failure!" do
+      @config.abort_on_failure!
+      @config.continue_on_failure!
+
+      refute @config.abort_on_failure?
+    end
+
+    test "abort_on_failure? returns true by default" do
+      assert @config.abort_on_failure?
+    end
+
+    test "working_directory sets working directory" do
+      @config.working_directory("/tmp")
+
+      assert_equal "/tmp", @config.values[:working_directory]
+    end
+
+    test "use_current_working_directory! sets working directory to nil" do
+      @config.working_directory("/tmp")
+      @config.use_current_working_directory!
+
+      assert_nil @config.values[:working_directory]
+    end
+
+    test "valid_working_directory returns nil when not set" do
+      assert_nil @config.valid_working_directory
+    end
+
+    test "valid_working_directory returns expanded pathname for valid directory" do
+      Dir.mktmpdir do |dir|
+        @config.working_directory(dir)
+        result = @config.valid_working_directory
+
+        assert_equal Pathname.new(dir).expand_path, result
+      end
+    end
+
+    test "valid_working_directory raises InvalidConfigError for non-existent directory" do
+      @config.working_directory("/non/existent/path")
+
+      error = assert_raises(Cog::Config::InvalidConfigError) do
+        @config.valid_working_directory
       end
 
-      test "initialize accepts initial hash" do
-        config = Config.new({ key: "value", another: 42 })
+      assert_match(/does not exist/, error.message)
+    end
 
-        assert_equal "value", config.values[:key]
-        assert_equal 42, config.values[:another]
-      end
+    test "valid_working_directory raises InvalidConfigError for file instead of directory" do
+      Tempfile.create("test_file") do |file|
+        @config.working_directory(file.path)
 
-      test "validate! does nothing by default" do
-        assert_nothing_raised do
-          @config.validate!
-        end
-      end
-
-      test "[]= sets a value" do
-        @config[:key] = "value"
-
-        assert_equal "value", @config.values[:key]
-      end
-
-      test "[] gets a value" do
-        @config[:key] = "value"
-
-        assert_equal "value", @config[:key]
-      end
-
-      test "[] returns nil for non-existent key" do
-        assert_nil @config[:non_existent]
-      end
-
-      test "merge creates new config with combined values" do
-        @config[:key1] = "value1"
-        @config[:key2] = "value2"
-
-        other = Config.new({ key2: "overridden", key3: "value3" })
-        merged = @config.merge(other)
-
-        assert_equal "value1", merged[:key1]
-        assert_equal "overridden", merged[:key2]
-        assert_equal "value3", merged[:key3]
-      end
-
-      test "merge does not modify original config" do
-        @config[:key] = "original"
-        other = Config.new({ key: "new" })
-
-        @config.merge(other)
-
-        assert_equal "original", @config[:key]
-      end
-
-      test "async! sets async to true" do
-        @config.async!
-
-        assert @config.async?
-      end
-
-      test "no_async! sets async to false" do
-        @config.async!
-        @config.no_async!
-
-        refute @config.async?
-      end
-
-      test "sync! is alias for no_async!" do
-        @config.async!
-        @config.sync!
-
-        refute @config.async?
-      end
-
-      test "async? returns false by default" do
-        refute @config.async?
-      end
-
-      test "abort_on_failure! sets abort_on_failure to true" do
-        @config.abort_on_failure!
-
-        assert @config.abort_on_failure?
-      end
-
-      test "no_abort_on_failure! sets abort_on_failure to false" do
-        @config.abort_on_failure!
-        @config.no_abort_on_failure!
-
-        refute @config.abort_on_failure?
-      end
-
-      test "continue_on_failure! is alias for no_abort_on_failure!" do
-        @config.abort_on_failure!
-        @config.continue_on_failure!
-
-        refute @config.abort_on_failure?
-      end
-
-      test "abort_on_failure? returns true by default" do
-        assert @config.abort_on_failure?
-      end
-
-      test "working_directory sets working directory" do
-        @config.working_directory("/tmp")
-
-        assert_equal "/tmp", @config.values[:working_directory]
-      end
-
-      test "use_current_working_directory! sets working directory to nil" do
-        @config.working_directory("/tmp")
-        @config.use_current_working_directory!
-
-        assert_nil @config.values[:working_directory]
-      end
-
-      test "valid_working_directory returns nil when not set" do
-        assert_nil @config.valid_working_directory
-      end
-
-      test "valid_working_directory returns expanded pathname for valid directory" do
-        Dir.mktmpdir do |dir|
-          @config.working_directory(dir)
-          result = @config.valid_working_directory
-
-          assert_equal Pathname.new(dir).expand_path, result
-        end
-      end
-
-      test "valid_working_directory raises InvalidConfigError for non-existent directory" do
-        @config.working_directory("/non/existent/path")
-
-        error = assert_raises(Config::InvalidConfigError) do
+        error = assert_raises(Cog::Config::InvalidConfigError) do
           @config.valid_working_directory
         end
 
-        assert_match(/does not exist/, error.message)
+        assert_match(/is not a directory/, error.message)
+      end
+    end
+
+    test "field defines getter method" do
+      test_class = Class.new(Cog::Config) do
+        field :test_field, "default_value"
       end
 
-      test "valid_working_directory raises InvalidConfigError for file instead of directory" do
-        Tempfile.create("test_file") do |file|
-          @config.working_directory(file.path)
+      config = test_class.new
 
-          error = assert_raises(Config::InvalidConfigError) do
-            @config.valid_working_directory
-          end
+      assert_equal "default_value", config.test_field
+    end
 
-          assert_match(/is not a directory/, error.message)
+    test "field defines setter method" do
+      test_class = Class.new(Cog::Config) do
+        field :test_field, "default_value"
+      end
+
+      config = test_class.new
+      config.test_field("new_value")
+
+      assert_equal "new_value", config.test_field
+    end
+
+    test "field returns default when value not set" do
+      test_class = Class.new(Cog::Config) do
+        field :test_field, { key: "value" }
+      end
+
+      config = test_class.new
+
+      assert_equal({ key: "value" }, config.test_field)
+    end
+
+    test "field deep dups default value" do
+      test_class = Class.new(Cog::Config) do
+        field :test_field, { key: "value" }
+      end
+
+      config = test_class.new
+      result1 = config.test_field
+      result2 = config.test_field
+
+      refute_same result1, result2
+    end
+
+    test "field validator is called when setting value" do
+      validator_called = false
+      test_class = Class.new(Cog::Config) do
+        field :test_field, "default" do |value|
+          validator_called = true
+          value.upcase
         end
       end
 
-      test "field defines getter method" do
-        test_class = Class.new(Config) do
-          field :test_field, "default_value"
-        end
+      config = test_class.new
+      config.test_field("lowercase")
 
-        config = test_class.new
+      assert validator_called
+      assert_equal "LOWERCASE", config.test_field
+    end
 
-        assert_equal "default_value", config.test_field
+    test "field defines use_default method" do
+      test_class = Class.new(Cog::Config) do
+        field :test_field, "default_value"
       end
 
-      test "field defines setter method" do
-        test_class = Class.new(Config) do
-          field :test_field, "default_value"
-        end
+      config = test_class.new
+      config.test_field("custom_value")
+      config.use_default_test_field!
 
-        config = test_class.new
-        config.test_field("new_value")
+      assert_equal "default_value", config.test_field
+    end
 
-        assert_equal "new_value", config.test_field
+    test "field use_default method deep dups default" do
+      test_class = Class.new(Cog::Config) do
+        field :test_field, { key: "value" }
       end
 
-      test "field returns default when value not set" do
-        test_class = Class.new(Config) do
-          field :test_field, { key: "value" }
-        end
+      config = test_class.new
+      config.use_default_test_field!
+      result1 = config.test_field
+      config.use_default_test_field!
+      result2 = config.test_field
 
-        config = test_class.new
-
-        assert_equal({ key: "value" }, config.test_field)
-      end
-
-      test "field deep dups default value" do
-        test_class = Class.new(Config) do
-          field :test_field, { key: "value" }
-        end
-
-        config = test_class.new
-        result1 = config.test_field
-        result2 = config.test_field
-
-        refute_same result1, result2
-      end
-
-      test "field validator is called when setting value" do
-        validator_called = false
-        test_class = Class.new(Config) do
-          field :test_field, "default" do |value|
-            validator_called = true
-            value.upcase
-          end
-        end
-
-        config = test_class.new
-        config.test_field("lowercase")
-
-        assert validator_called
-        assert_equal "LOWERCASE", config.test_field
-      end
-
-      test "field defines use_default method" do
-        test_class = Class.new(Config) do
-          field :test_field, "default_value"
-        end
-
-        config = test_class.new
-        config.test_field("custom_value")
-        config.use_default_test_field!
-
-        assert_equal "default_value", config.test_field
-      end
-
-      test "field use_default method deep dups default" do
-        test_class = Class.new(Config) do
-          field :test_field, { key: "value" }
-        end
-
-        config = test_class.new
-        config.use_default_test_field!
-        result1 = config.test_field
-        config.use_default_test_field!
-        result2 = config.test_field
-
-        refute_same result1, result2
-      end
+      refute_same result1, result2
     end
   end
 end

--- a/test/roast/cog/input_test.rb
+++ b/test/roast/cog/input_test.rb
@@ -3,118 +3,116 @@
 require "test_helper"
 
 module Roast
-  class Cog
-    class InputTest < ActiveSupport::TestCase
-      def setup
-        @input = Input.new
-      end
+  class Cog::InputTest < ActiveSupport::TestCase
+    def setup
+      @input = Cog::Input.new
+    end
 
-      test "validate! raises NotImplementedError" do
-        assert_raises(NotImplementedError) do
-          @input.validate!
+    test "validate! raises NotImplementedError" do
+      assert_raises(NotImplementedError) do
+        @input.validate!
+      end
+    end
+
+    test "coerce accepts any argument" do
+      assert_nothing_raised do
+        @input.coerce("some value")
+      end
+    end
+
+    test "coerce accepts nil" do
+      assert_nothing_raised do
+        @input.coerce(nil)
+      end
+    end
+
+    test "coerce accepts complex objects" do
+      assert_nothing_raised do
+        @input.coerce({ key: "value", nested: [1, 2, 3] })
+      end
+    end
+
+    test "coerce_ran? returns false initially" do
+      refute @input.send(:coerce_ran?)
+    end
+
+    test "coerce_ran? returns true after coerce is called" do
+      @input.coerce("value")
+
+      assert @input.send(:coerce_ran?)
+    end
+
+    test "coerce_ran? persists across multiple calls" do
+      @input.coerce("first")
+
+      assert @input.send(:coerce_ran?)
+
+      @input.coerce("second")
+
+      assert @input.send(:coerce_ran?)
+    end
+
+    test "subclass can override validate!" do
+      subclass = Class.new(Cog::Input) do
+        def validate!
+          raise Cog::Input::InvalidInputError, "custom validation failed"
         end
       end
 
-      test "coerce accepts any argument" do
-        assert_nothing_raised do
-          @input.coerce("some value")
+      input = subclass.new
+
+      error = assert_raises(Cog::Input::InvalidInputError) do
+        input.validate!
+      end
+
+      assert_equal "custom validation failed", error.message
+    end
+
+    test "subclass can override coerce" do
+      subclass = Class.new(Cog::Input) do
+        attr_reader :coerced_value
+
+        def coerce(input_return_value)
+          super
+          @coerced_value = input_return_value.upcase
         end
       end
 
-      test "coerce accepts nil" do
-        assert_nothing_raised do
-          @input.coerce(nil)
-        end
-      end
+      input = subclass.new
+      input.coerce("test")
 
-      test "coerce accepts complex objects" do
-        assert_nothing_raised do
-          @input.coerce({ key: "value", nested: [1, 2, 3] })
-        end
-      end
+      assert_equal "TEST", input.coerced_value
+      assert input.send(:coerce_ran?)
+    end
 
-      test "coerce_ran? returns false initially" do
-        refute @input.send(:coerce_ran?)
-      end
+    test "subclass can use coerce_ran? to adapt validation behavior" do
+      subclass = Class.new(Cog::Input) do
+        attr_accessor :optional_field
 
-      test "coerce_ran? returns true after coerce is called" do
-        @input.coerce("value")
-
-        assert @input.send(:coerce_ran?)
-      end
-
-      test "coerce_ran? persists across multiple calls" do
-        @input.coerce("first")
-
-        assert @input.send(:coerce_ran?)
-
-        @input.coerce("second")
-
-        assert @input.send(:coerce_ran?)
-      end
-
-      test "subclass can override validate!" do
-        subclass = Class.new(Input) do
-          def validate!
-            raise Input::InvalidInputError, "custom validation failed"
+        def validate!
+          if optional_field.nil? && !coerce_ran?
+            raise Cog::Input::InvalidInputError, "optional_field must be set before coercion"
           end
         end
 
-        input = subclass.new
-
-        error = assert_raises(Input::InvalidInputError) do
-          input.validate!
+        def coerce(input_return_value)
+          super
+          @optional_field = input_return_value
         end
-
-        assert_equal "custom validation failed", error.message
       end
 
-      test "subclass can override coerce" do
-        subclass = Class.new(Input) do
-          attr_reader :coerced_value
+      input = subclass.new
 
-          def coerce(input_return_value)
-            super
-            @coerced_value = input_return_value.upcase
-          end
-        end
-
-        input = subclass.new
-        input.coerce("test")
-
-        assert_equal "TEST", input.coerced_value
-        assert input.send(:coerce_ran?)
+      # First validation fails when optional_field is nil and coerce hasn't run
+      error = assert_raises(Cog::Input::InvalidInputError) do
+        input.validate!
       end
+      assert_equal "optional_field must be set before coercion", error.message
 
-      test "subclass can use coerce_ran? to adapt validation behavior" do
-        subclass = Class.new(Input) do
-          attr_accessor :optional_field
-
-          def validate!
-            if optional_field.nil? && !coerce_ran?
-              raise Input::InvalidInputError, "optional_field must be set before coercion"
-            end
-          end
-
-          def coerce(input_return_value)
-            super
-            @optional_field = input_return_value
-          end
-        end
-
-        input = subclass.new
-
-        # First validation fails when optional_field is nil and coerce hasn't run
-        error = assert_raises(Input::InvalidInputError) do
-          input.validate!
-        end
-        assert_equal "optional_field must be set before coercion", error.message
-
-        # After coerce runs, validation passes even with nil
-        input.coerce(nil)
-        assert_nothing_raised do
-          input.validate!
-        end
+      # After coerce runs, validation passes even with nil
+      input.coerce(nil)
+      assert_nothing_raised do
+        input.validate!
       end
     end
   end

--- a/test/roast/cog/output_test.rb
+++ b/test/roast/cog/output_test.rb
@@ -3,320 +3,318 @@
 require "test_helper"
 
 module Roast
-  class Cog
-    class OutputTest < ActiveSupport::TestCase
-      def setup
-        @output = Output.new
-      end
+  class Cog::OutputTest < ActiveSupport::TestCase
+    def setup
+      @output = Cog::Output.new
+    end
 
-      test "raw_text raises NotImplementedError" do
-        assert_raises(NotImplementedError) do
-          @output.send(:raw_text)
+    test "raw_text raises NotImplementedError" do
+      assert_raises(NotImplementedError) do
+        @output.send(:raw_text)
+      end
+    end
+
+    test "subclass can override raw_text" do
+      subclass = Class.new(Cog::Output) do
+        def raw_text
+          "custom output"
         end
       end
 
-      test "subclass can override raw_text" do
-        subclass = Class.new(Output) do
-          def raw_text
-            "custom output"
-          end
+      output = subclass.new
+
+      assert_equal "custom output", output.send(:raw_text)
+    end
+
+    # Test Output subclasses with JSON parsing capabilities
+    test "output with JSON support parses valid JSON" do
+      json_output = Class.new(Cog::Output) do
+        include Cog::Output::WithJson
+
+        def raw_text
+          '{"key": "value"}'
         end
+      end.new
+
+      assert_equal({ key: "value" }, json_output.json!)
+    end
 
-        output = subclass.new
+    test "output with JSON support raises error on invalid JSON with json!" do
+      json_output = Class.new(Cog::Output) do
+        include Cog::Output::WithJson
 
-        assert_equal "custom output", output.send(:raw_text)
-      end
+        def raw_text
+          "not json"
+        end
+      end.new
+
+      assert_raises(JSON::ParserError) { json_output.json! }
+    end
 
-      # Test Output subclasses with JSON parsing capabilities
-      test "output with JSON support parses valid JSON" do
-        json_output = Class.new(Output) do
-          include Output::WithJson
+    test "output with JSON support returns nil on invalid JSON with json" do
+      json_output = Class.new(Cog::Output) do
+        include Cog::Output::WithJson
 
-          def raw_text
-            '{"key": "value"}'
-          end
-        end.new
+        def raw_text
+          "not json"
+        end
+      end.new
+
+      assert_nil json_output.json
+    end
 
-        assert_equal({ key: "value" }, json_output.json!)
-      end
+    test "output with JSON support handles empty input" do
+      json_output = Class.new(Cog::Output) do
+        include Cog::Output::WithJson
 
-      test "output with JSON support raises error on invalid JSON with json!" do
-        json_output = Class.new(Output) do
-          include Output::WithJson
+        def raw_text
+          nil
+        end
+      end.new
+
+      assert_equal({}, json_output.json!)
+    end
 
-          def raw_text
-            "not json"
-          end
-        end.new
+    test "output with JSON support extracts JSON from markdown code blocks" do
+      json_output = Class.new(Cog::Output) do
+        include Cog::Output::WithJson
 
-        assert_raises(JSON::ParserError) { json_output.json! }
-      end
+        def raw_text
+          "Here's some JSON:\n```json\n{\"key\": \"value\"}\n```"
+        end
+      end.new
+
+      assert_equal({ key: "value" }, json_output.json!)
+    end
 
-      test "output with JSON support returns nil on invalid JSON with json" do
-        json_output = Class.new(Output) do
-          include Output::WithJson
+    test "output with JSON support extracts JSON-like blocks from text" do
+      json_output = Class.new(Cog::Output) do
+        include Cog::Output::WithJson
 
-          def raw_text
-            "not json"
-          end
-        end.new
+        def raw_text
+          "Some text before\n{\"key\": \"value\"}\nSome text after"
+        end
+      end.new
+
+      assert_equal({ key: "value" }, json_output.json!)
+    end
 
-        assert_nil json_output.json
-      end
+    # Test Output subclasses with number parsing capabilities
+    test "output with number support parses floats" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "42.5"
+        end
+      end.new
 
-      test "output with JSON support handles empty input" do
-        json_output = Class.new(Output) do
-          include Output::WithJson
+      assert_equal 42.5, number_output.float!
+    end
+
+    test "output with number support parses integers as floats" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "42"
+        end
+      end.new
 
-          def raw_text
-            nil
-          end
-        end.new
+      assert_equal 42.0, number_output.float!
+    end
+
+    test "output with number support raises error on invalid number with float!" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "not a number"
+        end
+      end.new
 
-        assert_equal({}, json_output.json!)
-      end
+      assert_raises(ArgumentError) { number_output.float! }
+    end
+
+    test "output with number support returns nil on invalid number with float" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "not a number"
+        end
+      end.new
 
-      test "output with JSON support extracts JSON from markdown code blocks" do
-        json_output = Class.new(Output) do
-          include Output::WithJson
+      assert_nil number_output.float
+    end
+
+    test "output with number support parses and rounds to integers" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "42.7"
+        end
+      end.new
 
-          def raw_text
-            "Here's some JSON:\n```json\n{\"key\": \"value\"}\n```"
-          end
-        end.new
+      assert_equal 43, number_output.integer!
+    end
+
+    test "output with number support parses integer values" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "42"
+        end
+      end.new
 
-        assert_equal({ key: "value" }, json_output.json!)
-      end
+      assert_equal 42, number_output.integer!
+    end
+
+    test "output with number support returns nil on invalid integer" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "not a number"
+        end
+      end.new
 
-      test "output with JSON support extracts JSON-like blocks from text" do
-        json_output = Class.new(Output) do
-          include Output::WithJson
-
-          def raw_text
-            "Some text before\n{\"key\": \"value\"}\nSome text after"
-          end
-        end.new
-
-        assert_equal({ key: "value" }, json_output.json!)
-      end
-
-      # Test Output subclasses with number parsing capabilities
-      test "output with number support parses floats" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "42.5"
-          end
-        end.new
-
-        assert_equal 42.5, number_output.float!
-      end
-
-      test "output with number support parses integers as floats" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "42"
-          end
-        end.new
-
-        assert_equal 42.0, number_output.float!
-      end
-
-      test "output with number support raises error on invalid number with float!" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "not a number"
-          end
-        end.new
-
-        assert_raises(ArgumentError) { number_output.float! }
-      end
-
-      test "output with number support returns nil on invalid number with float" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "not a number"
-          end
-        end.new
-
-        assert_nil number_output.float
-      end
-
-      test "output with number support parses and rounds to integers" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "42.7"
-          end
-        end.new
-
-        assert_equal 43, number_output.integer!
-      end
-
-      test "output with number support parses integer values" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "42"
-          end
-        end.new
-
-        assert_equal 42, number_output.integer!
-      end
-
-      test "output with number support returns nil on invalid integer" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "not a number"
-          end
-        end.new
-
-        assert_nil number_output.integer
-      end
-
-      test "output with number support handles numbers with thousand separators" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "1,234.56"
-          end
-        end.new
-
-        assert_equal 1234.56, number_output.float!
-      end
-
-      test "output with number support handles currency symbols" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "$42.50"
-          end
-        end.new
-
-        assert_equal 42.50, number_output.float!
-      end
-
-      test "output with number support extracts last number from a line with multiple numbers" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "12 - 5 = 7"
-          end
-        end.new
-
-        assert_equal 7, number_output.integer!
-      end
-
-      test "output with number support extracts last number from arithmetic expression" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "2 + 2 = 4"
-          end
-        end.new
-
-        assert_equal 4, number_output.integer!
-      end
-
-      test "output with number support extracts last number from multi-line response" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "First I calculated 2 + 2 = 4\nThen I multiplied 4 * 3 = 12\nFinally 12 - 5 = 7"
-          end
-        end.new
-
-        assert_equal 7, number_output.integer!
-      end
-
-      test "output with number support extracts last number from sentence with embedded numbers" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "The answer to 100 divided by 4 is 25"
-          end
-        end.new
-
-        assert_equal 25, number_output.integer!
-      end
-
-      test "output with number support extracts last float from a line with multiple numbers" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "3.14 * 2 = 6.28"
-          end
-        end.new
-
-        assert_in_delta 6.28, number_output.float!
-      end
-
-      test "output with number support prefers last line last number over earlier lines" do
-        number_output = Class.new(Output) do
-          include Output::WithNumber
-
-          def raw_text
-            "Step 1: 100\nStep 2: 50\nResult: 42"
-          end
-        end.new
-
-        assert_equal 42, number_output.integer!
-      end
-
-      # Test Output subclasses with text formatting capabilities
-      test "output with text support returns stripped text" do
-        text_output = Class.new(Output) do
-          include Output::WithText
-
-          def raw_text
-            "  hello world  \n"
-          end
-        end.new
-
-        assert_equal "hello world", text_output.text
-      end
-
-      test "output with text support returns lines as array" do
-        text_output = Class.new(Output) do
-          include Output::WithText
-
-          def raw_text
-            "  line1  \n  line2  \n  line3  "
-          end
-        end.new
-
-        assert_equal ["line1", "line2", "line3"], text_output.lines
-      end
-
-      test "output with text support handles empty text" do
-        text_output = Class.new(Output) do
-          include Output::WithText
-
-          def raw_text
-            "   \n   "
-          end
-        end.new
-
-        assert_equal "", text_output.text
-      end
+      assert_nil number_output.integer
+    end
+
+    test "output with number support handles numbers with thousand separators" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "1,234.56"
+        end
+      end.new
+
+      assert_equal 1234.56, number_output.float!
+    end
+
+    test "output with number support handles currency symbols" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "$42.50"
+        end
+      end.new
+
+      assert_equal 42.50, number_output.float!
+    end
+
+    test "output with number support extracts last number from a line with multiple numbers" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "12 - 5 = 7"
+        end
+      end.new
+
+      assert_equal 7, number_output.integer!
+    end
+
+    test "output with number support extracts last number from arithmetic expression" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "2 + 2 = 4"
+        end
+      end.new
+
+      assert_equal 4, number_output.integer!
+    end
+
+    test "output with number support extracts last number from multi-line response" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "First I calculated 2 + 2 = 4\nThen I multiplied 4 * 3 = 12\nFinally 12 - 5 = 7"
+        end
+      end.new
+
+      assert_equal 7, number_output.integer!
+    end
+
+    test "output with number support extracts last number from sentence with embedded numbers" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "The answer to 100 divided by 4 is 25"
+        end
+      end.new
+
+      assert_equal 25, number_output.integer!
+    end
+
+    test "output with number support extracts last float from a line with multiple numbers" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "3.14 * 2 = 6.28"
+        end
+      end.new
+
+      assert_in_delta 6.28, number_output.float!
+    end
+
+    test "output with number support prefers last line last number over earlier lines" do
+      number_output = Class.new(Cog::Output) do
+        include Cog::Output::WithNumber
+
+        def raw_text
+          "Step 1: 100\nStep 2: 50\nResult: 42"
+        end
+      end.new
+
+      assert_equal 42, number_output.integer!
+    end
+
+    # Test Output subclasses with text formatting capabilities
+    test "output with text support returns stripped text" do
+      text_output = Class.new(Cog::Output) do
+        include Cog::Output::WithText
+
+        def raw_text
+          "  hello world  \n"
+        end
+      end.new
+
+      assert_equal "hello world", text_output.text
+    end
+
+    test "output with text support returns lines as array" do
+      text_output = Class.new(Cog::Output) do
+        include Cog::Output::WithText
+
+        def raw_text
+          "  line1  \n  line2  \n  line3  "
+        end
+      end.new
+
+      assert_equal ["line1", "line2", "line3"], text_output.lines
+    end
+
+    test "output with text support handles empty text" do
+      text_output = Class.new(Cog::Output) do
+        include Cog::Output::WithText
+
+        def raw_text
+          "   \n   "
+        end
+      end.new
+
+      assert_equal "", text_output.text
     end
   end
 end

--- a/test/roast/cog/registry_test.rb
+++ b/test/roast/cog/registry_test.rb
@@ -3,71 +3,69 @@
 require "test_helper"
 
 module Roast
-  class Cog
-    class RegistryTest < ActiveSupport::TestCase
-      def setup
-        @registry = Registry.new
+  class Cog::RegistryTest < ActiveSupport::TestCase
+    def setup
+      @registry = Cog::Registry.new
+    end
+
+    test "initialize registers system cogs" do
+      assert @registry.cogs.key?(:call)
+      assert @registry.cogs.key?(:map)
+      assert @registry.cogs.key?(:repeat)
+    end
+
+    test "initialize registers standard cogs" do
+      assert @registry.cogs.key?(:cmd)
+      assert @registry.cogs.key?(:chat)
+      assert @registry.cogs.key?(:agent)
+      assert @registry.cogs.key?(:ruby)
+    end
+
+    test "use registers a cog class by derived name" do
+      custom_cog = Class.new(Cog)
+      # Give it a name by assigning to a constant
+      self.class.const_set(:CustomTestCog, custom_cog)
+
+      @registry.use(self.class::CustomTestCog)
+
+      assert @registry.cogs.key?(:custom_test_cog)
+      assert_equal self.class::CustomTestCog, @registry.cogs[:custom_test_cog]
+    ensure
+      self.class.send(:remove_const, :CustomTestCog) if self.class.const_defined?(:CustomTestCog)
+    end
+
+    test "use overwrites existing cog with same name" do
+      first_cog = Class.new(Cog)
+      second_cog = Class.new(Cog)
+      self.class.const_set(:OverwriteCog, first_cog)
+
+      @registry.use(self.class::OverwriteCog)
+      assert_equal first_cog, @registry.cogs[:overwrite_cog]
+
+      # Reassign constant to second cog class
+      self.class.send(:remove_const, :OverwriteCog)
+      self.class.const_set(:OverwriteCog, second_cog)
+
+      @registry.use(self.class::OverwriteCog)
+      assert_equal second_cog, @registry.cogs[:overwrite_cog]
+    ensure
+      self.class.send(:remove_const, :OverwriteCog) if self.class.const_defined?(:OverwriteCog)
+    end
+
+    test "use raises CouldNotDeriveCogNameError for anonymous class" do
+      anonymous_cog = Class.new(Cog)
+
+      assert_raises(Cog::Registry::CouldNotDeriveCogNameError) do
+        @registry.use(anonymous_cog)
       end
+    end
 
-      test "initialize registers system cogs" do
-        assert @registry.cogs.key?(:call)
-        assert @registry.cogs.key?(:map)
-        assert @registry.cogs.key?(:repeat)
-      end
-
-      test "initialize registers standard cogs" do
-        assert @registry.cogs.key?(:cmd)
-        assert @registry.cogs.key?(:chat)
-        assert @registry.cogs.key?(:agent)
-        assert @registry.cogs.key?(:ruby)
-      end
-
-      test "use registers a cog class by derived name" do
-        custom_cog = Class.new(Cog)
-        # Give it a name by assigning to a constant
-        self.class.const_set(:CustomTestCog, custom_cog)
-
-        @registry.use(self.class::CustomTestCog)
-
-        assert @registry.cogs.key?(:custom_test_cog)
-        assert_equal self.class::CustomTestCog, @registry.cogs[:custom_test_cog]
-      ensure
-        self.class.send(:remove_const, :CustomTestCog) if self.class.const_defined?(:CustomTestCog)
-      end
-
-      test "use overwrites existing cog with same name" do
-        first_cog = Class.new(Cog)
-        second_cog = Class.new(Cog)
-        self.class.const_set(:OverwriteCog, first_cog)
-
-        @registry.use(self.class::OverwriteCog)
-        assert_equal first_cog, @registry.cogs[:overwrite_cog]
-
-        # Reassign constant to second cog class
-        self.class.send(:remove_const, :OverwriteCog)
-        self.class.const_set(:OverwriteCog, second_cog)
-
-        @registry.use(self.class::OverwriteCog)
-        assert_equal second_cog, @registry.cogs[:overwrite_cog]
-      ensure
-        self.class.send(:remove_const, :OverwriteCog) if self.class.const_defined?(:OverwriteCog)
-      end
-
-      test "use raises CouldNotDeriveCogNameError for anonymous class" do
-        anonymous_cog = Class.new(Cog)
-
-        assert_raises(Registry::CouldNotDeriveCogNameError) do
-          @registry.use(anonymous_cog)
-        end
-      end
-
-      test "use derives name from demodulized underscored class name" do
-        # The standard cogs demonstrate this:
-        # Roast::Cogs::Agent -> :agent
-        # Roast::Cogs::Cmd -> :cmd
-        assert_equal Cogs::Agent, @registry.cogs[:agent]
-        assert_equal Cogs::Cmd, @registry.cogs[:cmd]
-      end
+    test "use derives name from demodulized underscored class name" do
+      # The standard cogs demonstrate this:
+      # Roast::Cogs::Agent -> :agent
+      # Roast::Cogs::Cmd -> :cmd
+      assert_equal Cogs::Agent, @registry.cogs[:agent]
+      assert_equal Cogs::Cmd, @registry.cogs[:cmd]
     end
   end
 end

--- a/test/roast/cog/stack_test.rb
+++ b/test/roast/cog/stack_test.rb
@@ -3,65 +3,63 @@
 require "test_helper"
 
 module Roast
-  class Cog
-    class StackTest < ActiveSupport::TestCase
-      def setup
-        @stack = Stack.new
-      end
+  class Cog::StackTest < ActiveSupport::TestCase
+    def setup
+      @stack = Cog::Stack.new
+    end
 
-      test "initialize creates empty stack" do
-        assert @stack.empty?
-        assert_equal 0, @stack.size
-      end
+    test "initialize creates empty stack" do
+      assert @stack.empty?
+      assert_equal 0, @stack.size
+    end
 
-      test "push adds items to the stack" do
-        @stack.push(:first)
-        @stack.push(:second)
+    test "push adds items to the stack" do
+      @stack.push(:first)
+      @stack.push(:second)
 
-        assert_equal 2, @stack.size
-        refute @stack.empty?
-      end
+      assert_equal 2, @stack.size
+      refute @stack.empty?
+    end
 
-      test "pop removes and returns items in FIFO order" do
-        @stack.push(:first)
-        @stack.push(:second)
-        @stack.push(:third)
+    test "pop removes and returns items in FIFO order" do
+      @stack.push(:first)
+      @stack.push(:second)
+      @stack.push(:third)
 
-        assert_equal :first, @stack.pop
-        assert_equal :second, @stack.pop
-        assert_equal :third, @stack.pop
-      end
+      assert_equal :first, @stack.pop
+      assert_equal :second, @stack.pop
+      assert_equal :third, @stack.pop
+    end
 
-      test "pop returns nil when stack is empty" do
-        assert_nil @stack.pop
-      end
+    test "pop returns nil when stack is empty" do
+      assert_nil @stack.pop
+    end
 
-      test "last returns the most recently pushed item" do
-        @stack.push(:first)
-        @stack.push(:second)
+    test "last returns the most recently pushed item" do
+      @stack.push(:first)
+      @stack.push(:second)
 
-        assert_equal :second, @stack.last
-      end
+      assert_equal :second, @stack.last
+    end
 
-      test "each iterates over all items" do
-        @stack.push(:first)
-        @stack.push(:second)
+    test "each iterates over all items" do
+      @stack.push(:first)
+      @stack.push(:second)
 
-        items = []
-        @stack.each { |item| items << item }
+      items = []
+      @stack.each { |item| items << item }
 
-        assert_equal [:first, :second], items
-      end
+      assert_equal [:first, :second], items
+    end
 
-      test "map transforms all items" do
-        @stack.push(1)
-        @stack.push(2)
-        @stack.push(3)
+    test "map transforms all items" do
+      @stack.push(1)
+      @stack.push(2)
+      @stack.push(3)
 
-        result = @stack.map { |n| n * 2 }
+      result = @stack.map { |n| n * 2 }
 
-        assert_equal [2, 4, 6], result
-      end
+      assert_equal [2, 4, 6], result
     end
   end
 end

--- a/test/roast/cog/store_test.rb
+++ b/test/roast/cog/store_test.rb
@@ -3,68 +3,66 @@
 require "test_helper"
 
 module Roast
-  class Cog
-    class StoreTest < ActiveSupport::TestCase
-      def setup
-        @store = Store.new
-        @cog1 = Cog.new(:test_cog, ->(_input) { "result" })
-        @cog2 = Cog.new(:another_cog, ->(_input) { "result2" })
+  class Cog::StoreTest < ActiveSupport::TestCase
+    def setup
+      @store = Cog::Store.new
+      @cog1 = Cog.new(:test_cog, ->(_input) { "result" })
+      @cog2 = Cog.new(:another_cog, ->(_input) { "result2" })
+    end
+
+    test "insert adds cog to store" do
+      result = @store.insert(@cog1)
+
+      assert_equal @cog1, result
+      assert_equal @cog1, @store.store[:test_cog]
+    end
+
+    test "insert multiple cogs with different names" do
+      @store.insert(@cog1)
+      @store.insert(@cog2)
+
+      assert_equal @cog1, @store.store[:test_cog]
+      assert_equal @cog2, @store.store[:another_cog]
+      assert_equal 2, @store.store.size
+    end
+
+    test "insert raises CogAlreadyDefinedError for duplicate cog name" do
+      @store.insert(@cog1)
+
+      duplicate_cog = Cog.new(:test_cog, ->(_input) { "different result" })
+
+      error = assert_raises(Cog::Store::CogAlreadyDefinedError) do
+        @store.insert(duplicate_cog)
       end
 
-      test "insert adds cog to store" do
-        result = @store.insert(@cog1)
+      assert_equal "test_cog", error.message
+    end
 
-        assert_equal @cog1, result
-        assert_equal @cog1, @store.store[:test_cog]
-      end
+    test "[] delegates to store hash" do
+      @store.insert(@cog1)
 
-      test "insert multiple cogs with different names" do
-        @store.insert(@cog1)
-        @store.insert(@cog2)
+      assert_equal @cog1, @store[:test_cog]
+    end
 
-        assert_equal @cog1, @store.store[:test_cog]
-        assert_equal @cog2, @store.store[:another_cog]
-        assert_equal 2, @store.store.size
-      end
+    test "[] returns nil for non-existent key" do
+      assert_nil @store[:non_existent]
+    end
 
-      test "insert raises CogAlreadyDefinedError for duplicate cog name" do
-        @store.insert(@cog1)
+    test "key? delegates to store hash" do
+      @store.insert(@cog1)
 
-        duplicate_cog = Cog.new(:test_cog, ->(_input) { "different result" })
+      assert @store.key?(:test_cog)
+      refute @store.key?(:non_existent)
+    end
 
-        error = assert_raises(Store::CogAlreadyDefinedError) do
-          @store.insert(duplicate_cog)
-        end
+    test "key? returns false for empty store" do
+      refute @store.key?(:anything)
+    end
 
-        assert_equal "test_cog", error.message
-      end
+    test "insert returns the cog" do
+      result = @store.insert(@cog1)
 
-      test "[] delegates to store hash" do
-        @store.insert(@cog1)
-
-        assert_equal @cog1, @store[:test_cog]
-      end
-
-      test "[] returns nil for non-existent key" do
-        assert_nil @store[:non_existent]
-      end
-
-      test "key? delegates to store hash" do
-        @store.insert(@cog1)
-
-        assert @store.key?(:test_cog)
-        refute @store.key?(:non_existent)
-      end
-
-      test "key? returns false for empty store" do
-        refute @store.key?(:anything)
-      end
-
-      test "insert returns the cog" do
-        result = @store.insert(@cog1)
-
-        assert_same @cog1, result
-      end
+      assert_same @cog1, result
     end
   end
 end

--- a/test/roast/cogs/agent/config_test.rb
+++ b/test/roast/cogs/agent/config_test.rb
@@ -4,289 +4,287 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      class ConfigTest < ActiveSupport::TestCase
-        def setup
-          @config = Config.new
-          @default_provider = Config::VALID_PROVIDERS.first
+    class Agent::ConfigTest < ActiveSupport::TestCase
+      def setup
+        @config = Agent::Config.new
+        @default_provider = Agent::Config::VALID_PROVIDERS.first
+      end
+
+      # Provider configuration tests
+      test "provider sets provider value" do
+        @config.provider(@default_provider)
+
+        assert_equal @default_provider, @config.valid_provider!
+      end
+
+      test "use_default_provider! clears provider value" do
+        @config.provider(:fake_provider)
+        @config.use_default_provider!
+
+        assert_equal @default_provider, @config.valid_provider!
+      end
+
+      test "valid_provider! returns default when not set" do
+        assert_equal @default_provider, @config.valid_provider!
+      end
+
+      test "valid_provider! raises on invalid provider" do
+        @config.provider(:invalid_provider)
+
+        error = assert_raises(ArgumentError) do
+          @config.valid_provider!
         end
 
-        # Provider configuration tests
-        test "provider sets provider value" do
-          @config.provider(@default_provider)
+        assert_match(/invalid_provider.*not a valid provider/, error.message)
+      end
 
-          assert_equal @default_provider, @config.valid_provider!
-        end
+      # Command configuration tests
+      test "command sets command value" do
+        @config.command("test-command")
 
-        test "use_default_provider! clears provider value" do
-          @config.provider(:fake_provider)
-          @config.use_default_provider!
+        assert_equal "test-command", @config.valid_command
+      end
 
-          assert_equal @default_provider, @config.valid_provider!
-        end
+      test "command accepts array" do
+        @config.command(["test-cmd", "arg1", "arg2"])
 
-        test "valid_provider! returns default when not set" do
-          assert_equal @default_provider, @config.valid_provider!
-        end
+        assert_equal ["test-cmd", "arg1", "arg2"], @config.valid_command
+      end
 
-        test "valid_provider! raises on invalid provider" do
-          @config.provider(:invalid_provider)
+      test "use_default_command! clears command value" do
+        @config.command("test-command")
+        @config.use_default_command!
 
-          error = assert_raises(ArgumentError) do
-            @config.valid_provider!
-          end
+        assert_nil @config.valid_command
+      end
 
-          assert_match(/invalid_provider.*not a valid provider/, error.message)
-        end
+      test "valid_command returns nil when not set" do
+        assert_nil @config.valid_command
+      end
 
-        # Command configuration tests
-        test "command sets command value" do
-          @config.command("test-command")
+      test "valid_command returns nil for empty string" do
+        @config.command("")
 
-          assert_equal "test-command", @config.valid_command
-        end
+        assert_nil @config.valid_command
+      end
 
-        test "command accepts array" do
-          @config.command(["test-cmd", "arg1", "arg2"])
+      # Model configuration tests
+      test "model sets model value" do
+        @config.model("test-model")
 
-          assert_equal ["test-cmd", "arg1", "arg2"], @config.valid_command
-        end
+        assert_equal "test-model", @config.valid_model
+      end
 
-        test "use_default_command! clears command value" do
-          @config.command("test-command")
-          @config.use_default_command!
+      test "use_default_model! clears model value" do
+        @config.model("test-model")
+        @config.use_default_model!
 
-          assert_nil @config.valid_command
-        end
+        assert_nil @config.valid_model
+      end
 
-        test "valid_command returns nil when not set" do
-          assert_nil @config.valid_command
-        end
+      test "valid_model returns nil when not set" do
+        assert_nil @config.valid_model
+      end
 
-        test "valid_command returns nil for empty string" do
-          @config.command("")
+      # System prompt configuration tests
+      test "replace_system_prompt sets replacement prompt" do
+        @config.replace_system_prompt("Custom prompt")
 
-          assert_nil @config.valid_command
-        end
+        assert_equal "Custom prompt", @config.valid_replace_system_prompt
+      end
 
-        # Model configuration tests
-        test "model sets model value" do
-          @config.model("test-model")
+      test "no_replace_system_prompt! clears replacement prompt" do
+        @config.replace_system_prompt("Custom")
+        @config.no_replace_system_prompt!
 
-          assert_equal "test-model", @config.valid_model
-        end
+        assert_nil @config.valid_replace_system_prompt
+      end
 
-        test "use_default_model! clears model value" do
-          @config.model("test-model")
-          @config.use_default_model!
+      test "valid_replace_system_prompt returns nil when not set" do
+        assert_nil @config.valid_replace_system_prompt
+      end
 
-          assert_nil @config.valid_model
-        end
+      test "append_system_prompt sets appended prompt" do
+        @config.append_system_prompt("Additional instructions")
 
-        test "valid_model returns nil when not set" do
-          assert_nil @config.valid_model
-        end
+        assert_equal "Additional instructions", @config.valid_append_system_prompt
+      end
 
-        # System prompt configuration tests
-        test "replace_system_prompt sets replacement prompt" do
-          @config.replace_system_prompt("Custom prompt")
+      test "no_append_system_prompt! clears appended prompt" do
+        @config.append_system_prompt("Additional")
+        @config.no_append_system_prompt!
 
-          assert_equal "Custom prompt", @config.valid_replace_system_prompt
-        end
+        assert_nil @config.valid_append_system_prompt
+      end
 
-        test "no_replace_system_prompt! clears replacement prompt" do
-          @config.replace_system_prompt("Custom")
-          @config.no_replace_system_prompt!
+      test "valid_append_system_prompt returns nil when not set" do
+        assert_nil @config.valid_append_system_prompt
+      end
 
-          assert_nil @config.valid_replace_system_prompt
-        end
+      # Permissions configuration tests
+      test "apply_permissions! enables permissions" do
+        # ensure that configured value is initially the opposite of what we want to test
+        @config.no_apply_permissions!
+        refute @config.apply_permissions?
 
-        test "valid_replace_system_prompt returns nil when not set" do
-          assert_nil @config.valid_replace_system_prompt
-        end
+        @config.apply_permissions!
 
-        test "append_system_prompt sets appended prompt" do
-          @config.append_system_prompt("Additional instructions")
+        assert @config.apply_permissions?
+      end
 
-          assert_equal "Additional instructions", @config.valid_append_system_prompt
-        end
+      test "no_apply_permissions! disables permissions" do
+        # ensure that configured value is initially the opposite of what we want to test
+        @config.apply_permissions!
+        assert @config.apply_permissions?
 
-        test "no_append_system_prompt! clears appended prompt" do
-          @config.append_system_prompt("Additional")
-          @config.no_append_system_prompt!
+        @config.no_apply_permissions!
 
-          assert_nil @config.valid_append_system_prompt
-        end
+        refute @config.apply_permissions?
+      end
 
-        test "valid_append_system_prompt returns nil when not set" do
-          assert_nil @config.valid_append_system_prompt
-        end
+      test "apply_permissions? returns true by default" do
+        assert @config.apply_permissions?
+      end
 
-        # Permissions configuration tests
-        test "apply_permissions! enables permissions" do
-          # ensure that configured value is initially the opposite of what we want to test
-          @config.no_apply_permissions!
-          refute @config.apply_permissions?
+      test "skip_permissions! is alias for no_apply_permissions!" do
+        # ensure that configured value is initially the opposite of what we want to test
+        @config.apply_permissions!
+        assert @config.apply_permissions?
 
-          @config.apply_permissions!
+        @config.skip_permissions!
 
-          assert @config.apply_permissions?
-        end
+        refute @config.apply_permissions?
+      end
 
-        test "no_apply_permissions! disables permissions" do
-          # ensure that configured value is initially the opposite of what we want to test
-          @config.apply_permissions!
-          assert @config.apply_permissions?
+      test "no_skip_permissions! is alias for apply_permissions!" do
+        # ensure that configured value is initially the opposite of what we want to test
+        @config.no_apply_permissions!
+        refute @config.apply_permissions?
 
-          @config.no_apply_permissions!
+        @config.no_skip_permissions!
 
-          refute @config.apply_permissions?
-        end
+        assert @config.apply_permissions?
+      end
 
-        test "apply_permissions? returns true by default" do
-          assert @config.apply_permissions?
-        end
+      # Display configuration tests
+      test "show_prompt! enables prompt display" do
+        @config.show_prompt!
 
-        test "skip_permissions! is alias for no_apply_permissions!" do
-          # ensure that configured value is initially the opposite of what we want to test
-          @config.apply_permissions!
-          assert @config.apply_permissions?
+        assert @config.show_prompt?
+      end
 
-          @config.skip_permissions!
+      test "no_show_prompt! disables prompt display" do
+        @config.show_prompt!
+        @config.no_show_prompt!
 
-          refute @config.apply_permissions?
-        end
+        refute @config.show_prompt?
+      end
 
-        test "no_skip_permissions! is alias for apply_permissions!" do
-          # ensure that configured value is initially the opposite of what we want to test
-          @config.no_apply_permissions!
-          refute @config.apply_permissions?
+      test "show_prompt? returns false by default" do
+        refute @config.show_prompt?
+      end
 
-          @config.no_skip_permissions!
+      test "show_progress! enables progress display" do
+        @config.show_progress!
 
-          assert @config.apply_permissions?
-        end
+        assert @config.show_progress?
+      end
 
-        # Display configuration tests
-        test "show_prompt! enables prompt display" do
-          @config.show_prompt!
+      test "no_show_progress! disables progress display" do
+        @config.no_show_progress!
 
-          assert @config.show_prompt?
-        end
+        refute @config.show_progress?
+      end
 
-        test "no_show_prompt! disables prompt display" do
-          @config.show_prompt!
-          @config.no_show_prompt!
+      test "show_progress? returns true by default" do
+        assert @config.show_progress?
+      end
 
-          refute @config.show_prompt?
-        end
+      test "show_response! enables response display" do
+        @config.show_response!
 
-        test "show_prompt? returns false by default" do
-          refute @config.show_prompt?
-        end
+        assert @config.show_response?
+      end
 
-        test "show_progress! enables progress display" do
-          @config.show_progress!
+      test "no_show_response! disables response display" do
+        @config.no_show_response!
 
-          assert @config.show_progress?
-        end
+        refute @config.show_response?
+      end
 
-        test "no_show_progress! disables progress display" do
-          @config.no_show_progress!
+      test "show_response? returns true by default" do
+        assert @config.show_response?
+      end
 
-          refute @config.show_progress?
-        end
+      test "show_stats! enables stats display" do
+        @config.show_stats!
 
-        test "show_progress? returns true by default" do
-          assert @config.show_progress?
-        end
+        assert @config.show_stats?
+      end
 
-        test "show_response! enables response display" do
-          @config.show_response!
+      test "no_show_stats! disables stats display" do
+        @config.no_show_stats!
 
-          assert @config.show_response?
-        end
+        refute @config.show_stats?
+      end
 
-        test "no_show_response! disables response display" do
-          @config.no_show_response!
+      test "show_stats? returns true by default" do
+        assert @config.show_stats?
+      end
 
-          refute @config.show_response?
-        end
+      test "display! enables all display options" do
+        @config.no_display!
+        @config.display!
 
-        test "show_response? returns true by default" do
-          assert @config.show_response?
-        end
+        assert @config.show_prompt?
+        assert @config.show_progress?
+        assert @config.show_response?
+        assert @config.show_stats?
+      end
 
-        test "show_stats! enables stats display" do
-          @config.show_stats!
+      test "no_display! disables all display options" do
+        @config.display!
+        @config.no_display!
 
-          assert @config.show_stats?
-        end
+        refute @config.show_prompt?
+        refute @config.show_progress?
+        refute @config.show_response?
+        refute @config.show_stats?
+      end
 
-        test "no_show_stats! disables stats display" do
-          @config.no_show_stats!
+      test "quiet! is alias for no_display!" do
+        @config.display!
+        @config.quiet!
 
-          refute @config.show_stats?
-        end
+        refute @config.show_prompt?
+        refute @config.show_progress?
+        refute @config.show_response?
+        refute @config.show_stats?
+      end
 
-        test "show_stats? returns true by default" do
-          assert @config.show_stats?
-        end
+      test "display? returns true when any display option is enabled" do
+        @config.no_display!
+        @config.show_prompt!
 
-        test "display! enables all display options" do
-          @config.no_display!
-          @config.display!
+        assert @config.display?
+      end
 
-          assert @config.show_prompt?
-          assert @config.show_progress?
-          assert @config.show_response?
-          assert @config.show_stats?
-        end
+      test "display? returns false when all display options are disabled" do
+        @config.no_display!
 
-        test "no_display! disables all display options" do
-          @config.display!
-          @config.no_display!
+        refute @config.display?
+      end
 
-          refute @config.show_prompt?
-          refute @config.show_progress?
-          refute @config.show_response?
-          refute @config.show_stats?
-        end
+      # Debug configuration tests
+      test "dump_raw_agent_messages_to sets dump path" do
+        test_path = File.join(Dir.tmpdir, "messages.log")
+        @config.dump_raw_agent_messages_to(test_path)
 
-        test "quiet! is alias for no_display!" do
-          @config.display!
-          @config.quiet!
+        assert_equal Pathname.new(test_path), @config.valid_dump_raw_agent_messages_to_path
+      end
 
-          refute @config.show_prompt?
-          refute @config.show_progress?
-          refute @config.show_response?
-          refute @config.show_stats?
-        end
-
-        test "display? returns true when any display option is enabled" do
-          @config.no_display!
-          @config.show_prompt!
-
-          assert @config.display?
-        end
-
-        test "display? returns false when all display options are disabled" do
-          @config.no_display!
-
-          refute @config.display?
-        end
-
-        # Debug configuration tests
-        test "dump_raw_agent_messages_to sets dump path" do
-          test_path = File.join(Dir.tmpdir, "messages.log")
-          @config.dump_raw_agent_messages_to(test_path)
-
-          assert_equal Pathname.new(test_path), @config.valid_dump_raw_agent_messages_to_path
-        end
-
-        test "valid_dump_raw_agent_messages_to_path returns nil when not set" do
-          assert_nil @config.valid_dump_raw_agent_messages_to_path
-        end
+      test "valid_dump_raw_agent_messages_to_path returns nil when not set" do
+        assert_nil @config.valid_dump_raw_agent_messages_to_path
       end
     end
   end

--- a/test/roast/cogs/agent/input_test.rb
+++ b/test/roast/cogs/agent/input_test.rb
@@ -4,123 +4,121 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      class InputTest < ActiveSupport::TestCase
-        def setup
-          @input = Input.new
+    class Agent::InputTest < ActiveSupport::TestCase
+      def setup
+        @input = Agent::Input.new
+      end
+
+      test "initialize sets prompts to empty array" do
+        assert_equal [], @input.prompts
+      end
+
+      test "prompt= sets prompts to single-element array" do
+        @input.prompt = "What is 2+2?"
+
+        assert_equal ["What is 2+2?"], @input.prompts
+      end
+
+      test "prompts can be set directly" do
+        @input.prompts = ["First", "Second"]
+
+        assert_equal ["First", "Second"], @input.prompts
+      end
+
+      test "session can be set" do
+        @input.session = "session-123"
+
+        assert_equal "session-123", @input.session
+      end
+
+      test "validate! raises error when prompts is empty" do
+        error = assert_raises(Cog::Input::InvalidInputError) do
+          @input.validate!
         end
 
-        test "initialize sets prompts to empty array" do
-          assert_equal [], @input.prompts
+        assert_equal "At least one prompt is required", error.message
+      end
+
+      test "validate! raises error when any prompt is blank" do
+        @input.prompts = ["Valid prompt", "  ", "Another"]
+
+        error = assert_raises(Cog::Input::InvalidInputError) do
+          @input.validate!
         end
 
-        test "prompt= sets prompts to single-element array" do
-          @input.prompt = "What is 2+2?"
+        assert_equal "Blank prompts are not allowed", error.message
+      end
 
-          assert_equal ["What is 2+2?"], @input.prompts
+      test "validate! succeeds when prompts has at least one element" do
+        @input.prompt = "What is 2+2?"
+
+        assert_nothing_raised do
+          @input.validate!
         end
+      end
 
-        test "prompts can be set directly" do
-          @input.prompts = ["First", "Second"]
+      test "validate! succeeds with multiple prompts" do
+        @input.prompts = ["First", "Second"]
 
-          assert_equal ["First", "Second"], @input.prompts
+        assert_nothing_raised do
+          @input.validate!
         end
+      end
 
-        test "session can be set" do
-          @input.session = "session-123"
+      test "coerce sets prompts from string" do
+        @input.coerce("What is the meaning of life?")
 
-          assert_equal "session-123", @input.session
-        end
+        assert_equal ["What is the meaning of life?"], @input.prompts
+      end
 
-        test "validate! raises error when prompts is empty" do
-          error = assert_raises(Cog::Input::InvalidInputError) do
-            @input.validate!
-          end
+      test "coerce overrides existing prompts" do
+        @input.prompt = "Original prompt"
+        @input.coerce("New prompt")
 
-          assert_equal "At least one prompt is required", error.message
-        end
+        assert_equal ["New prompt"], @input.prompts
+      end
 
-        test "validate! raises error when any prompt is blank" do
-          @input.prompts = ["Valid prompt", "  ", "Another"]
+      test "coerce does nothing for non-string non-array values" do
+        @input.coerce(42)
 
-          error = assert_raises(Cog::Input::InvalidInputError) do
-            @input.validate!
-          end
+        assert_equal [], @input.prompts
+      end
 
-          assert_equal "Blank prompts are not allowed", error.message
-        end
+      test "coerce does nothing for nil" do
+        @input.coerce(nil)
 
-        test "validate! succeeds when prompts has at least one element" do
-          @input.prompt = "What is 2+2?"
+        assert_equal [], @input.prompts
+      end
 
-          assert_nothing_raised do
-            @input.validate!
-          end
-        end
+      test "coerce with array sets all prompts" do
+        @input.coerce(["Main prompt", "Finalizer 1", "Finalizer 2"])
 
-        test "validate! succeeds with multiple prompts" do
-          @input.prompts = ["First", "Second"]
+        assert_equal ["Main prompt", "Finalizer 1", "Finalizer 2"], @input.prompts
+      end
 
-          assert_nothing_raised do
-            @input.validate!
-          end
-        end
+      test "coerce with single-element array" do
+        @input.coerce(["Only prompt"])
 
-        test "coerce sets prompts from string" do
-          @input.coerce("What is the meaning of life?")
+        assert_equal ["Only prompt"], @input.prompts
+      end
 
-          assert_equal ["What is the meaning of life?"], @input.prompts
-        end
+      test "coerce with array converts elements to strings" do
+        @input.coerce(["Main prompt", 42, :symbol])
 
-        test "coerce overrides existing prompts" do
-          @input.prompt = "Original prompt"
-          @input.coerce("New prompt")
+        assert_equal ["Main prompt", "42", "symbol"], @input.prompts
+      end
 
-          assert_equal ["New prompt"], @input.prompts
-        end
+      test "coerce with empty array sets prompts to empty" do
+        @input.coerce([])
 
-        test "coerce does nothing for non-string non-array values" do
-          @input.coerce(42)
+        assert_equal [], @input.prompts
+      end
 
-          assert_equal [], @input.prompts
-        end
+      test "prompt= overrides all existing prompts" do
+        @input.prompts = ["First", "Second", "Third"]
+        @input.prompt = "Only"
 
-        test "coerce does nothing for nil" do
-          @input.coerce(nil)
-
-          assert_equal [], @input.prompts
-        end
-
-        test "coerce with array sets all prompts" do
-          @input.coerce(["Main prompt", "Finalizer 1", "Finalizer 2"])
-
-          assert_equal ["Main prompt", "Finalizer 1", "Finalizer 2"], @input.prompts
-        end
-
-        test "coerce with single-element array" do
-          @input.coerce(["Only prompt"])
-
-          assert_equal ["Only prompt"], @input.prompts
-        end
-
-        test "coerce with array converts elements to strings" do
-          @input.coerce(["Main prompt", 42, :symbol])
-
-          assert_equal ["Main prompt", "42", "symbol"], @input.prompts
-        end
-
-        test "coerce with empty array sets prompts to empty" do
-          @input.coerce([])
-
-          assert_equal [], @input.prompts
-        end
-
-        test "prompt= overrides all existing prompts" do
-          @input.prompts = ["First", "Second", "Third"]
-          @input.prompt = "Only"
-
-          assert_equal ["Only"], @input.prompts
-        end
+        assert_equal ["Only"], @input.prompts
       end
     end
   end

--- a/test/roast/cogs/agent/output_test.rb
+++ b/test/roast/cogs/agent/output_test.rb
@@ -4,65 +4,63 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      class OutputTest < ActiveSupport::TestCase
-        # Test implementation that sets response like real subclasses would
-        class TestOutput < Output
-          def initialize(response:, session: nil, stats: nil)
-            super()
-            @response = response
-            @session = session
-            @stats = stats
-          end
+    class Agent::OutputTest < ActiveSupport::TestCase
+      # Test implementation that sets response like real subclasses would
+      class TestOutput < Agent::Output
+        def initialize(response:, session: nil, stats: nil)
+          super()
+          @response = response
+          @session = session
+          @stats = stats
         end
+      end
 
-        test "provides text parsing from response" do
-          output = TestOutput.new(response: "  Test response  \n")
+      test "provides text parsing from response" do
+        output = TestOutput.new(response: "  Test response  \n")
 
-          assert_equal "Test response", output.text
-        end
+        assert_equal "Test response", output.text
+      end
 
-        test "provides line parsing from response" do
-          output = TestOutput.new(response: "  line1  \n  line2  ")
+      test "provides line parsing from response" do
+        output = TestOutput.new(response: "  line1  \n  line2  ")
 
-          assert_equal ["line1", "line2"], output.lines
-        end
+        assert_equal ["line1", "line2"], output.lines
+      end
 
-        test "provides JSON parsing from response" do
-          output = TestOutput.new(response: '{"key": "value"}')
+      test "provides JSON parsing from response" do
+        output = TestOutput.new(response: '{"key": "value"}')
 
-          assert_equal({ key: "value" }, output.json!)
-        end
+        assert_equal({ key: "value" }, output.json!)
+      end
 
-        test "provides safe JSON parsing from response" do
-          output = TestOutput.new(response: "not json")
+      test "provides safe JSON parsing from response" do
+        output = TestOutput.new(response: "not json")
 
-          assert_nil output.json
-        end
+        assert_nil output.json
+      end
 
-        test "provides float parsing from response" do
-          output = TestOutput.new(response: "42.5")
+      test "provides float parsing from response" do
+        output = TestOutput.new(response: "42.5")
 
-          assert_equal 42.5, output.float!
-        end
+        assert_equal 42.5, output.float!
+      end
 
-        test "provides safe float parsing from response" do
-          output = TestOutput.new(response: "not a number")
+      test "provides safe float parsing from response" do
+        output = TestOutput.new(response: "not a number")
 
-          assert_nil output.float
-        end
+        assert_nil output.float
+      end
 
-        test "provides integer parsing from response" do
-          output = TestOutput.new(response: "42")
+      test "provides integer parsing from response" do
+        output = TestOutput.new(response: "42")
 
-          assert_equal 42, output.integer!
-        end
+        assert_equal 42, output.integer!
+      end
 
-        test "provides safe integer parsing from response" do
-          output = TestOutput.new(response: "not a number")
+      test "provides safe integer parsing from response" do
+        output = TestOutput.new(response: "not a number")
 
-          assert_nil output.integer
-        end
+        assert_nil output.integer
       end
     end
   end

--- a/test/roast/cogs/agent/provider_test.rb
+++ b/test/roast/cogs/agent/provider_test.rb
@@ -4,42 +4,40 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      class ProviderTest < ActiveSupport::TestCase
-        def setup
-          @config = Config.new
-          @provider = Provider.new(@config)
+    class Agent::ProviderTest < ActiveSupport::TestCase
+      def setup
+        @config = Agent::Config.new
+        @provider = Agent::Provider.new(@config)
+      end
+
+      test "initialize stores config" do
+        assert_equal @config, @provider.instance_variable_get(:@config)
+      end
+
+      test "invoke raises NotImplementedError" do
+        input = Agent::Input.new
+
+        error = assert_raises(NotImplementedError) do
+          @provider.invoke(input)
         end
 
-        test "initialize stores config" do
-          assert_equal @config, @provider.instance_variable_get(:@config)
-        end
+        assert_equal "Subclasses must implement #invoke", error.message
+      end
 
-        test "invoke raises NotImplementedError" do
-          input = Input.new
-
-          error = assert_raises(NotImplementedError) do
-            @provider.invoke(input)
+      test "subclass can override invoke" do
+        subclass = Class.new(Agent::Provider) do
+          def invoke(input)
+            output = Agent::Output.new
+            output.instance_variable_set(:@response, "Test response")
+            output
           end
-
-          assert_equal "Subclasses must implement #invoke", error.message
         end
 
-        test "subclass can override invoke" do
-          subclass = Class.new(Provider) do
-            def invoke(input)
-              output = Output.new
-              output.instance_variable_set(:@response, "Test response")
-              output
-            end
-          end
+        provider = subclass.new(@config)
+        input = Agent::Input.new
+        output = provider.invoke(input)
 
-          provider = subclass.new(@config)
-          input = Input.new
-          output = provider.invoke(input)
-
-          assert_equal "Test response", output.response
-        end
+        assert_equal "Test response", output.response
       end
     end
   end

--- a/test/roast/cogs/agent/providers/claude/claude_invocation_test.rb
+++ b/test/roast/cogs/agent/providers/claude/claude_invocation_test.rb
@@ -4,455 +4,451 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          class ClaudeInvocationTest < ActiveSupport::TestCase
-            def setup
-              @config = Agent::Config.new
-              @config.no_display!
-              @invocation = ClaudeInvocation.new(@config, "Test prompt", nil)
+    module Agent::Providers
+      class Claude::ClaudeInvocationTest < ActiveSupport::TestCase
+        def setup
+          @config = Agent::Config.new
+          @config.no_display!
+          @invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil)
+        end
+
+        def success_status
+          mock = Minitest::Mock.new
+          mock.expect(:success?, true)
+          mock
+        end
+
+        def failure_status
+          mock = Minitest::Mock.new
+          mock.expect(:success?, false)
+          mock
+        end
+
+        test "Context#tool_use returns nil when tool_use_id is nil" do
+          context = Claude::ClaudeInvocation::Context.new
+
+          assert_nil context.tool_use(nil)
+        end
+
+        test "Context#tool_use returns nil for unknown tool_use_id" do
+          context = Claude::ClaudeInvocation::Context.new
+
+          assert_nil context.tool_use("unknown_id")
+        end
+
+        test "Context#tool_use returns stored ToolUseMessage for known id" do
+          context = Claude::ClaudeInvocation::Context.new
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { id: "test_id", name: "bash", input: { command: "ls" } },
+          )
+          context.add_tool_use(tool_use_message)
+
+          result = context.tool_use("test_id")
+
+          assert_equal tool_use_message, result
+        end
+
+        test "Context#add_tool_use ignores message with nil id" do
+          context = Claude::ClaudeInvocation::Context.new
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "bash", input: { command: "ls" } },
+          )
+          context.add_tool_use(tool_use_message)
+
+          assert_nil context.tool_use(nil)
+        end
+
+        test "Result initializes with empty response and success false" do
+          result = Claude::ClaudeInvocation::Result.new
+
+          assert_equal "", result.response
+          refute result.success
+          assert_nil result.session
+          assert_nil result.stats
+        end
+
+        test "started? returns false initially" do
+          refute @invocation.started?
+        end
+
+        test "completed? returns false initially" do
+          refute @invocation.completed?
+        end
+
+        test "failed? returns false initially" do
+          refute @invocation.failed?
+        end
+
+        test "running? returns false when not started" do
+          refute @invocation.running?
+        end
+
+        test "result raises ClaudeNotStartedError when not started" do
+          assert_raises(Claude::ClaudeInvocation::ClaudeNotStartedError) do
+            @invocation.result
+          end
+        end
+
+        test "result raises ClaudeFailedError when failed" do
+          CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
+            @invocation.run!
+          end
+
+          assert_raises(Claude::ClaudeInvocation::ClaudeFailedError) do
+            @invocation.result
+          end
+        end
+
+        test "result raises ClaudeNotCompletedError when started but not completed" do
+          CommandRunner.stub(:execute, ->(*) {
+            assert_raises(Claude::ClaudeInvocation::ClaudeNotCompletedError) do
+              @invocation.result
             end
+            ["", "", success_status]
+          }) do
+            @invocation.run!
+          end
+        end
 
-            def success_status
-              mock = Minitest::Mock.new
-              mock.expect(:success?, true)
-              mock
+        test "run! raises ClaudeAlreadyStartedError when called twice" do
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            @invocation.run!
+            assert_raises(Claude::ClaudeInvocation::ClaudeAlreadyStartedError) do
+              @invocation.run!
             end
+          end
+        end
+
+        test "run! sets started to true" do
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            @invocation.run!
+          end
+
+          assert @invocation.started?
+        end
+
+        test "run! sets completed to true on successful execution" do
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            @invocation.run!
+          end
+
+          assert @invocation.completed?
+          refute @invocation.failed?
+        end
 
-            def failure_status
-              mock = Minitest::Mock.new
-              mock.expect(:success?, false)
-              mock
-            end
-
-            test "Context#tool_use returns nil when tool_use_id is nil" do
-              context = ClaudeInvocation::Context.new
-
-              assert_nil context.tool_use(nil)
-            end
-
-            test "Context#tool_use returns nil for unknown tool_use_id" do
-              context = ClaudeInvocation::Context.new
-
-              assert_nil context.tool_use("unknown_id")
-            end
-
-            test "Context#tool_use returns stored ToolUseMessage for known id" do
-              context = ClaudeInvocation::Context.new
-              tool_use_message = Messages::ToolUseMessage.new(
-                type: :tool_use,
-                hash: { id: "test_id", name: "bash", input: { command: "ls" } },
-              )
-              context.add_tool_use(tool_use_message)
-
-              result = context.tool_use("test_id")
-
-              assert_equal tool_use_message, result
-            end
-
-            test "Context#add_tool_use ignores message with nil id" do
-              context = ClaudeInvocation::Context.new
-              tool_use_message = Messages::ToolUseMessage.new(
-                type: :tool_use,
-                hash: { name: "bash", input: { command: "ls" } },
-              )
-              context.add_tool_use(tool_use_message)
-
-              assert_nil context.tool_use(nil)
-            end
-
-            test "Result initializes with empty response and success false" do
-              result = ClaudeInvocation::Result.new
-
-              assert_equal "", result.response
-              refute result.success
-              assert_nil result.session
-              assert_nil result.stats
-            end
-
-            test "started? returns false initially" do
-              refute @invocation.started?
-            end
-
-            test "completed? returns false initially" do
-              refute @invocation.completed?
-            end
-
-            test "failed? returns false initially" do
-              refute @invocation.failed?
-            end
-
-            test "running? returns false when not started" do
-              refute @invocation.running?
-            end
-
-            test "result raises ClaudeNotStartedError when not started" do
-              assert_raises(ClaudeInvocation::ClaudeNotStartedError) do
-                @invocation.result
-              end
-            end
-
-            test "result raises ClaudeFailedError when failed" do
-              CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
-                @invocation.run!
-              end
-
-              assert_raises(ClaudeInvocation::ClaudeFailedError) do
-                @invocation.result
-              end
-            end
-
-            test "result raises ClaudeNotCompletedError when started but not completed" do
-              CommandRunner.stub(:execute, ->(*) {
-                assert_raises(ClaudeInvocation::ClaudeNotCompletedError) do
-                  @invocation.result
-                end
-                ["", "", success_status]
-              }) do
-                @invocation.run!
-              end
-            end
-
-            test "run! raises ClaudeAlreadyStartedError when called twice" do
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                @invocation.run!
-                assert_raises(ClaudeInvocation::ClaudeAlreadyStartedError) do
-                  @invocation.run!
-                end
-              end
-            end
-
-            test "run! sets started to true" do
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                @invocation.run!
-              end
-
-              assert @invocation.started?
-            end
-
-            test "run! sets completed to true on successful execution" do
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                @invocation.run!
-              end
-
-              assert @invocation.completed?
-              refute @invocation.failed?
-            end
+        test "run! sets failed to true on unsuccessful execution" do
+          CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
+            @invocation.run!
+          end
 
-            test "run! sets failed to true on unsuccessful execution" do
-              CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
-                @invocation.run!
-              end
-
-              assert @invocation.failed?
-              refute @invocation.completed?
-            end
-
-            test "running? returns true during execution" do
-              CommandRunner.stub(:execute, ->(*) {
-                assert @invocation.started?
-                assert @invocation.running?
-                ["", "", success_status]
-              }) do
-                @invocation.run!
-              end
-
-              refute @invocation.running?
-            end
+          assert @invocation.failed?
+          refute @invocation.completed?
+        end
 
-            test "result returns Result object when completed successfully" do
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                @invocation.run!
-              end
+        test "running? returns true during execution" do
+          CommandRunner.stub(:execute, ->(*) {
+            assert @invocation.started?
+            assert @invocation.running?
+            ["", "", success_status]
+          }) do
+            @invocation.run!
+          end
+
+          refute @invocation.running?
+        end
 
-              result = @invocation.result
-              assert_kind_of ClaudeInvocation::Result, result
-            end
+        test "result returns Result object when completed successfully" do
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            @invocation.run!
+          end
 
-            test "command_line uses default claude command" do
-              command = @invocation.send(:command_line)
+          result = @invocation.result
+          assert_kind_of Claude::ClaudeInvocation::Result, result
+        end
 
-              assert_equal "claude", command.first
-              assert_includes command, "-p"
-              assert_includes command, "--verbose"
-              assert_includes command, "--output-format"
-              assert_includes command, "stream-json"
-            end
+        test "command_line uses default claude command" do
+          command = @invocation.send(:command_line)
 
-            test "command_line uses custom command when configured as string" do
-              @config.command("custom-claude --flag")
-              invocation = ClaudeInvocation.new(@config, "Test prompt", nil)
+          assert_equal "claude", command.first
+          assert_includes command, "-p"
+          assert_includes command, "--verbose"
+          assert_includes command, "--output-format"
+          assert_includes command, "stream-json"
+        end
 
-              command = invocation.send(:command_line)
+        test "command_line uses custom command when configured as string" do
+          @config.command("custom-claude --flag")
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil)
 
-              assert_equal "custom-claude", command.first
-              assert_includes command, "--flag"
-            end
+          command = invocation.send(:command_line)
 
-            test "command_line uses custom command when configured as array" do
-              @config.command(["my-claude", "--opt"])
-              invocation = ClaudeInvocation.new(@config, "Test prompt", nil)
+          assert_equal "custom-claude", command.first
+          assert_includes command, "--flag"
+        end
 
-              command = invocation.send(:command_line)
+        test "command_line uses custom command when configured as array" do
+          @config.command(["my-claude", "--opt"])
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil)
 
-              assert_equal "my-claude", command.first
-              assert_includes command, "--opt"
-            end
+          command = invocation.send(:command_line)
 
-            test "command_line includes model when configured" do
-              @config.model("claude-opus-4-5-20251101")
-              invocation = ClaudeInvocation.new(@config, "Test prompt", nil)
+          assert_equal "my-claude", command.first
+          assert_includes command, "--opt"
+        end
 
-              command = invocation.send(:command_line)
+        test "command_line includes model when configured" do
+          @config.model("claude-opus-4-5-20251101")
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil)
 
-              model_index = command.index("--model")
-              assert model_index
-              assert_equal "claude-opus-4-5-20251101", command[model_index + 1]
-            end
+          command = invocation.send(:command_line)
 
-            test "command_line includes replace_system_prompt when configured" do
-              @config.replace_system_prompt("Custom system prompt")
-              invocation = ClaudeInvocation.new(@config, "Test prompt", nil)
+          model_index = command.index("--model")
+          assert model_index
+          assert_equal "claude-opus-4-5-20251101", command[model_index + 1]
+        end
 
-              command = invocation.send(:command_line)
+        test "command_line includes replace_system_prompt when configured" do
+          @config.replace_system_prompt("Custom system prompt")
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil)
 
-              prompt_index = command.index("--system-prompt")
-              assert prompt_index
-              assert_equal "Custom system prompt", command[prompt_index + 1]
-            end
+          command = invocation.send(:command_line)
 
-            test "command_line includes append_system_prompt when configured" do
-              @config.append_system_prompt("Additional instructions")
-              invocation = ClaudeInvocation.new(@config, "Test prompt", nil)
+          prompt_index = command.index("--system-prompt")
+          assert prompt_index
+          assert_equal "Custom system prompt", command[prompt_index + 1]
+        end
 
-              command = invocation.send(:command_line)
+        test "command_line includes append_system_prompt when configured" do
+          @config.append_system_prompt("Additional instructions")
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil)
 
-              prompt_index = command.index("--append-system-prompt")
-              assert prompt_index
-              assert_equal "Additional instructions", command[prompt_index + 1]
-            end
+          command = invocation.send(:command_line)
 
-            test "command_line includes fork-session and resume when session is set" do
-              invocation = ClaudeInvocation.new(@config, "Test prompt", "session_123")
+          prompt_index = command.index("--append-system-prompt")
+          assert prompt_index
+          assert_equal "Additional instructions", command[prompt_index + 1]
+        end
 
-              command = invocation.send(:command_line)
+        test "command_line includes fork-session and resume when session is set" do
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", "session_123")
 
-              assert_includes command, "--fork-session"
-              assert_includes command, "--resume"
-              resume_index = command.index("--resume")
-              assert_equal "session_123", command[resume_index + 1]
-            end
+          command = invocation.send(:command_line)
 
-            test "command_line includes resume without fork-session when fork_session is false" do
-              invocation = ClaudeInvocation.new(@config, "Test prompt", "session_123", fork_session: false)
+          assert_includes command, "--fork-session"
+          assert_includes command, "--resume"
+          resume_index = command.index("--resume")
+          assert_equal "session_123", command[resume_index + 1]
+        end
 
-              command = invocation.send(:command_line)
+        test "command_line includes resume without fork-session when fork_session is false" do
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", "session_123", fork_session: false)
 
-              refute_includes command, "--fork-session"
-              assert_includes command, "--resume"
-              resume_index = command.index("--resume")
-              assert_equal "session_123", command[resume_index + 1]
-            end
+          command = invocation.send(:command_line)
 
-            test "command_line omits fork-session when no session is given even if fork_session is true" do
-              invocation = ClaudeInvocation.new(@config, "Test prompt", nil, fork_session: true)
+          refute_includes command, "--fork-session"
+          assert_includes command, "--resume"
+          resume_index = command.index("--resume")
+          assert_equal "session_123", command[resume_index + 1]
+        end
 
-              command = invocation.send(:command_line)
+        test "command_line omits fork-session when no session is given even if fork_session is true" do
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil, fork_session: true)
 
-              refute_includes command, "--fork-session"
-              refute_includes command, "--resume"
-            end
+          command = invocation.send(:command_line)
 
-            test "command_line includes dangerously-skip-permissions when permissions skipped" do
-              @config.skip_permissions!
-              command = @invocation.send(:command_line)
+          refute_includes command, "--fork-session"
+          refute_includes command, "--resume"
+        end
 
-              refute_includes command, "--dangerously-skip-permissions"
-            end
+        test "command_line includes dangerously-skip-permissions when permissions skipped" do
+          @config.skip_permissions!
+          command = @invocation.send(:command_line)
 
-            test "command_line omits dangerously-skip-permissions when permissions applied" do
-              @config.apply_permissions!
-              invocation = ClaudeInvocation.new(@config, "Test prompt", nil)
+          refute_includes command, "--dangerously-skip-permissions"
+        end
 
-              command = invocation.send(:command_line)
+        test "command_line omits dangerously-skip-permissions when permissions applied" do
+          @config.apply_permissions!
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil)
 
-              refute_includes command, "--dangerously-skip-permissions"
-            end
+          command = invocation.send(:command_line)
 
-            test "command_line omits dangerously-skip-permissions by default" do
-              invocation = ClaudeInvocation.new(@config, "Test prompt", nil)
+          refute_includes command, "--dangerously-skip-permissions"
+        end
 
-              command = invocation.send(:command_line)
+        test "command_line omits dangerously-skip-permissions by default" do
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil)
 
-              refute_includes command, "--dangerously-skip-permissions"
-            end
+          command = invocation.send(:command_line)
 
-            test "handle_message processes ResultMessage and sets response" do
-              result_message = Messages::ResultMessage.new(
-                type: :result,
-                hash: { result: "Test response", subtype: "success" },
-              )
+          refute_includes command, "--dangerously-skip-permissions"
+        end
 
-              @invocation.send(:handle_message, result_message)
+        test "handle_message processes ResultMessage and sets response" do
+          result_message = Claude::Messages::ResultMessage.new(
+            type: :result,
+            hash: { result: "Test response", subtype: "success" },
+          )
 
-              internal_result = @invocation.instance_variable_get(:@result)
-              assert_equal "Test response", internal_result.response
-              assert internal_result.success
-            end
+          @invocation.send(:handle_message, result_message)
 
-            test "handle_message processes ToolUseMessage and stores in context" do
-              tool_use_message = Messages::ToolUseMessage.new(
-                type: :tool_use,
-                hash: { id: "tool_123", name: "bash", input: { command: "ls" } },
-              )
+          internal_result = @invocation.instance_variable_get(:@result)
+          assert_equal "Test response", internal_result.response
+          assert internal_result.success
+        end
 
-              @invocation.send(:handle_message, tool_use_message)
+        test "handle_message processes ToolUseMessage and stores in context" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { id: "tool_123", name: "bash", input: { command: "ls" } },
+          )
 
-              context = @invocation.instance_variable_get(:@context)
-              assert_equal tool_use_message, context.tool_use("tool_123")
-            end
+          @invocation.send(:handle_message, tool_use_message)
 
-            test "handle_message processes AssistantMessage recursively" do
-              text_hash = { type: :text, text: "Hello" }
-              assistant_message = Messages::AssistantMessage.new(
-                type: :assistant,
-                hash: { message: { content: [text_hash] } },
-              )
+          context = @invocation.instance_variable_get(:@context)
+          assert_equal tool_use_message, context.tool_use("tool_123")
+        end
 
-              assert_nothing_raised do
-                @invocation.send(:handle_message, assistant_message)
-              end
-            end
+        test "handle_message processes AssistantMessage recursively" do
+          text_hash = { type: :text, text: "Hello" }
+          assistant_message = Claude::Messages::AssistantMessage.new(
+            type: :assistant,
+            hash: { message: { content: [text_hash] } },
+          )
 
-            test "handle_message emits debug event for unparsed message data" do
-              message = Messages::TextMessage.new(
-                type: :text,
-                hash: { text: "Hello", extra_field: "unexpected" },
-              )
-
-              Event.expects(:<<).with { |payload| payload[:debug].include?("Unhandled data") }
-
-              @invocation.send(:handle_message, message)
-            end
-
-            test "handle_message does not emit event when unparsed data is blank" do
-              message = Messages::ResultMessage.new(
-                type: :result,
-                hash: { result: "Test response", subtype: "success" },
-              )
-
-              Event.expects(:<<).never
+          assert_nothing_raised do
+            @invocation.send(:handle_message, assistant_message)
+          end
+        end
 
-              @invocation.send(:handle_message, message)
-            end
-
-            test "handle_message captures session_id when present" do
-              message = Messages::TextMessage.new(
-                type: :text,
-                hash: { text: "Hello", session_id: "new_session" },
-              )
-
-              @invocation.send(:handle_message, message)
-
-              internal_result = @invocation.instance_variable_get(:@result)
-              assert_equal "new_session", internal_result.session
-            end
-
-            test "handle_message emits info event when session_id is set for the first time" do
-              message = Messages::TextMessage.new(
-                type: :text,
-                hash: { text: "Hello", session_id: "first_session" },
-              )
-
-              Event.expects(:<<).with { |payload| payload[:debug] == "New Claude Session ID: first_session" }
-
-              @invocation.send(:handle_message, message)
-            end
-
-            test "handle_message emits info event when session_id changes" do
-              first = Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "session_1" })
-              second = Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "session_2" })
-
-              @invocation.send(:handle_message, first)
-              Event.expects(:<<).with { |payload| payload[:debug] == "New Claude Session ID: session_2" }
-              @invocation.send(:handle_message, second)
-            end
-
-            test "handle_message does not emit event when session_id is unchanged" do
-              first = Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "same_session" })
-              second = Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "same_session" })
-
-              @invocation.send(:handle_message, first)
-              Event.expects(:<<).never
-              @invocation.send(:handle_message, second)
-            end
-
-            test "run! emits USER PROMPT block event when show_prompt is enabled" do
-              @config.show_prompt!
-              invocation = ClaudeInvocation.new(@config, "Hello agent", nil)
-
-              Event.expects(:<<).with do |payload|
-                payload[:block] &&
-                  payload[:block][:header] == "USER PROMPT" &&
-                  payload[:block][:content] == "Hello agent"
-              end
-
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                invocation.run!
-              end
-            end
-
-            test "run! does not emit USER PROMPT block event when show_prompt is disabled" do
-              invocation = ClaudeInvocation.new(@config, "Hello agent", nil)
-
-              Event.expects(:<<).never
-
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                invocation.run!
-              end
-            end
-
-            test "run! emits AGENT RESPONSE block event when show_response is enabled" do
-              @config.show_response!
-              invocation = ClaudeInvocation.new(@config, "Hello agent", nil)
-
-              result_json = { type: "result", subtype: "success", result: "Here is my answer" }.to_json
-              Event.expects(:<<).with do |payload|
-                payload[:block] &&
-                  payload[:block][:header] == "AGENT RESPONSE" &&
-                  payload[:block][:content] == "Here is my answer"
-              end
-
-              CommandRunner.stub(:execute, ->(*_args, **kwargs) {
-                kwargs[:stdout_handler]&.call(result_json)
-                ["", "", success_status]
-              }) do
-                invocation.run!
-              end
-            end
-
-            test "run! does not emit AGENT RESPONSE block event when show_response is disabled" do
-              @config.no_show_response!
-              invocation = ClaudeInvocation.new(@config, "Hello agent", nil)
-
-              Event.expects(:<<).never
-
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                invocation.run!
-              end
-            end
-
-            test "run! does not emit AGENT RESPONSE block event on failure even when show_response is enabled" do
-              @config.show_response!
-              invocation = ClaudeInvocation.new(@config, "Hello agent", nil)
-
-              Event.expects(:<<).never
-
-              CommandRunner.stub(:execute, ["", "Error", failure_status]) do
-                invocation.run!
-              end
-            end
+        test "handle_message emits debug event for unparsed message data" do
+          message = Claude::Messages::TextMessage.new(
+            type: :text,
+            hash: { text: "Hello", extra_field: "unexpected" },
+          )
+
+          Event.expects(:<<).with { |payload| payload[:debug].include?("Unhandled data") }
+
+          @invocation.send(:handle_message, message)
+        end
+
+        test "handle_message does not emit event when unparsed data is blank" do
+          message = Claude::Messages::ResultMessage.new(
+            type: :result,
+            hash: { result: "Test response", subtype: "success" },
+          )
+
+          Event.expects(:<<).never
+
+          @invocation.send(:handle_message, message)
+        end
+
+        test "handle_message captures session_id when present" do
+          message = Claude::Messages::TextMessage.new(
+            type: :text,
+            hash: { text: "Hello", session_id: "new_session" },
+          )
+
+          @invocation.send(:handle_message, message)
+
+          internal_result = @invocation.instance_variable_get(:@result)
+          assert_equal "new_session", internal_result.session
+        end
+
+        test "handle_message emits info event when session_id is set for the first time" do
+          message = Claude::Messages::TextMessage.new(
+            type: :text,
+            hash: { text: "Hello", session_id: "first_session" },
+          )
+
+          Event.expects(:<<).with { |payload| payload[:debug] == "New Claude Session ID: first_session" }
+
+          @invocation.send(:handle_message, message)
+        end
+
+        test "handle_message emits info event when session_id changes" do
+          first = Claude::Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "session_1" })
+          second = Claude::Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "session_2" })
+
+          @invocation.send(:handle_message, first)
+          Event.expects(:<<).with { |payload| payload[:debug] == "New Claude Session ID: session_2" }
+          @invocation.send(:handle_message, second)
+        end
+
+        test "handle_message does not emit event when session_id is unchanged" do
+          first = Claude::Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "same_session" })
+          second = Claude::Messages::TextMessage.new(type: :text, hash: { text: "Hello", session_id: "same_session" })
+
+          @invocation.send(:handle_message, first)
+          Event.expects(:<<).never
+          @invocation.send(:handle_message, second)
+        end
+
+        test "run! emits USER PROMPT block event when show_prompt is enabled" do
+          @config.show_prompt!
+          invocation = Claude::ClaudeInvocation.new(@config, "Hello agent", nil)
+
+          Event.expects(:<<).with do |payload|
+            payload[:block] &&
+              payload[:block][:header] == "USER PROMPT" &&
+              payload[:block][:content] == "Hello agent"
+          end
+
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            invocation.run!
+          end
+        end
+
+        test "run! does not emit USER PROMPT block event when show_prompt is disabled" do
+          invocation = Claude::ClaudeInvocation.new(@config, "Hello agent", nil)
+
+          Event.expects(:<<).never
+
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            invocation.run!
+          end
+        end
+
+        test "run! emits AGENT RESPONSE block event when show_response is enabled" do
+          @config.show_response!
+          invocation = Claude::ClaudeInvocation.new(@config, "Hello agent", nil)
+
+          result_json = { type: "result", subtype: "success", result: "Here is my answer" }.to_json
+          Event.expects(:<<).with do |payload|
+            payload[:block] &&
+              payload[:block][:header] == "AGENT RESPONSE" &&
+              payload[:block][:content] == "Here is my answer"
+          end
+
+          CommandRunner.stub(:execute, ->(*_args, **kwargs) {
+            kwargs[:stdout_handler]&.call(result_json)
+            ["", "", success_status]
+          }) do
+            invocation.run!
+          end
+        end
+
+        test "run! does not emit AGENT RESPONSE block event when show_response is disabled" do
+          @config.no_show_response!
+          invocation = Claude::ClaudeInvocation.new(@config, "Hello agent", nil)
+
+          Event.expects(:<<).never
+
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            invocation.run!
+          end
+        end
+
+        test "run! does not emit AGENT RESPONSE block event on failure even when show_response is enabled" do
+          @config.show_response!
+          invocation = Claude::ClaudeInvocation.new(@config, "Hello agent", nil)
+
+          Event.expects(:<<).never
+
+          CommandRunner.stub(:execute, ["", "Error", failure_status]) do
+            invocation.run!
           end
         end
       end

--- a/test/roast/cogs/agent/providers/claude/message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/message_test.rb
@@ -4,216 +4,212 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          class MessageTest < ActiveSupport::TestCase
-            test "from_json parses JSON and creates message" do
-              json = '{"type": "text", "text": "Hello"}'
-              message = Message.from_json(json)
+    module Agent::Providers
+      class Claude::MessageTest < ActiveSupport::TestCase
+        test "from_json parses JSON and creates message" do
+          json = '{"type": "text", "text": "Hello"}'
+          message = Claude::Message.from_json(json)
 
-              assert_kind_of Messages::TextMessage, message
-              assert_equal "Hello", message.text
-            end
+          assert_kind_of Claude::Messages::TextMessage, message
+          assert_equal "Hello", message.text
+        end
 
-            test "from_json with assistant type creates AssistantMessage" do
-              json = '{"type": "assistant", "message": {"content": []}}'
-              message = Message.from_json(json)
+        test "from_json with assistant type creates AssistantMessage" do
+          json = '{"type": "assistant", "message": {"content": []}}'
+          message = Claude::Message.from_json(json)
 
-              assert_kind_of Messages::AssistantMessage, message
-            end
+          assert_kind_of Claude::Messages::AssistantMessage, message
+        end
 
-            test "from_json with result type creates ResultMessage" do
-              json = '{"type": "result", "result": "done"}'
-              message = Message.from_json(json)
+        test "from_json with result type creates ResultMessage" do
+          json = '{"type": "result", "result": "done"}'
+          message = Claude::Message.from_json(json)
 
-              assert_kind_of Messages::ResultMessage, message
-            end
+          assert_kind_of Claude::Messages::ResultMessage, message
+        end
 
-            test "from_json with system type creates SystemMessage" do
-              json = '{"type": "system", "message": "System prompt"}'
-              message = Message.from_json(json)
+        test "from_json with system type creates SystemMessage" do
+          json = '{"type": "system", "message": "System prompt"}'
+          message = Claude::Message.from_json(json)
 
-              assert_kind_of Messages::SystemMessage, message
-            end
+          assert_kind_of Claude::Messages::SystemMessage, message
+        end
 
-            test "from_json with text type creates TextMessage" do
-              json = '{"type": "text", "text": "Hello"}'
-              message = Message.from_json(json)
+        test "from_json with text type creates TextMessage" do
+          json = '{"type": "text", "text": "Hello"}'
+          message = Claude::Message.from_json(json)
 
-              assert_kind_of Messages::TextMessage, message
-            end
+          assert_kind_of Claude::Messages::TextMessage, message
+        end
 
-            test "from_json with thinking type creates ThinkingMessage" do
-              json = '{"type": "thinking", "thinking": "Let me consider..."}'
-              message = Message.from_json(json)
+        test "from_json with thinking type creates ThinkingMessage" do
+          json = '{"type": "thinking", "thinking": "Let me consider..."}'
+          message = Claude::Message.from_json(json)
 
-              assert_kind_of Messages::ThinkingMessage, message
-            end
+          assert_kind_of Claude::Messages::ThinkingMessage, message
+        end
 
-            test "from_json with tool_result type creates ToolResultMessage" do
-              json = '{"type": "tool_result", "tool_use_id": "123"}'
-              message = Message.from_json(json)
+        test "from_json with tool_result type creates ToolResultMessage" do
+          json = '{"type": "tool_result", "tool_use_id": "123"}'
+          message = Claude::Message.from_json(json)
 
-              assert_kind_of Messages::ToolResultMessage, message
-            end
+          assert_kind_of Claude::Messages::ToolResultMessage, message
+        end
 
-            test "from_json with tool_use type creates ToolUseMessage" do
-              json = '{"type": "tool_use", "name": "test"}'
-              message = Message.from_json(json)
+        test "from_json with tool_use type creates ToolUseMessage" do
+          json = '{"type": "tool_use", "name": "test"}'
+          message = Claude::Message.from_json(json)
 
-              assert_kind_of Messages::ToolUseMessage, message
-            end
+          assert_kind_of Claude::Messages::ToolUseMessage, message
+        end
 
-            test "from_json with user type creates UserMessage" do
-              json = '{"type": "user", "message": {"content": []}}'
-              message = Message.from_json(json)
+        test "from_json with user type creates UserMessage" do
+          json = '{"type": "user", "message": {"content": []}}'
+          message = Claude::Message.from_json(json)
 
-              assert_kind_of Messages::UserMessage, message
-            end
+          assert_kind_of Claude::Messages::UserMessage, message
+        end
 
-            test "from_json with unknown type creates UnknownMessage" do
-              json = '{"type": "unknown_type", "foo": "bar"}'
-              message = Message.from_json(json)
+        test "from_json with unknown type creates UnknownMessage" do
+          json = '{"type": "unknown_type", "foo": "bar"}'
+          message = Claude::Message.from_json(json)
 
-              assert_kind_of Messages::UnknownMessage, message
-            end
+          assert_kind_of Claude::Messages::UnknownMessage, message
+        end
 
-            test "from_hash with assistant type creates AssistantMessage" do
-              hash = { type: :assistant, message: { content: [] } }
-              message = Message.from_hash(hash)
+        test "from_hash with assistant type creates AssistantMessage" do
+          hash = { type: :assistant, message: { content: [] } }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::AssistantMessage, message
-            end
+          assert_kind_of Claude::Messages::AssistantMessage, message
+        end
 
-            test "from_hash with result type creates ResultMessage" do
-              hash = { type: :result, result: "done" }
-              message = Message.from_hash(hash)
+        test "from_hash with result type creates ResultMessage" do
+          hash = { type: :result, result: "done" }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::ResultMessage, message
-            end
+          assert_kind_of Claude::Messages::ResultMessage, message
+        end
 
-            test "from_hash with system type creates SystemMessage" do
-              hash = { type: :system, message: "prompt" }
-              message = Message.from_hash(hash)
+        test "from_hash with system type creates SystemMessage" do
+          hash = { type: :system, message: "prompt" }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::SystemMessage, message
-            end
+          assert_kind_of Claude::Messages::SystemMessage, message
+        end
 
-            test "from_hash with text type creates TextMessage" do
-              hash = { type: :text, text: "Hello" }
-              message = Message.from_hash(hash)
+        test "from_hash with text type creates TextMessage" do
+          hash = { type: :text, text: "Hello" }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::TextMessage, message
-            end
+          assert_kind_of Claude::Messages::TextMessage, message
+        end
 
-            test "from_hash with thinking type creates ThinkingMessage" do
-              hash = { type: :thinking, thinking: "Let me consider..." }
-              message = Message.from_hash(hash)
+        test "from_hash with thinking type creates ThinkingMessage" do
+          hash = { type: :thinking, thinking: "Let me consider..." }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::ThinkingMessage, message
-            end
+          assert_kind_of Claude::Messages::ThinkingMessage, message
+        end
 
-            test "from_hash with tool_result type creates ToolResultMessage" do
-              hash = { type: :tool_result, tool_use_id: "123" }
-              message = Message.from_hash(hash)
+        test "from_hash with tool_result type creates ToolResultMessage" do
+          hash = { type: :tool_result, tool_use_id: "123" }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::ToolResultMessage, message
-            end
+          assert_kind_of Claude::Messages::ToolResultMessage, message
+        end
 
-            test "from_hash with tool_use type creates ToolUseMessage" do
-              hash = { type: :tool_use, name: "test" }
-              message = Message.from_hash(hash)
+        test "from_hash with tool_use type creates ToolUseMessage" do
+          hash = { type: :tool_use, name: "test" }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::ToolUseMessage, message
-            end
+          assert_kind_of Claude::Messages::ToolUseMessage, message
+        end
 
-            test "from_hash with user type creates UserMessage" do
-              hash = { type: :user, message: { content: [] } }
-              message = Message.from_hash(hash)
+        test "from_hash with user type creates UserMessage" do
+          hash = { type: :user, message: { content: [] } }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::UserMessage, message
-            end
+          assert_kind_of Claude::Messages::UserMessage, message
+        end
 
-            test "from_hash with unknown type creates UnknownMessage" do
-              hash = { type: :unknown_type, foo: "bar" }
-              message = Message.from_hash(hash)
+        test "from_hash with unknown type creates UnknownMessage" do
+          hash = { type: :unknown_type, foo: "bar" }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::UnknownMessage, message
-            end
+          assert_kind_of Claude::Messages::UnknownMessage, message
+        end
 
-            test "from_hash with nil type creates UnknownMessage" do
-              hash = { type: nil, foo: "bar" }
-              message = Message.from_hash(hash)
+        test "from_hash with nil type creates UnknownMessage" do
+          hash = { type: nil, foo: "bar" }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::UnknownMessage, message
-            end
+          assert_kind_of Claude::Messages::UnknownMessage, message
+        end
 
-            test "from_hash removes type from hash" do
-              hash = { type: :text, text: "Hello" }
-              Message.from_hash(hash)
+        test "from_hash removes type from hash" do
+          hash = { type: :text, text: "Hello" }
+          Claude::Message.from_hash(hash)
 
-              refute hash.key?(:type)
-            end
+          refute hash.key?(:type)
+        end
 
-            test "from_hash converts string type to symbol" do
-              hash = { type: "text", text: "Hello" }
-              message = Message.from_hash(hash)
+        test "from_hash converts string type to symbol" do
+          hash = { type: "text", text: "Hello" }
+          message = Claude::Message.from_hash(hash)
 
-              assert_kind_of Messages::TextMessage, message
-            end
+          assert_kind_of Claude::Messages::TextMessage, message
+        end
 
-            test "initialize sets session_id from hash" do
-              hash = { session_id: "session_123" }
-              message = Message.new(type: :test, hash:)
+        test "initialize sets session_id from hash" do
+          hash = { session_id: "session_123" }
+          message = Claude::Message.new(type: :test, hash:)
 
-              assert_equal "session_123", message.session_id
-            end
+          assert_equal "session_123", message.session_id
+        end
 
-            test "initialize sets type" do
-              hash = {}
-              message = Message.new(type: :custom, hash:)
+        test "initialize sets type" do
+          hash = {}
+          message = Claude::Message.new(type: :custom, hash:)
 
-              assert_equal :custom, message.type
-            end
+          assert_equal :custom, message.type
+        end
 
-            test "initialize removes session_id from hash" do
-              hash = { session_id: "123" }
-              Message.new(type: :test, hash:)
+        test "initialize removes session_id from hash" do
+          hash = { session_id: "123" }
+          Claude::Message.new(type: :test, hash:)
 
-              refute hash.key?(:session_id)
-            end
+          refute hash.key?(:session_id)
+        end
 
-            test "initialize removes uuid from hash" do
-              hash = { uuid: "abc-123" }
-              Message.new(type: :test, hash:)
+        test "initialize removes uuid from hash" do
+          hash = { uuid: "abc-123" }
+          Claude::Message.new(type: :test, hash:)
 
-              refute hash.key?(:uuid)
-            end
+          refute hash.key?(:uuid)
+        end
 
-            test "initialize stores remaining hash in unparsed" do
-              hash = { foo: "bar", baz: 123 }
-              message = Message.new(type: :test, hash:)
+        test "initialize stores remaining hash in unparsed" do
+          hash = { foo: "bar", baz: 123 }
+          message = Claude::Message.new(type: :test, hash:)
 
-              assert_equal "bar", message.unparsed[:foo]
-              assert_equal 123, message.unparsed[:baz]
-            end
+          assert_equal "bar", message.unparsed[:foo]
+          assert_equal 123, message.unparsed[:baz]
+        end
 
-            test "initialize with empty hash creates empty unparsed" do
-              hash = {}
-              message = Message.new(type: :test, hash:)
+        test "initialize with empty hash creates empty unparsed" do
+          hash = {}
+          message = Claude::Message.new(type: :test, hash:)
 
-              assert_equal({}, message.unparsed)
-            end
+          assert_equal({}, message.unparsed)
+        end
 
-            test "format returns nil by default" do
-              hash = {}
-              message = Message.new(type: :test, hash:)
-              context = Object.new
+        test "format returns nil by default" do
+          hash = {}
+          message = Claude::Message.new(type: :test, hash:)
+          context = Object.new
 
-              assert_nil message.format(context)
-            end
-          end
+          assert_nil message.format(context)
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/messages/assistant_message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/messages/assistant_message_test.rb
@@ -4,83 +4,77 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          module Messages
-            class AssistantMessageTest < ActiveSupport::TestCase
-              test "initialize with empty message content" do
-                hash = { message: { content: [] } }
-                message = AssistantMessage.new(type: :assistant, hash:)
+    module Agent::Providers::Claude::Messages
+      class AssistantMessageTest < ActiveSupport::TestCase
+        test "initialize with empty message content" do
+          hash = { message: { content: [] } }
+          message = AssistantMessage.new(type: :assistant, hash:)
 
-                assert_equal [], message.messages
-              end
+          assert_equal [], message.messages
+        end
 
-              test "initialize with nil message" do
-                hash = {}
-                message = AssistantMessage.new(type: :assistant, hash:)
+        test "initialize with nil message" do
+          hash = {}
+          message = AssistantMessage.new(type: :assistant, hash:)
 
-                assert_equal [], message.messages
-              end
+          assert_equal [], message.messages
+        end
 
-              test "initialize with message content creates messages" do
-                hash = {
-                  message: {
-                    content: [
-                      { type: :text, text: "Hello" },
-                      { type: :text, text: "World" },
-                    ],
-                  },
-                }
-                message = AssistantMessage.new(type: :assistant, hash:)
+        test "initialize with message content creates messages" do
+          hash = {
+            message: {
+              content: [
+                { type: :text, text: "Hello" },
+                { type: :text, text: "World" },
+              ],
+            },
+          }
+          message = AssistantMessage.new(type: :assistant, hash:)
 
-                assert_equal 2, message.messages.length
-              end
+          assert_equal 2, message.messages.length
+        end
 
-              test "initialize sets role to assistant on content items" do
-                hash = {
-                  message: {
-                    content: [
-                      { type: :text, text: "Hello" },
-                    ],
-                  },
-                }
-                message = AssistantMessage.new(type: :assistant, hash:)
+        test "initialize sets role to assistant on content items" do
+          hash = {
+            message: {
+              content: [
+                { type: :text, text: "Hello" },
+              ],
+            },
+          }
+          message = AssistantMessage.new(type: :assistant, hash:)
 
-                assert_equal :assistant, message.messages.first.role
-              end
+          assert_equal :assistant, message.messages.first.role
+        end
 
-              test "initialize removes message from hash" do
-                hash = { message: { content: [] } }
-                AssistantMessage.new(type: :assistant, hash:)
+        test "initialize removes message from hash" do
+          hash = { message: { content: [] } }
+          AssistantMessage.new(type: :assistant, hash:)
 
-                refute hash.key?(:message)
-              end
+          refute hash.key?(:message)
+        end
 
-              test "initialize removes parent_tool_use_id from hash" do
-                hash = { parent_tool_use_id: "123" }
-                AssistantMessage.new(type: :assistant, hash:)
+        test "initialize removes parent_tool_use_id from hash" do
+          hash = { parent_tool_use_id: "123" }
+          AssistantMessage.new(type: :assistant, hash:)
 
-                refute hash.key?(:parent_tool_use_id)
-              end
+          refute hash.key?(:parent_tool_use_id)
+        end
 
-              test "initialize handles message content without nils" do
-                hash = {
-                  message: {
-                    content: [
-                      { type: :text, text: "Hello" },
-                      { type: :text, text: "World" },
-                    ],
-                  },
-                }
-                message = AssistantMessage.new(type: :assistant, hash:)
+        test "initialize handles message content without nils" do
+          hash = {
+            message: {
+              content: [
+                { type: :text, text: "Hello" },
+                { type: :text, text: "World" },
+              ],
+            },
+          }
+          message = AssistantMessage.new(type: :assistant, hash:)
 
-                assert_equal 2, message.messages.length
-                assert_equal "Hello", message.messages.first.text
-                assert_equal "World", message.messages.last.text
-              end
-            end
-          end
+          assert_equal 2, message.messages.length
+          assert_equal "Hello", message.messages.first.text
+          assert_equal "World", message.messages.last.text
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/messages/result_message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/messages/result_message_test.rb
@@ -4,193 +4,187 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          module Messages
-            class ResultMessageTest < ActiveSupport::TestCase
-              test "initialize with success subtype sets success to true" do
-                hash = { subtype: "success", result: "Task completed" }
-                message = ResultMessage.new(type: :result, hash:)
+    module Agent::Providers::Claude::Messages
+      class ResultMessageTest < ActiveSupport::TestCase
+        test "initialize with success subtype sets success to true" do
+          hash = { subtype: "success", result: "Task completed" }
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert message.success
-                assert_equal "Task completed", message.content
-              end
+          assert message.success
+          assert_equal "Task completed", message.content
+        end
 
-              test "initialize with error subtype sets content to empty string when no result" do
-                hash = { subtype: "error", error: { message: "Something went wrong" } }
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize with error subtype sets content to empty string when no result" do
+          hash = { subtype: "error", error: { message: "Something went wrong" } }
+          message = ResultMessage.new(type: :result, hash:)
 
-                refute message.success
-                assert_equal "", message.content
-              end
+          refute message.success
+          assert_equal "", message.content
+        end
 
-              test "initialize with is_error sets content from result" do
-                hash = { is_error: true, result: "Error result" }
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize with is_error sets content from result" do
+          hash = { is_error: true, result: "Error result" }
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert_equal "Error result", message.content
-              end
+          assert_equal "Error result", message.content
+        end
 
-              test "initialize with is_error and no result sets content to empty string" do
-                hash = { is_error: true }
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize with is_error and no result sets content to empty string" do
+          hash = { is_error: true }
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert_equal "", message.content
-              end
+          assert_equal "", message.content
+        end
 
-              test "initialize sets content from result field" do
-                hash = { result: "Test result" }
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize sets content from result field" do
+          hash = { result: "Test result" }
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert_equal "Test result", message.content
-              end
+          assert_equal "Test result", message.content
+        end
 
-              test "initialize sets content to empty string when no result" do
-                hash = {}
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize sets content to empty string when no result" do
+          hash = {}
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert_equal "", message.content
-              end
+          assert_equal "", message.content
+        end
 
-              test "initialize sets success from hash" do
-                hash = { success: true }
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize sets success from hash" do
+          hash = { success: true }
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert message.success
-              end
+          assert message.success
+        end
 
-              test "initialize creates stats object" do
-                hash = {}
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize creates stats object" do
+          hash = {}
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert_kind_of Stats, message.stats
-              end
+          assert_kind_of Agent::Stats, message.stats
+        end
 
-              test "initialize sets duration_ms in stats" do
-                hash = { duration_ms: 1500 }
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize sets duration_ms in stats" do
+          hash = { duration_ms: 1500 }
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert_equal 1500, message.stats.duration_ms
-              end
+          assert_equal 1500, message.stats.duration_ms
+        end
 
-              test "initialize sets num_turns in stats" do
-                hash = { num_turns: 3 }
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize sets num_turns in stats" do
+          hash = { num_turns: 3 }
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert_equal 3, message.stats.num_turns
-              end
+          assert_equal 3, message.stats.num_turns
+        end
 
-              test "initialize sets total_cost_usd in stats usage" do
-                hash = { total_cost_usd: 0.05 }
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize sets total_cost_usd in stats usage" do
+          hash = { total_cost_usd: 0.05 }
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert_equal 0.05, message.stats.usage.cost_usd
-              end
+          assert_equal 0.05, message.stats.usage.cost_usd
+        end
 
-              test "initialize processes modelUsage into stats" do
-                hash = {
-                  modelUsage: {
-                    "claude-3-opus" => {
-                      inputTokens: 100,
-                      outputTokens: 50,
-                      costUSD: 0.03,
-                    },
-                  },
-                }
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize processes modelUsage into stats" do
+          hash = {
+            modelUsage: {
+              "claude-3-opus" => {
+                inputTokens: 100,
+                outputTokens: 50,
+                costUSD: 0.03,
+              },
+            },
+          }
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert_equal 1, message.stats.model_usage.size
-                assert_equal 100, message.stats.model_usage["claude-3-opus"].input_tokens
-                assert_equal 50, message.stats.model_usage["claude-3-opus"].output_tokens
-                assert_equal 0.03, message.stats.model_usage["claude-3-opus"].cost_usd
-              end
+          assert_equal 1, message.stats.model_usage.size
+          assert_equal 100, message.stats.model_usage["claude-3-opus"].input_tokens
+          assert_equal 50, message.stats.model_usage["claude-3-opus"].output_tokens
+          assert_equal 0.03, message.stats.model_usage["claude-3-opus"].cost_usd
+        end
 
-              test "initialize aggregates token usage across models" do
-                hash = {
-                  modelUsage: {
-                    "model-a" => { inputTokens: 100, outputTokens: 50, costUSD: 0.02 },
-                    "model-b" => { inputTokens: 200, outputTokens: 75, costUSD: 0.03 },
-                  },
-                }
-                message = ResultMessage.new(type: :result, hash:)
+        test "initialize aggregates token usage across models" do
+          hash = {
+            modelUsage: {
+              "model-a" => { inputTokens: 100, outputTokens: 50, costUSD: 0.02 },
+              "model-b" => { inputTokens: 200, outputTokens: 75, costUSD: 0.03 },
+            },
+          }
+          message = ResultMessage.new(type: :result, hash:)
 
-                assert_equal 300, message.stats.usage.input_tokens
-                assert_equal 125, message.stats.usage.output_tokens
-              end
+          assert_equal 300, message.stats.usage.input_tokens
+          assert_equal 125, message.stats.usage.output_tokens
+        end
 
-              test "initialize removes ignored fields from hash" do
-                hash = {
-                  duration_api_ms: 1000,
-                  permission_denials: [],
-                  usage: {},
-                  uuid: "abc-123",
-                }
-                ResultMessage.new(type: :result, hash:)
+        test "initialize removes ignored fields from hash" do
+          hash = {
+            duration_api_ms: 1000,
+            permission_denials: [],
+            usage: {},
+            uuid: "abc-123",
+          }
+          ResultMessage.new(type: :result, hash:)
 
-                refute hash.key?(:duration_api_ms)
-                refute hash.key?(:permission_denials)
-                refute hash.key?(:usage)
-                refute hash.key?(:uuid)
-              end
+          refute hash.key?(:duration_api_ms)
+          refute hash.key?(:permission_denials)
+          refute hash.key?(:usage)
+          refute hash.key?(:uuid)
+        end
 
-              test "initialize removes subtype from hash" do
-                hash = { subtype: "success" }
-                ResultMessage.new(type: :result, hash:)
+        test "initialize removes subtype from hash" do
+          hash = { subtype: "success" }
+          ResultMessage.new(type: :result, hash:)
 
-                refute hash.key?(:subtype)
-              end
+          refute hash.key?(:subtype)
+        end
 
-              test "initialize removes result from hash" do
-                hash = { result: "done" }
-                ResultMessage.new(type: :result, hash:)
+        test "initialize removes result from hash" do
+          hash = { result: "done" }
+          ResultMessage.new(type: :result, hash:)
 
-                refute hash.key?(:result)
-              end
+          refute hash.key?(:result)
+        end
 
-              test "initialize removes success from hash" do
-                hash = { success: true }
-                ResultMessage.new(type: :result, hash:)
+        test "initialize removes success from hash" do
+          hash = { success: true }
+          ResultMessage.new(type: :result, hash:)
 
-                refute hash.key?(:success)
-              end
+          refute hash.key?(:success)
+        end
 
-              test "initialize removes error from hash when is_error is true" do
-                hash = { is_error: true, error: { message: "test" } }
-                ResultMessage.new(type: :result, hash:)
+        test "initialize removes error from hash when is_error is true" do
+          hash = { is_error: true, error: { message: "test" } }
+          ResultMessage.new(type: :result, hash:)
 
-                refute hash.key?(:error)
-              end
+          refute hash.key?(:error)
+        end
 
-              test "initialize removes duration_ms from hash" do
-                hash = { duration_ms: 100 }
-                ResultMessage.new(type: :result, hash:)
+        test "initialize removes duration_ms from hash" do
+          hash = { duration_ms: 100 }
+          ResultMessage.new(type: :result, hash:)
 
-                refute hash.key?(:duration_ms)
-              end
+          refute hash.key?(:duration_ms)
+        end
 
-              test "initialize removes num_turns from hash" do
-                hash = { num_turns: 1 }
-                ResultMessage.new(type: :result, hash:)
+        test "initialize removes num_turns from hash" do
+          hash = { num_turns: 1 }
+          ResultMessage.new(type: :result, hash:)
 
-                refute hash.key?(:num_turns)
-              end
+          refute hash.key?(:num_turns)
+        end
 
-              test "initialize removes modelUsage from hash" do
-                hash = { modelUsage: {} }
-                ResultMessage.new(type: :result, hash:)
+        test "initialize removes modelUsage from hash" do
+          hash = { modelUsage: {} }
+          ResultMessage.new(type: :result, hash:)
 
-                refute hash.key?(:modelUsage)
-              end
+          refute hash.key?(:modelUsage)
+        end
 
-              test "initialize removes total_cost_usd from hash" do
-                hash = { total_cost_usd: 0.01 }
-                ResultMessage.new(type: :result, hash:)
+        test "initialize removes total_cost_usd from hash" do
+          hash = { total_cost_usd: 0.01 }
+          ResultMessage.new(type: :result, hash:)
 
-                refute hash.key?(:total_cost_usd)
-              end
-            end
-          end
+          refute hash.key?(:total_cost_usd)
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/messages/system_message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/messages/system_message_test.rb
@@ -4,95 +4,89 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          module Messages
-            class SystemMessageTest < ActiveSupport::TestCase
-              def setup
-                @hash = { message: "System prompt", model: "claude-3-opus" }
-                @message = SystemMessage.new(type: :system, hash: @hash.dup)
-              end
+    module Agent::Providers::Claude::Messages
+      class SystemMessageTest < ActiveSupport::TestCase
+        def setup
+          @hash = { message: "System prompt", model: "claude-3-opus" }
+          @message = SystemMessage.new(type: :system, hash: @hash.dup)
+        end
 
-              test "initialize sets message from hash" do
-                assert_equal "System prompt", @message.message
-              end
+        test "initialize sets message from hash" do
+          assert_equal "System prompt", @message.message
+        end
 
-              test "initialize sets model from hash" do
-                assert_equal "claude-3-opus", @message.model
-              end
+        test "initialize sets model from hash" do
+          assert_equal "claude-3-opus", @message.model
+        end
 
-              test "initialize removes message from hash" do
-                hash = { message: "test" }
-                SystemMessage.new(type: :system, hash:)
+        test "initialize removes message from hash" do
+          hash = { message: "test" }
+          SystemMessage.new(type: :system, hash:)
 
-                refute hash.key?(:message)
-              end
+          refute hash.key?(:message)
+        end
 
-              test "initialize removes model from hash" do
-                hash = { model: "test" }
-                SystemMessage.new(type: :system, hash:)
+        test "initialize removes model from hash" do
+          hash = { model: "test" }
+          SystemMessage.new(type: :system, hash:)
 
-                refute hash.key?(:model)
-              end
+          refute hash.key?(:model)
+        end
 
-              test "initialize removes ignored fields from hash" do
-                hash = {
-                  message: "test",
-                  subtype: "info",
-                  cwd: "/tmp",
-                  tools: [],
-                  mcp_servers: [],
-                  permissionMode: "strict",
-                  slash_commands: [],
-                  apiKeySource: "env",
-                  claude_code_version: "1.0",
-                  output_style: "json",
-                  agents: [],
-                  skills: [],
-                  plugins: [],
-                  hook_name: "test",
-                  hook_event: "start",
-                  stdout: "output",
-                  stderr: "error",
-                  exit_code: 0,
-                }
-                SystemMessage.new(type: :system, hash:)
+        test "initialize removes ignored fields from hash" do
+          hash = {
+            message: "test",
+            subtype: "info",
+            cwd: "/tmp",
+            tools: [],
+            mcp_servers: [],
+            permissionMode: "strict",
+            slash_commands: [],
+            apiKeySource: "env",
+            claude_code_version: "1.0",
+            output_style: "json",
+            agents: [],
+            skills: [],
+            plugins: [],
+            hook_name: "test",
+            hook_event: "start",
+            stdout: "output",
+            stderr: "error",
+            exit_code: 0,
+          }
+          SystemMessage.new(type: :system, hash:)
 
-                refute hash.key?(:subtype)
-                refute hash.key?(:cwd)
-                refute hash.key?(:tools)
-                refute hash.key?(:mcp_servers)
-                refute hash.key?(:permissionMode)
-                refute hash.key?(:slash_commands)
-                refute hash.key?(:apiKeySource)
-                refute hash.key?(:claude_code_version)
-                refute hash.key?(:output_style)
-                refute hash.key?(:agents)
-                refute hash.key?(:skills)
-                refute hash.key?(:plugins)
-                refute hash.key?(:hook_name)
-                refute hash.key?(:hook_event)
-                refute hash.key?(:stdout)
-                refute hash.key?(:stderr)
-                refute hash.key?(:exit_code)
-              end
+          refute hash.key?(:subtype)
+          refute hash.key?(:cwd)
+          refute hash.key?(:tools)
+          refute hash.key?(:mcp_servers)
+          refute hash.key?(:permissionMode)
+          refute hash.key?(:slash_commands)
+          refute hash.key?(:apiKeySource)
+          refute hash.key?(:claude_code_version)
+          refute hash.key?(:output_style)
+          refute hash.key?(:agents)
+          refute hash.key?(:skills)
+          refute hash.key?(:plugins)
+          refute hash.key?(:hook_name)
+          refute hash.key?(:hook_event)
+          refute hash.key?(:stdout)
+          refute hash.key?(:stderr)
+          refute hash.key?(:exit_code)
+        end
 
-              test "initialize allows nil message" do
-                hash = { model: "claude-3-opus" }
-                message = SystemMessage.new(type: :system, hash:)
+        test "initialize allows nil message" do
+          hash = { model: "claude-3-opus" }
+          message = SystemMessage.new(type: :system, hash:)
 
-                assert_nil message.message
-              end
+          assert_nil message.message
+        end
 
-              test "initialize allows nil model" do
-                hash = { message: "test" }
-                message = SystemMessage.new(type: :system, hash:)
+        test "initialize allows nil model" do
+          hash = { message: "test" }
+          message = SystemMessage.new(type: :system, hash:)
 
-                assert_nil message.model
-              end
-            end
-          end
+          assert_nil message.model
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/messages/text_message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/messages/text_message_test.rb
@@ -4,66 +4,60 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          module Messages
-            class TextMessageTest < ActiveSupport::TestCase
-              def setup
-                @hash = { role: :user, text: "Hello world" }
-                @message = TextMessage.new(type: :text, hash: @hash.dup)
-              end
+    module Agent::Providers::Claude::Messages
+      class TextMessageTest < ActiveSupport::TestCase
+        def setup
+          @hash = { role: :user, text: "Hello world" }
+          @message = TextMessage.new(type: :text, hash: @hash.dup)
+        end
 
-              test "initialize sets role from hash" do
-                assert_equal :user, @message.role
-              end
+        test "initialize sets role from hash" do
+          assert_equal :user, @message.role
+        end
 
-              test "initialize sets text from hash" do
-                assert_equal "Hello world", @message.text
-              end
+        test "initialize sets text from hash" do
+          assert_equal "Hello world", @message.text
+        end
 
-              test "initialize removes role from hash" do
-                hash = { role: :assistant, text: "test" }
-                TextMessage.new(type: :text, hash:)
+        test "initialize removes role from hash" do
+          hash = { role: :assistant, text: "test" }
+          TextMessage.new(type: :text, hash:)
 
-                refute hash.key?(:role)
-              end
+          refute hash.key?(:role)
+        end
 
-              test "initialize removes text from hash" do
-                hash = { text: "test" }
-                TextMessage.new(type: :text, hash:)
+        test "initialize removes text from hash" do
+          hash = { text: "test" }
+          TextMessage.new(type: :text, hash:)
 
-                refute hash.key?(:text)
-              end
+          refute hash.key?(:text)
+        end
 
-              test "initialize sets text to empty string when nil" do
-                hash = { role: :user }
-                message = TextMessage.new(type: :text, hash:)
+        test "initialize sets text to empty string when nil" do
+          hash = { role: :user }
+          message = TextMessage.new(type: :text, hash:)
 
-                assert_equal "", message.text
-              end
+          assert_equal "", message.text
+        end
 
-              test "initialize sets text to empty string when not provided" do
-                hash = { role: :user, text: nil }
-                message = TextMessage.new(type: :text, hash:)
+        test "initialize sets text to empty string when not provided" do
+          hash = { role: :user, text: nil }
+          message = TextMessage.new(type: :text, hash:)
 
-                assert_equal "", message.text
-              end
+          assert_equal "", message.text
+        end
 
-              test "format returns text" do
-                context = Object.new
-                result = @message.format(context)
+        test "format returns text" do
+          context = Object.new
+          result = @message.format(context)
 
-                assert_equal "Hello world", result
-              end
+          assert_equal "Hello world", result
+        end
 
-              test "format returns text regardless of context" do
-                result = @message.format(nil)
+        test "format returns text regardless of context" do
+          result = @message.format(nil)
 
-                assert_equal "Hello world", result
-              end
-            end
-          end
+          assert_equal "Hello world", result
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/messages/thinking_message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/messages/thinking_message_test.rb
@@ -4,63 +4,57 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          module Messages
-            class ThinkingMessageTest < ActiveSupport::TestCase
-              def setup
-                @hash = { thinking: "Let me think about this...", signature: "abc123", role: :assistant }
-                @message = ThinkingMessage.new(type: :thinking, hash: @hash.dup)
-              end
+    module Agent::Providers::Claude::Messages
+      class ThinkingMessageTest < ActiveSupport::TestCase
+        def setup
+          @hash = { thinking: "Let me think about this...", signature: "abc123", role: :assistant }
+          @message = ThinkingMessage.new(type: :thinking, hash: @hash.dup)
+        end
 
-              test "initialize sets thinking from hash" do
-                assert_equal "Let me think about this...", @message.thinking
-              end
+        test "initialize sets thinking from hash" do
+          assert_equal "Let me think about this...", @message.thinking
+        end
 
-              test "initialize removes thinking from hash" do
-                hash = { thinking: "test" }
-                ThinkingMessage.new(type: :thinking, hash:)
+        test "initialize removes thinking from hash" do
+          hash = { thinking: "test" }
+          ThinkingMessage.new(type: :thinking, hash:)
 
-                refute hash.key?(:thinking)
-              end
+          refute hash.key?(:thinking)
+        end
 
-              test "initialize removes ignored fields from hash" do
-                hash = { thinking: "test", signature: "sig", role: :assistant }
-                ThinkingMessage.new(type: :thinking, hash:)
+        test "initialize removes ignored fields from hash" do
+          hash = { thinking: "test", signature: "sig", role: :assistant }
+          ThinkingMessage.new(type: :thinking, hash:)
 
-                refute hash.key?(:signature)
-                refute hash.key?(:role)
-              end
+          refute hash.key?(:signature)
+          refute hash.key?(:role)
+        end
 
-              test "initialize sets thinking to empty string when nil" do
-                hash = { signature: "sig" }
-                message = ThinkingMessage.new(type: :thinking, hash:)
+        test "initialize sets thinking to empty string when nil" do
+          hash = { signature: "sig" }
+          message = ThinkingMessage.new(type: :thinking, hash:)
 
-                assert_equal "", message.thinking
-              end
+          assert_equal "", message.thinking
+        end
 
-              test "initialize sets thinking to empty string when not provided" do
-                hash = { thinking: nil }
-                message = ThinkingMessage.new(type: :thinking, hash:)
+        test "initialize sets thinking to empty string when not provided" do
+          hash = { thinking: nil }
+          message = ThinkingMessage.new(type: :thinking, hash:)
 
-                assert_equal "", message.thinking
-              end
+          assert_equal "", message.thinking
+        end
 
-              test "format returns thinking" do
-                context = Object.new
-                result = @message.format(context)
+        test "format returns thinking" do
+          context = Object.new
+          result = @message.format(context)
 
-                assert_equal "Let me think about this...", result
-              end
+          assert_equal "Let me think about this...", result
+        end
 
-              test "format returns thinking regardless of context" do
-                result = @message.format(nil)
+        test "format returns thinking regardless of context" do
+          result = @message.format(nil)
 
-                assert_equal "Let me think about this...", result
-              end
-            end
-          end
+          assert_equal "Let me think about this...", result
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/messages/tool_result_message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/messages/tool_result_message_test.rb
@@ -4,82 +4,76 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          module Messages
-            class ToolResultMessageTest < ActiveSupport::TestCase
-              def setup
-                @hash = { tool_use_id: "tool_123", content: "Result content", is_error: false }
-                @message = ToolResultMessage.new(type: :tool_result, hash: @hash.dup)
-              end
+    module Agent::Providers::Claude::Messages
+      class ToolResultMessageTest < ActiveSupport::TestCase
+        def setup
+          @hash = { tool_use_id: "tool_123", content: "Result content", is_error: false }
+          @message = ToolResultMessage.new(type: :tool_result, hash: @hash.dup)
+        end
 
-              test "initialize sets tool_use_id from hash" do
-                assert_equal "tool_123", @message.tool_use_id
-              end
+        test "initialize sets tool_use_id from hash" do
+          assert_equal "tool_123", @message.tool_use_id
+        end
 
-              test "initialize sets content from hash" do
-                assert_equal "Result content", @message.content
-              end
+        test "initialize sets content from hash" do
+          assert_equal "Result content", @message.content
+        end
 
-              test "initialize sets is_error from hash" do
-                refute @message.is_error
-              end
+        test "initialize sets is_error from hash" do
+          refute @message.is_error
+        end
 
-              test "initialize removes tool_use_id from hash" do
-                hash = { tool_use_id: "123" }
-                ToolResultMessage.new(type: :tool_result, hash:)
+        test "initialize removes tool_use_id from hash" do
+          hash = { tool_use_id: "123" }
+          ToolResultMessage.new(type: :tool_result, hash:)
 
-                refute hash.key?(:tool_use_id)
-              end
+          refute hash.key?(:tool_use_id)
+        end
 
-              test "initialize removes content from hash" do
-                hash = { content: "test" }
-                ToolResultMessage.new(type: :tool_result, hash:)
+        test "initialize removes content from hash" do
+          hash = { content: "test" }
+          ToolResultMessage.new(type: :tool_result, hash:)
 
-                refute hash.key?(:content)
-              end
+          refute hash.key?(:content)
+        end
 
-              test "initialize removes is_error from hash" do
-                hash = { is_error: true }
-                ToolResultMessage.new(type: :tool_result, hash:)
+        test "initialize removes is_error from hash" do
+          hash = { is_error: true }
+          ToolResultMessage.new(type: :tool_result, hash:)
 
-                refute hash.key?(:is_error)
-              end
+          refute hash.key?(:is_error)
+        end
 
-              test "initialize removes role from hash" do
-                hash = { role: :user }
-                ToolResultMessage.new(type: :tool_result, hash:)
+        test "initialize removes role from hash" do
+          hash = { role: :user }
+          ToolResultMessage.new(type: :tool_result, hash:)
 
-                refute hash.key?(:role)
-              end
+          refute hash.key?(:role)
+        end
 
-              test "initialize defaults is_error to false" do
-                hash = { tool_use_id: "123" }
-                message = ToolResultMessage.new(type: :tool_result, hash:)
+        test "initialize defaults is_error to false" do
+          hash = { tool_use_id: "123" }
+          message = ToolResultMessage.new(type: :tool_result, hash:)
 
-                refute message.is_error
-              end
+          refute message.is_error
+        end
 
-              test "initialize allows is_error true" do
-                hash = { is_error: true }
-                message = ToolResultMessage.new(type: :tool_result, hash:)
+        test "initialize allows is_error true" do
+          hash = { is_error: true }
+          message = ToolResultMessage.new(type: :tool_result, hash:)
 
-                assert message.is_error
-              end
+          assert message.is_error
+        end
 
-              test "format calls context.tool_use with tool_use_id" do
-                mock_context = Minitest::Mock.new
-                mock_tool_use = Struct.new(:name, :input).new(:test_tool, {})
-                mock_context.expect(:tool_use, mock_tool_use, ["tool_123"])
+        test "format calls context.tool_use with tool_use_id" do
+          mock_context = Minitest::Mock.new
+          mock_tool_use = Struct.new(:name, :input).new(:test_tool, {})
+          mock_context.expect(:tool_use, mock_tool_use, ["tool_123"])
 
-                result = @message.format(mock_context)
+          result = @message.format(mock_context)
 
-                mock_context.verify
-                assert_kind_of String, result
-              end
-            end
-          end
+          mock_context.verify
+          assert_kind_of String, result
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/messages/tool_use_message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/messages/tool_use_message_test.rb
@@ -4,92 +4,86 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          module Messages
-            class ToolUseMessageTest < ActiveSupport::TestCase
-              def setup
-                @hash = { name: "TestTool", id: "tool_123", input: { arg: "value" } }
-                @message = ToolUseMessage.new(type: :tool_use, hash: @hash.dup)
-              end
+    module Agent::Providers::Claude::Messages
+      class ToolUseMessageTest < ActiveSupport::TestCase
+        def setup
+          @hash = { name: "TestTool", id: "tool_123", input: { arg: "value" } }
+          @message = ToolUseMessage.new(type: :tool_use, hash: @hash.dup)
+        end
 
-              test "initialize sets name as symbol" do
-                assert_equal :testtool, @message.name
-              end
+        test "initialize sets name as symbol" do
+          assert_equal :testtool, @message.name
+        end
 
-              test "initialize converts name to lowercase" do
-                hash = { name: "MyTool" }
-                message = ToolUseMessage.new(type: :tool_use, hash:)
+        test "initialize converts name to lowercase" do
+          hash = { name: "MyTool" }
+          message = ToolUseMessage.new(type: :tool_use, hash:)
 
-                assert_equal :mytool, message.name
-              end
+          assert_equal :mytool, message.name
+        end
 
-              test "initialize sets id from hash" do
-                assert_equal "tool_123", @message.id
-              end
+        test "initialize sets id from hash" do
+          assert_equal "tool_123", @message.id
+        end
 
-              test "initialize sets input from hash" do
-                assert_equal({ arg: "value" }, @message.input)
-              end
+        test "initialize sets input from hash" do
+          assert_equal({ arg: "value" }, @message.input)
+        end
 
-              test "initialize removes name from hash" do
-                hash = { name: "test" }
-                ToolUseMessage.new(type: :tool_use, hash:)
+        test "initialize removes name from hash" do
+          hash = { name: "test" }
+          ToolUseMessage.new(type: :tool_use, hash:)
 
-                refute hash.key?(:name)
-              end
+          refute hash.key?(:name)
+        end
 
-              test "initialize removes id from hash" do
-                hash = { id: "123" }
-                ToolUseMessage.new(type: :tool_use, hash:)
+        test "initialize removes id from hash" do
+          hash = { id: "123" }
+          ToolUseMessage.new(type: :tool_use, hash:)
 
-                refute hash.key?(:id)
-              end
+          refute hash.key?(:id)
+        end
 
-              test "initialize removes input from hash" do
-                hash = { input: {} }
-                ToolUseMessage.new(type: :tool_use, hash:)
+        test "initialize removes input from hash" do
+          hash = { input: {} }
+          ToolUseMessage.new(type: :tool_use, hash:)
 
-                refute hash.key?(:input)
-              end
+          refute hash.key?(:input)
+        end
 
-              test "initialize removes role from hash" do
-                hash = { role: :assistant }
-                ToolUseMessage.new(type: :tool_use, hash:)
+        test "initialize removes role from hash" do
+          hash = { role: :assistant }
+          ToolUseMessage.new(type: :tool_use, hash:)
 
-                refute hash.key?(:role)
-              end
+          refute hash.key?(:role)
+        end
 
-              test "initialize sets name to unknown when nil" do
-                hash = { name: nil }
-                message = ToolUseMessage.new(type: :tool_use, hash:)
+        test "initialize sets name to unknown when nil" do
+          hash = { name: nil }
+          message = ToolUseMessage.new(type: :tool_use, hash:)
 
-                assert_equal :unknown, message.name
-              end
+          assert_equal :unknown, message.name
+        end
 
-              test "initialize sets input to empty hash when nil" do
-                hash = { name: "test" }
-                message = ToolUseMessage.new(type: :tool_use, hash:)
+        test "initialize sets input to empty hash when nil" do
+          hash = { name: "test" }
+          message = ToolUseMessage.new(type: :tool_use, hash:)
 
-                assert_equal({}, message.input)
-              end
+          assert_equal({}, message.input)
+        end
 
-              test "initialize sets input to empty hash when not provided" do
-                hash = { name: "test", input: nil }
-                message = ToolUseMessage.new(type: :tool_use, hash:)
+        test "initialize sets input to empty hash when not provided" do
+          hash = { name: "test", input: nil }
+          message = ToolUseMessage.new(type: :tool_use, hash:)
 
-                assert_equal({}, message.input)
-              end
+          assert_equal({}, message.input)
+        end
 
-              test "format creates ToolUse and calls format" do
-                context = Object.new
-                result = @message.format(context)
+        test "format creates ToolUse and calls format" do
+          context = Object.new
+          result = @message.format(context)
 
-                assert_kind_of String, result
-              end
-            end
-          end
+          assert_kind_of String, result
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/messages/unknown_message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/messages/unknown_message_test.rb
@@ -4,33 +4,27 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          module Messages
-            class UnknownMessageTest < ActiveSupport::TestCase
-              def setup
-                @hash = { foo: "bar", baz: 123 }
-                @message = UnknownMessage.new(type: :unknown, hash: @hash.dup)
-              end
+    module Agent::Providers::Claude::Messages
+      class UnknownMessageTest < ActiveSupport::TestCase
+        def setup
+          @hash = { foo: "bar", baz: 123 }
+          @message = UnknownMessage.new(type: :unknown, hash: @hash.dup)
+        end
 
-              test "initialize stores hash in raw" do
-                assert_equal @hash, @message.raw
-              end
+        test "initialize stores hash in raw" do
+          assert_equal @hash, @message.raw
+        end
 
-              test "raw contains all fields from hash" do
-                assert_equal "bar", @message.raw[:foo]
-                assert_equal 123, @message.raw[:baz]
-              end
+        test "raw contains all fields from hash" do
+          assert_equal "bar", @message.raw[:foo]
+          assert_equal 123, @message.raw[:baz]
+        end
 
-              test "raw is the same object as hash passed to initialize" do
-                hash = { test: "value" }
-                message = UnknownMessage.new(type: :unknown, hash:)
+        test "raw is the same object as hash passed to initialize" do
+          hash = { test: "value" }
+          message = UnknownMessage.new(type: :unknown, hash:)
 
-                assert_same hash, message.raw
-              end
-            end
-          end
+          assert_same hash, message.raw
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/messages/user_message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/messages/user_message_test.rb
@@ -4,90 +4,84 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          module Messages
-            class UserMessageTest < ActiveSupport::TestCase
-              test "initialize with empty message content" do
-                hash = { message: { content: [] } }
-                message = UserMessage.new(type: :user, hash:)
+    module Agent::Providers::Claude::Messages
+      class UserMessageTest < ActiveSupport::TestCase
+        test "initialize with empty message content" do
+          hash = { message: { content: [] } }
+          message = UserMessage.new(type: :user, hash:)
 
-                assert_equal [], message.messages
-              end
+          assert_equal [], message.messages
+        end
 
-              test "initialize with nil message" do
-                hash = {}
-                message = UserMessage.new(type: :user, hash:)
+        test "initialize with nil message" do
+          hash = {}
+          message = UserMessage.new(type: :user, hash:)
 
-                assert_equal [], message.messages
-              end
+          assert_equal [], message.messages
+        end
 
-              test "initialize with message content creates messages" do
-                hash = {
-                  message: {
-                    content: [
-                      { type: :text, text: "Hello" },
-                      { type: :text, text: "World" },
-                    ],
-                  },
-                }
-                message = UserMessage.new(type: :user, hash:)
+        test "initialize with message content creates messages" do
+          hash = {
+            message: {
+              content: [
+                { type: :text, text: "Hello" },
+                { type: :text, text: "World" },
+              ],
+            },
+          }
+          message = UserMessage.new(type: :user, hash:)
 
-                assert_equal 2, message.messages.length
-              end
+          assert_equal 2, message.messages.length
+        end
 
-              test "initialize sets role to user on content items" do
-                hash = {
-                  message: {
-                    content: [
-                      { type: :text, text: "Hello" },
-                    ],
-                  },
-                }
-                message = UserMessage.new(type: :user, hash:)
+        test "initialize sets role to user on content items" do
+          hash = {
+            message: {
+              content: [
+                { type: :text, text: "Hello" },
+              ],
+            },
+          }
+          message = UserMessage.new(type: :user, hash:)
 
-                assert_equal :user, message.messages.first.role
-              end
+          assert_equal :user, message.messages.first.role
+        end
 
-              test "initialize removes message from hash" do
-                hash = { message: { content: [] } }
-                UserMessage.new(type: :user, hash:)
+        test "initialize removes message from hash" do
+          hash = { message: { content: [] } }
+          UserMessage.new(type: :user, hash:)
 
-                refute hash.key?(:message)
-              end
+          refute hash.key?(:message)
+        end
 
-              test "initialize removes parent_tool_use_id from hash" do
-                hash = { parent_tool_use_id: "123" }
-                UserMessage.new(type: :user, hash:)
+        test "initialize removes parent_tool_use_id from hash" do
+          hash = { parent_tool_use_id: "123" }
+          UserMessage.new(type: :user, hash:)
 
-                refute hash.key?(:parent_tool_use_id)
-              end
+          refute hash.key?(:parent_tool_use_id)
+        end
 
-              test "initialize removes tool_use_result from hash" do
-                hash = { tool_use_result: "result" }
-                UserMessage.new(type: :user, hash:)
+        test "initialize removes tool_use_result from hash" do
+          hash = { tool_use_result: "result" }
+          UserMessage.new(type: :user, hash:)
 
-                refute hash.key?(:tool_use_result)
-              end
+          refute hash.key?(:tool_use_result)
+        end
 
-              test "initialize handles message content without nils" do
-                hash = {
-                  message: {
-                    content: [
-                      { type: :text, text: "Hello" },
-                      { type: :text, text: "World" },
-                    ],
-                  },
-                }
-                message = UserMessage.new(type: :user, hash:)
+        test "initialize handles message content without nils" do
+          hash = {
+            message: {
+              content: [
+                { type: :text, text: "Hello" },
+                { type: :text, text: "World" },
+              ],
+            },
+          }
+          message = UserMessage.new(type: :user, hash:)
 
-                assert_equal 2, message.messages.length
-                assert_equal "Hello", message.messages.first.text
-                assert_equal "World", message.messages.last.text
-              end
-            end
-          end
+          assert_equal 2, message.messages.length
+          assert_equal "Hello", message.messages.first.text
+          assert_equal "World", message.messages.last.text
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/tool_result_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_result_test.rb
@@ -4,105 +4,101 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          class ToolResultTest < ActiveSupport::TestCase
-            test "initialize with tool_use message" do
-              tool_use_message = Messages::ToolUseMessage.new(
-                type: :tool_use,
-                hash: { name: "bash", input: { description: "List files" } },
-              )
-              tool_result = ToolResult.new(
-                tool_use: tool_use_message,
-                content: "file1.txt\nfile2.txt",
-                is_error: false,
-              )
+    module Agent::Providers
+      class Claude::ToolResultTest < ActiveSupport::TestCase
+        test "initialize with tool_use message" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "bash", input: { description: "List files" } },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: "file1.txt\nfile2.txt",
+            is_error: false,
+          )
 
-              assert_equal :bash, tool_result.tool_name
-              assert_equal "List files", tool_result.tool_use_description
-              assert_equal "file1.txt\nfile2.txt", tool_result.content
-              refute tool_result.is_error
-            end
+          assert_equal :bash, tool_result.tool_name
+          assert_equal "List files", tool_result.tool_use_description
+          assert_equal "file1.txt\nfile2.txt", tool_result.content
+          refute tool_result.is_error
+        end
 
-            test "initialize with nil tool_use" do
-              tool_result = ToolResult.new(
-                tool_use: nil,
-                content: "some content",
-                is_error: false,
-              )
+        test "initialize with nil tool_use" do
+          tool_result = Claude::ToolResult.new(
+            tool_use: nil,
+            content: "some content",
+            is_error: false,
+          )
 
-              assert_equal :unknown, tool_result.tool_name
-              assert_nil tool_result.tool_use_description
-            end
+          assert_equal :unknown, tool_result.tool_name
+          assert_nil tool_result.tool_use_description
+        end
 
-            test "initialize with tool_use without description" do
-              tool_use_message = Messages::ToolUseMessage.new(
-                type: :tool_use,
-                hash: { name: "custom", input: {} },
-              )
-              tool_result = ToolResult.new(
-                tool_use: tool_use_message,
-                content: "result",
-                is_error: false,
-              )
+        test "initialize with tool_use without description" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "custom", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: "result",
+            is_error: false,
+          )
 
-              assert_nil tool_result.tool_use_description
-            end
+          assert_nil tool_result.tool_use_description
+        end
 
-            test "initialize sets is_error flag" do
-              tool_result = ToolResult.new(
-                tool_use: nil,
-                content: "error message",
-                is_error: true,
-              )
+        test "initialize sets is_error flag" do
+          tool_result = Claude::ToolResult.new(
+            tool_use: nil,
+            content: "error message",
+            is_error: true,
+          )
 
-              assert tool_result.is_error
-            end
+          assert tool_result.is_error
+        end
 
-            test "format calls format_unknown for unknown tool" do
-              tool_result = ToolResult.new(
-                tool_use: nil,
-                content: "result content",
-                is_error: false,
-              )
+        test "format calls format_unknown for unknown tool" do
+          tool_result = Claude::ToolResult.new(
+            tool_use: nil,
+            content: "result content",
+            is_error: false,
+          )
 
-              output = tool_result.format
+          output = tool_result.format
 
-              assert_match(/UNKNOWN \[unknown\]/, output)
-              assert_match(/OK/, output)
-              assert_match(/result content/, output)
-            end
+          assert_match(/UNKNOWN \[unknown\]/, output)
+          assert_match(/OK/, output)
+          assert_match(/result content/, output)
+        end
 
-            test "format shows ERROR for error results" do
-              tool_result = ToolResult.new(
-                tool_use: nil,
-                content: "error details",
-                is_error: true,
-              )
+        test "format shows ERROR for error results" do
+          tool_result = Claude::ToolResult.new(
+            tool_use: nil,
+            content: "error details",
+            is_error: true,
+          )
 
-              output = tool_result.format
+          output = tool_result.format
 
-              assert_match(/ERROR/, output)
-              assert_match(/error details/, output)
-            end
+          assert_match(/ERROR/, output)
+          assert_match(/error details/, output)
+        end
 
-            test "format includes description when present" do
-              tool_use_message = Messages::ToolUseMessage.new(
-                type: :tool_use,
-                hash: { name: "bash", input: { description: "Run command" } },
-              )
-              tool_result = ToolResult.new(
-                tool_use: tool_use_message,
-                content: "output",
-                is_error: false,
-              )
+        test "format includes description when present" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "bash", input: { description: "Run command" } },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: "output",
+            is_error: false,
+          )
 
-              output = tool_result.format
+          output = tool_result.format
 
-              assert_match(/Run command/, output)
-            end
-          end
+          assert_match(/Run command/, output)
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -4,44 +4,40 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Claude < Provider
-          class ToolUseTest < ActiveSupport::TestCase
-            test "initialize sets name and input" do
-              tool_use = ToolUse.new(name: :bash, input: { command: "ls" })
+    module Agent::Providers
+      class Claude::ToolUseTest < ActiveSupport::TestCase
+        test "initialize sets name and input" do
+          tool_use = Claude::ToolUse.new(name: :bash, input: { command: "ls" })
 
-              assert_equal :bash, tool_use.name
-              assert_equal({ command: "ls" }, tool_use.input)
-            end
+          assert_equal :bash, tool_use.name
+          assert_equal({ command: "ls" }, tool_use.input)
+        end
 
-            test "format calls format_bash for bash tool" do
-              tool_use = ToolUse.new(name: :bash, input: { command: "ls" })
+        test "format calls format_bash for bash tool" do
+          tool_use = Claude::ToolUse.new(name: :bash, input: { command: "ls" })
 
-              output = tool_use.format
+          output = tool_use.format
 
-              assert_match(/BASH/, output)
-              assert_match(/command.*ls/, output)
-            end
+          assert_match(/BASH/, output)
+          assert_match(/command.*ls/, output)
+        end
 
-            test "format calls format_unknown for unknown tool" do
-              tool_use = ToolUse.new(name: :unknown_tool, input: { arg: "value" })
+        test "format calls format_unknown for unknown tool" do
+          tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 
-              output = tool_use.format
+          output = tool_use.format
 
-              assert_match(/UNKNOWN \[unknown_tool\]/, output)
-              assert_match(/arg.*value/, output)
-            end
+          assert_match(/UNKNOWN \[unknown_tool\]/, output)
+          assert_match(/arg.*value/, output)
+        end
 
-            test "format_unknown includes tool name and input" do
-              tool_use = ToolUse.new(name: :custom, input: { key: "value" })
+        test "format_unknown includes tool name and input" do
+          tool_use = Claude::ToolUse.new(name: :custom, input: { key: "value" })
 
-              output = tool_use.send(:format_unknown)
+          output = tool_use.send(:format_unknown)
 
-              assert_match(/UNKNOWN \[custom\]/, output)
-              assert_match(/key.*value/, output)
-            end
-          end
+          assert_match(/UNKNOWN \[custom\]/, output)
+          assert_match(/key.*value/, output)
         end
       end
     end

--- a/test/roast/cogs/agent/providers/claude_test.rb
+++ b/test/roast/cogs/agent/providers/claude_test.rb
@@ -4,259 +4,257 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class ClaudeTest < ActiveSupport::TestCase
-          def setup
-            @config = Agent::Config.new
-            @config.no_display!
-            @provider = Claude.new(@config)
-          end
+    module Agent::Providers
+      class ClaudeTest < ActiveSupport::TestCase
+        def setup
+          @config = Agent::Config.new
+          @config.no_display!
+          @provider = Claude.new(@config)
+        end
 
-          def mock_status(success:)
-            status = stub("process_status")
-            status.stubs(success?: success)
-            status
-          end
+        def mock_status(success:)
+          status = stub("process_status")
+          status.stubs(success?: success)
+          status
+        end
 
-          test "invoke with single prompt runs a single invocation" do
-            input = Agent::Input.new
-            input.prompt = "Do something"
+        test "invoke with single prompt runs a single invocation" do
+          input = Agent::Input.new
+          input.prompt = "Do something"
 
-            CommandRunner.stubs(:execute).returns(["", "", mock_status(success: true)])
+          CommandRunner.stubs(:execute).returns(["", "", mock_status(success: true)])
 
-            output = @provider.invoke(input)
+          output = @provider.invoke(input)
 
-            assert_kind_of Agent::Output, output
-          end
+          assert_kind_of Agent::Output, output
+        end
 
-          test "invoke passes prompt as stdin to the invocation" do
-            input = Agent::Input.new
-            input.prompt = "Do something"
+        test "invoke passes prompt as stdin to the invocation" do
+          input = Agent::Input.new
+          input.prompt = "Do something"
 
-            stdin_received = nil
-            CommandRunner.stubs(:execute).with do |_args, **kwargs|
-              stdin_received = kwargs[:stdin_content]
-              true
-            end.returns(["", "", mock_status(success: true)])
+          stdin_received = nil
+          CommandRunner.stubs(:execute).with do |_args, **kwargs|
+            stdin_received = kwargs[:stdin_content]
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            @provider.invoke(input)
+          @provider.invoke(input)
 
-            assert_equal "Do something", stdin_received
-          end
+          assert_equal "Do something", stdin_received
+        end
 
-          test "invoke passes session from input to first invocation" do
-            input = Agent::Input.new
-            input.prompt = "Do something"
-            input.session = "existing_session"
+        test "invoke passes session from input to first invocation" do
+          input = Agent::Input.new
+          input.prompt = "Do something"
+          input.session = "existing_session"
 
-            args_received = nil
-            CommandRunner.stubs(:execute).with do |args, **_kwargs|
-              args_received = args
-              true
-            end.returns(["", "", mock_status(success: true)])
+          args_received = nil
+          CommandRunner.stubs(:execute).with do |args, **_kwargs|
+            args_received = args
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            @provider.invoke(input)
+          @provider.invoke(input)
 
-            assert_includes args_received, "--resume"
-            resume_index = args_received.index("--resume")
-            assert_equal "existing_session", args_received[resume_index + 1]
-          end
+          assert_includes args_received, "--resume"
+          resume_index = args_received.index("--resume")
+          assert_equal "existing_session", args_received[resume_index + 1]
+        end
 
-          test "invoke runs all prompts in order" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Summarize", "Format as JSON"]
+        test "invoke runs all prompts in order" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Summarize", "Format as JSON"]
 
-            prompts_received = []
-            CommandRunner.stubs(:execute).with do |_args, **kwargs|
-              prompts_received << kwargs[:stdin_content]
-              result_json = { type: "result", subtype: "success", result: "ok" }.to_json
-              kwargs[:stdout_handler]&.call(result_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
+          prompts_received = []
+          CommandRunner.stubs(:execute).with do |_args, **kwargs|
+            prompts_received << kwargs[:stdin_content]
+            result_json = { type: "result", subtype: "success", result: "ok" }.to_json
+            kwargs[:stdout_handler]&.call(result_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            @provider.invoke(input)
+          @provider.invoke(input)
 
-            assert_equal ["Main task", "Summarize", "Format as JSON"], prompts_received
-          end
+          assert_equal ["Main task", "Summarize", "Format as JSON"], prompts_received
+        end
 
-          test "invoke chains session from previous invocation result to next" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalizer"]
+        test "invoke chains session from previous invocation result to next" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalizer"]
 
-            sessions_seen = []
-            call_count = 0
-            CommandRunner.stubs(:execute).with do |args, **kwargs|
-              call_count += 1
-              if call_count == 1
-                result_json = { type: "result", subtype: "success", result: "done", session_id: "session_from_first" }.to_json
-              else
-                if args.include?("--resume")
-                  resume_index = args.index("--resume")
-                  sessions_seen << args[resume_index + 1]
-                end
-                result_json = { type: "result", subtype: "success", result: "finalized" }.to_json
+          sessions_seen = []
+          call_count = 0
+          CommandRunner.stubs(:execute).with do |args, **kwargs|
+            call_count += 1
+            if call_count == 1
+              result_json = { type: "result", subtype: "success", result: "done", session_id: "session_from_first" }.to_json
+            else
+              if args.include?("--resume")
+                resume_index = args.index("--resume")
+                sessions_seen << args[resume_index + 1]
               end
-              kwargs[:stdout_handler]&.call(result_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
-
-            @provider.invoke(input)
-
-            assert_equal ["session_from_first"], sessions_seen
-          end
-
-          test "invoke does not fork session for subsequent invocations" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalizer"]
-
-            fork_flags = []
-            call_count = 0
-            CommandRunner.stubs(:execute).with do |args, **kwargs|
-              call_count += 1
-              fork_flags << args.include?("--fork-session")
-              result_json = { type: "result", subtype: "success", result: "done", session_id: "session_1" }.to_json
-              kwargs[:stdout_handler]&.call(result_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
-
-            @provider.invoke(input)
-
-            assert_equal [false, false], fork_flags
-          end
-
-          test "invoke forks session for first invocation when input has session" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalizer"]
-            input.session = "external_session"
-
-            fork_flags = []
-            CommandRunner.stubs(:execute).with do |args, **kwargs|
-              fork_flags << args.include?("--fork-session")
-              result_json = { type: "result", subtype: "success", result: "done", session_id: "new_session" }.to_json
-              kwargs[:stdout_handler]&.call(result_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
-
-            @provider.invoke(input)
-
-            assert_equal [true, false], fork_flags
-          end
-
-          test "invoke stops on first failed invocation" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalizer 1", "Finalizer 2"]
-
-            call_count = 0
-            CommandRunner.stubs(:execute).with do |_args, **_kwargs|
-              call_count += 1
-              true
-            end.returns(["", "Error occurred", mock_status(success: false)])
-
-            assert_raises(Claude::ClaudeInvocation::ClaudeFailedError) do
-              @provider.invoke(input)
+              result_json = { type: "result", subtype: "success", result: "finalized" }.to_json
             end
+            kwargs[:stdout_handler]&.call(result_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            assert_equal 1, call_count
+          @provider.invoke(input)
+
+          assert_equal ["session_from_first"], sessions_seen
+        end
+
+        test "invoke does not fork session for subsequent invocations" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalizer"]
+
+          fork_flags = []
+          call_count = 0
+          CommandRunner.stubs(:execute).with do |args, **kwargs|
+            call_count += 1
+            fork_flags << args.include?("--fork-session")
+            result_json = { type: "result", subtype: "success", result: "done", session_id: "session_1" }.to_json
+            kwargs[:stdout_handler]&.call(result_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
+
+          @provider.invoke(input)
+
+          assert_equal [false, false], fork_flags
+        end
+
+        test "invoke forks session for first invocation when input has session" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalizer"]
+          input.session = "external_session"
+
+          fork_flags = []
+          CommandRunner.stubs(:execute).with do |args, **kwargs|
+            fork_flags << args.include?("--fork-session")
+            result_json = { type: "result", subtype: "success", result: "done", session_id: "new_session" }.to_json
+            kwargs[:stdout_handler]&.call(result_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
+
+          @provider.invoke(input)
+
+          assert_equal [true, false], fork_flags
+        end
+
+        test "invoke stops on first failed invocation" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalizer 1", "Finalizer 2"]
+
+          call_count = 0
+          CommandRunner.stubs(:execute).with do |_args, **_kwargs|
+            call_count += 1
+            true
+          end.returns(["", "Error occurred", mock_status(success: false)])
+
+          assert_raises(Claude::ClaudeInvocation::ClaudeFailedError) do
+            @provider.invoke(input)
           end
 
-          test "invoke returns output from last invocation" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalize it"]
+          assert_equal 1, call_count
+        end
 
-            call_count = 0
-            CommandRunner.stubs(:execute).with do |_args, **kwargs|
-              call_count += 1
-              result_text = call_count == 1 ? "intermediate" : "final result"
-              result_json = { type: "result", subtype: "success", result: result_text }.to_json
-              kwargs[:stdout_handler]&.call(result_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
+        test "invoke returns output from last invocation" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalize it"]
 
-            output = @provider.invoke(input)
+          call_count = 0
+          CommandRunner.stubs(:execute).with do |_args, **kwargs|
+            call_count += 1
+            result_text = call_count == 1 ? "intermediate" : "final result"
+            result_json = { type: "result", subtype: "success", result: result_text }.to_json
+            kwargs[:stdout_handler]&.call(result_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            assert_equal "final result", output.response
-          end
+          output = @provider.invoke(input)
 
-          test "invoke sums stats across multiple invocations" do
-            input = Agent::Input.new
-            input.prompts = ["First", "Second"]
+          assert_equal "final result", output.response
+        end
 
-            call_count = 0
-            CommandRunner.stubs(:execute).with do |_args, **kwargs|
-              call_count += 1
-              result_hash = {
-                type: "result",
-                subtype: "success",
-                result: call_count == 1 ? "intermediate" : "final",
-                duration_ms: call_count == 1 ? 1000 : 2000,
-                num_turns: call_count == 1 ? 3 : 5,
-                total_cost_usd: call_count == 1 ? 0.01 : 0.02,
-                modelUsage: {
-                  "claude-sonnet" => {
-                    inputTokens: call_count == 1 ? 100 : 200,
-                    outputTokens: call_count == 1 ? 50 : 75,
-                  },
-                },
-              }
-              kwargs[:stdout_handler]&.call(result_hash.to_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
+        test "invoke sums stats across multiple invocations" do
+          input = Agent::Input.new
+          input.prompts = ["First", "Second"]
 
-            output = @provider.invoke(input)
-
-            assert_equal 3000, output.stats.duration_ms
-            assert_equal 8, output.stats.num_turns
-            assert_in_delta 0.03, output.stats.usage.cost_usd
-            assert_equal 300, output.stats.model_usage[:"claude-sonnet"].input_tokens
-            assert_equal 125, output.stats.model_usage[:"claude-sonnet"].output_tokens
-          end
-
-          test "invoke does not sum stats for single invocation" do
-            input = Agent::Input.new
-            input.prompt = "Only prompt"
-
+          call_count = 0
+          CommandRunner.stubs(:execute).with do |_args, **kwargs|
+            call_count += 1
             result_hash = {
               type: "result",
               subtype: "success",
-              result: "done",
-              duration_ms: 1000,
-              num_turns: 3,
-              total_cost_usd: 0.01,
+              result: call_count == 1 ? "intermediate" : "final",
+              duration_ms: call_count == 1 ? 1000 : 2000,
+              num_turns: call_count == 1 ? 3 : 5,
+              total_cost_usd: call_count == 1 ? 0.01 : 0.02,
+              modelUsage: {
+                "claude-sonnet" => {
+                  inputTokens: call_count == 1 ? 100 : 200,
+                  outputTokens: call_count == 1 ? 50 : 75,
+                },
+              },
             }
-            CommandRunner.stubs(:execute).with do |_args, **kwargs|
-              kwargs[:stdout_handler]&.call(result_hash.to_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
+            kwargs[:stdout_handler]&.call(result_hash.to_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            output = @provider.invoke(input)
+          output = @provider.invoke(input)
 
-            assert_equal 1000, output.stats.duration_ms
-            assert_equal 3, output.stats.num_turns
-          end
+          assert_equal 3000, output.stats.duration_ms
+          assert_equal 8, output.stats.num_turns
+          assert_in_delta 0.03, output.stats.usage.cost_usd
+          assert_equal 300, output.stats.model_usage[:"claude-sonnet"].input_tokens
+          assert_equal 125, output.stats.model_usage[:"claude-sonnet"].output_tokens
+        end
 
-          test "invoke uses input session when no previous invocation session exists" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalize"]
-            input.session = "input_session"
+        test "invoke does not sum stats for single invocation" do
+          input = Agent::Input.new
+          input.prompt = "Only prompt"
 
-            sessions_for_calls = []
-            CommandRunner.stubs(:execute).with do |args, **kwargs|
-              if args.include?("--resume")
-                resume_index = args.index("--resume")
-                sessions_for_calls << args[resume_index + 1]
-              else
-                sessions_for_calls << nil
-              end
-              result_json = { type: "result", subtype: "success", result: "done" }.to_json
-              kwargs[:stdout_handler]&.call(result_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
+          result_hash = {
+            type: "result",
+            subtype: "success",
+            result: "done",
+            duration_ms: 1000,
+            num_turns: 3,
+            total_cost_usd: 0.01,
+          }
+          CommandRunner.stubs(:execute).with do |_args, **kwargs|
+            kwargs[:stdout_handler]&.call(result_hash.to_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            @provider.invoke(input)
+          output = @provider.invoke(input)
 
-            assert_equal ["input_session", "input_session"], sessions_for_calls
-          end
+          assert_equal 1000, output.stats.duration_ms
+          assert_equal 3, output.stats.num_turns
+        end
+
+        test "invoke uses input session when no previous invocation session exists" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalize"]
+          input.session = "input_session"
+
+          sessions_for_calls = []
+          CommandRunner.stubs(:execute).with do |args, **kwargs|
+            if args.include?("--resume")
+              resume_index = args.index("--resume")
+              sessions_for_calls << args[resume_index + 1]
+            else
+              sessions_for_calls << nil
+            end
+            result_json = { type: "result", subtype: "success", result: "done" }.to_json
+            kwargs[:stdout_handler]&.call(result_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
+
+          @provider.invoke(input)
+
+          assert_equal ["input_session", "input_session"], sessions_for_calls
         end
       end
     end

--- a/test/roast/cogs/agent/providers/pi/messages/tool_call_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/tool_call_message_test.rb
@@ -4,57 +4,51 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Pi < Provider
-          module Messages
-            class ToolCallMessageTest < ActiveSupport::TestCase
-              test "format returns BASH with command for bash tool" do
-                msg = ToolCallMessage.new(id: "1", name: "bash", arguments: { command: "ls -la" })
-                assert_equal "BASH ls -la", msg.format
-              end
+    module Agent::Providers::Pi::Messages
+      class ToolCallMessageTest < ActiveSupport::TestCase
+        test "format returns BASH with command for bash tool" do
+          msg = ToolCallMessage.new(id: "1", name: "bash", arguments: { command: "ls -la" })
+          assert_equal "BASH ls -la", msg.format
+        end
 
-              test "format returns READ with path for read tool" do
-                msg = ToolCallMessage.new(id: "1", name: "read", arguments: { path: "/tmp/test.rb" })
-                assert_equal "READ /tmp/test.rb", msg.format
-              end
+        test "format returns READ with path for read tool" do
+          msg = ToolCallMessage.new(id: "1", name: "read", arguments: { path: "/tmp/test.rb" })
+          assert_equal "READ /tmp/test.rb", msg.format
+        end
 
-              test "format returns EDIT with path for edit tool" do
-                msg = ToolCallMessage.new(id: "1", name: "edit", arguments: { path: "/tmp/test.rb" })
-                assert_equal "EDIT /tmp/test.rb", msg.format
-              end
+        test "format returns EDIT with path for edit tool" do
+          msg = ToolCallMessage.new(id: "1", name: "edit", arguments: { path: "/tmp/test.rb" })
+          assert_equal "EDIT /tmp/test.rb", msg.format
+        end
 
-              test "format returns WRITE with path for write tool" do
-                msg = ToolCallMessage.new(id: "1", name: "write", arguments: { path: "/tmp/test.rb" })
-                assert_equal "WRITE /tmp/test.rb", msg.format
-              end
+        test "format returns WRITE with path for write tool" do
+          msg = ToolCallMessage.new(id: "1", name: "write", arguments: { path: "/tmp/test.rb" })
+          assert_equal "WRITE /tmp/test.rb", msg.format
+        end
 
-              test "format returns GREP with pattern for grep tool" do
-                msg = ToolCallMessage.new(id: "1", name: "grep", arguments: { pattern: "foo", path: "." })
-                assert_equal "GREP foo .", msg.format
-              end
+        test "format returns GREP with pattern for grep tool" do
+          msg = ToolCallMessage.new(id: "1", name: "grep", arguments: { pattern: "foo", path: "." })
+          assert_equal "GREP foo .", msg.format
+        end
 
-              test "format returns FIND with pattern for find tool" do
-                msg = ToolCallMessage.new(id: "1", name: "find", arguments: { pattern: "*.rb", path: "." })
-                assert_equal "FIND *.rb .", msg.format
-              end
+        test "format returns FIND with pattern for find tool" do
+          msg = ToolCallMessage.new(id: "1", name: "find", arguments: { pattern: "*.rb", path: "." })
+          assert_equal "FIND *.rb .", msg.format
+        end
 
-              test "format returns LS with path for ls tool" do
-                msg = ToolCallMessage.new(id: "1", name: "ls", arguments: { path: "/tmp" })
-                assert_equal "LS /tmp", msg.format
-              end
+        test "format returns LS with path for ls tool" do
+          msg = ToolCallMessage.new(id: "1", name: "ls", arguments: { path: "/tmp" })
+          assert_equal "LS /tmp", msg.format
+        end
 
-              test "format returns TOOL with name and args for unknown tools" do
-                msg = ToolCallMessage.new(id: "1", name: "custom_tool", arguments: { key: "value" })
-                assert_equal "TOOL [custom_tool] #{{ key: "value" }.inspect}", msg.format
-              end
+        test "format returns TOOL with name and args for unknown tools" do
+          msg = ToolCallMessage.new(id: "1", name: "custom_tool", arguments: { key: "value" })
+          assert_equal "TOOL [custom_tool] #{{ key: "value" }.inspect}", msg.format
+        end
 
-              test "format returns nil when name is nil" do
-                msg = ToolCallMessage.new(id: "1", name: nil, arguments: {})
-                assert_nil msg.format
-              end
-            end
-          end
+        test "format returns nil when name is nil" do
+          msg = ToolCallMessage.new(id: "1", name: nil, arguments: {})
+          assert_nil msg.format
         end
       end
     end

--- a/test/roast/cogs/agent/providers/pi/messages/tool_result_message_test.rb
+++ b/test/roast/cogs/agent/providers/pi/messages/tool_result_message_test.rb
@@ -4,90 +4,84 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Pi < Provider
-          module Messages
-            class ToolResultMessageTest < ActiveSupport::TestCase
-              def setup
-                @context = PiInvocation::Context.new
-              end
+    module Agent::Providers::Pi::Messages
+      class ToolResultMessageTest < ActiveSupport::TestCase
+        def setup
+          @context = Roast::Cogs::Agent::Providers::Pi::PiInvocation::Context.new
+        end
 
-              test "format returns tool name and OK status for successful result" do
-                msg = ToolResultMessage.new(
-                  tool_call_id: "1",
-                  tool_name: "bash",
-                  content: "file1.rb\nfile2.rb",
-                  is_error: false,
-                )
+        test "format returns tool name and OK status for successful result" do
+          msg = ToolResultMessage.new(
+            tool_call_id: "1",
+            tool_name: "bash",
+            content: "file1.rb\nfile2.rb",
+            is_error: false,
+          )
 
-                assert_equal "BASH OK file1.rb\nfile2.rb", msg.format(@context)
-              end
+          assert_equal "BASH OK file1.rb\nfile2.rb", msg.format(@context)
+        end
 
-              test "format returns tool name and ERROR status for error result" do
-                msg = ToolResultMessage.new(
-                  tool_call_id: "1",
-                  tool_name: "bash",
-                  content: "command not found",
-                  is_error: true,
-                )
+        test "format returns tool name and ERROR status for error result" do
+          msg = ToolResultMessage.new(
+            tool_call_id: "1",
+            tool_name: "bash",
+            content: "command not found",
+            is_error: true,
+          )
 
-                assert_equal "BASH ERROR command not found", msg.format(@context)
-              end
+          assert_equal "BASH ERROR command not found", msg.format(@context)
+        end
 
-              test "format truncates long content" do
-                long_content = "x" * 300
-                msg = ToolResultMessage.new(
-                  tool_call_id: "1",
-                  tool_name: "read",
-                  content: long_content,
-                  is_error: false,
-                )
+        test "format truncates long content" do
+          long_content = "x" * 300
+          msg = ToolResultMessage.new(
+            tool_call_id: "1",
+            tool_name: "read",
+            content: long_content,
+            is_error: false,
+          )
 
-                result = msg.format(@context)
-                assert result.length < 220
-                assert result.end_with?("...")
-              end
+          result = msg.format(@context)
+          assert result.length < 220
+          assert result.end_with?("...")
+        end
 
-              test "format handles nil content" do
-                msg = ToolResultMessage.new(
-                  tool_call_id: "1",
-                  tool_name: "bash",
-                  content: nil,
-                  is_error: false,
-                )
+        test "format handles nil content" do
+          msg = ToolResultMessage.new(
+            tool_call_id: "1",
+            tool_name: "bash",
+            content: nil,
+            is_error: false,
+          )
 
-                assert_equal "BASH OK", msg.format(@context)
-              end
+          assert_equal "BASH OK", msg.format(@context)
+        end
 
-              test "format uses tool name from context when tool_name is nil" do
-                tool_call = Messages::ToolCallMessage.new(id: "1", name: "edit", arguments: {})
-                @context.add_tool_call(tool_call)
+        test "format uses tool name from context when tool_name is nil" do
+          tool_call = ToolCallMessage.new(id: "1", name: "edit", arguments: {})
+          @context.add_tool_call(tool_call)
 
-                msg = ToolResultMessage.new(
-                  tool_call_id: "1",
-                  tool_name: nil,
-                  content: "done",
-                  is_error: false,
-                )
+          msg = ToolResultMessage.new(
+            tool_call_id: "1",
+            tool_name: nil,
+            content: "done",
+            is_error: false,
+          )
 
-                result = msg.format(@context)
-                assert result.start_with?("EDIT")
-              end
+          result = msg.format(@context)
+          assert result.start_with?("EDIT")
+        end
 
-              test "format falls back to unknown when no tool name available" do
-                msg = ToolResultMessage.new(
-                  tool_call_id: "nonexistent",
-                  tool_name: nil,
-                  content: "result",
-                  is_error: false,
-                )
+        test "format falls back to unknown when no tool name available" do
+          msg = ToolResultMessage.new(
+            tool_call_id: "nonexistent",
+            tool_name: nil,
+            content: "result",
+            is_error: false,
+          )
 
-                result = msg.format(@context)
-                assert result.start_with?("UNKNOWN")
-              end
-            end
-          end
+          result = msg.format(@context)
+          assert result.start_with?("UNKNOWN")
         end
       end
     end

--- a/test/roast/cogs/agent/providers/pi/pi_invocation_test.rb
+++ b/test/roast/cogs/agent/providers/pi/pi_invocation_test.rb
@@ -4,424 +4,414 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class Pi < Provider
-          class PiInvocationTest < ActiveSupport::TestCase
-            def setup
-              @config = Agent::Config.new
-              @config.provider(:pi)
-              @config.no_display!
-              @invocation = PiInvocation.new(@config, "Test prompt", nil)
+    module Agent::Providers
+      class Pi::PiInvocationTest < ActiveSupport::TestCase
+        def setup
+          @config = Agent::Config.new
+          @config.provider(:pi)
+          @config.no_display!
+          @invocation = Pi::PiInvocation.new(@config, "Test prompt", nil)
+        end
+
+        def success_status
+          mock = Minitest::Mock.new
+          mock.expect(:success?, true)
+          mock
+        end
+
+        def failure_status
+          mock = Minitest::Mock.new
+          mock.expect(:success?, false)
+          mock
+        end
+
+        test "Context#tool_call returns nil when tool_call_id is nil" do
+          context = Pi::PiInvocation::Context.new
+          assert_nil context.tool_call(nil)
+        end
+
+        test "Context#tool_call returns nil for unknown tool_call_id" do
+          context = Pi::PiInvocation::Context.new
+          assert_nil context.tool_call("unknown_id")
+        end
+
+        test "Context#tool_call returns stored ToolCallMessage for known id" do
+          context = Pi::PiInvocation::Context.new
+          tool_call_msg = Pi::Messages::ToolCallMessage.new(
+            id: "test_id",
+            name: "bash",
+            arguments: { command: "ls" },
+          )
+          context.add_tool_call(tool_call_msg)
+
+          result = context.tool_call("test_id")
+          assert_equal tool_call_msg, result
+        end
+
+        test "Context#add_tool_call ignores message with nil id" do
+          context = Pi::PiInvocation::Context.new
+          tool_call_msg = Pi::Messages::ToolCallMessage.new(
+            id: nil,
+            name: "bash",
+            arguments: { command: "ls" },
+          )
+          context.add_tool_call(tool_call_msg)
+          assert_nil context.tool_call(nil)
+        end
+
+        test "Result initializes with empty response and success false" do
+          result = Pi::PiInvocation::Result.new
+          assert_equal "", result.response
+          refute result.success
+          assert_nil result.session
+          assert_nil result.stats
+        end
+
+        test "started? returns false initially" do
+          refute @invocation.started?
+        end
+
+        test "completed? returns false initially" do
+          refute @invocation.completed?
+        end
+
+        test "failed? returns false initially" do
+          refute @invocation.failed?
+        end
+
+        test "running? returns false when not started" do
+          refute @invocation.running?
+        end
+
+        test "result raises PiNotStartedError when not started" do
+          assert_raises(Pi::PiInvocation::PiNotStartedError) do
+            @invocation.result
+          end
+        end
+
+        test "result raises PiFailedError when failed" do
+          CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
+            @invocation.run!
+          end
+
+          assert_raises(Pi::PiInvocation::PiFailedError) do
+            @invocation.result
+          end
+        end
+
+        test "result raises PiNotCompletedError when started but not completed" do
+          CommandRunner.stub(:execute, ->(*) {
+            assert_raises(Pi::PiInvocation::PiNotCompletedError) do
+              @invocation.result
             end
-
-            def success_status
-              mock = Minitest::Mock.new
-              mock.expect(:success?, true)
-              mock
-            end
-
-            def failure_status
-              mock = Minitest::Mock.new
-              mock.expect(:success?, false)
-              mock
-            end
-
-            test "Context#tool_call returns nil when tool_call_id is nil" do
-              context = PiInvocation::Context.new
-              assert_nil context.tool_call(nil)
-            end
-
-            test "Context#tool_call returns nil for unknown tool_call_id" do
-              context = PiInvocation::Context.new
-              assert_nil context.tool_call("unknown_id")
-            end
-
-            test "Context#tool_call returns stored ToolCallMessage for known id" do
-              context = PiInvocation::Context.new
-              tool_call_msg = Messages::ToolCallMessage.new(
-                id: "test_id",
-                name: "bash",
-                arguments: { command: "ls" },
-              )
-              context.add_tool_call(tool_call_msg)
-
-              result = context.tool_call("test_id")
-              assert_equal tool_call_msg, result
-            end
-
-            test "Context#add_tool_call ignores message with nil id" do
-              context = PiInvocation::Context.new
-              tool_call_msg = Messages::ToolCallMessage.new(
-                id: nil,
-                name: "bash",
-                arguments: { command: "ls" },
-              )
-              context.add_tool_call(tool_call_msg)
-              assert_nil context.tool_call(nil)
-            end
-
-            test "Result initializes with empty response and success false" do
-              result = PiInvocation::Result.new
-              assert_equal "", result.response
-              refute result.success
-              assert_nil result.session
-              assert_nil result.stats
-            end
-
-            test "started? returns false initially" do
-              refute @invocation.started?
-            end
-
-            test "completed? returns false initially" do
-              refute @invocation.completed?
-            end
-
-            test "failed? returns false initially" do
-              refute @invocation.failed?
-            end
-
-            test "running? returns false when not started" do
-              refute @invocation.running?
-            end
-
-            test "result raises PiNotStartedError when not started" do
-              assert_raises(PiInvocation::PiNotStartedError) do
-                @invocation.result
-              end
-            end
-
-            test "result raises PiFailedError when failed" do
-              CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
-                @invocation.run!
-              end
-
-              assert_raises(PiInvocation::PiFailedError) do
-                @invocation.result
-              end
-            end
-
-            test "result raises PiNotCompletedError when started but not completed" do
-              CommandRunner.stub(:execute, ->(*) {
-                assert_raises(PiInvocation::PiNotCompletedError) do
-                  @invocation.result
-                end
-                ["", "", success_status]
-              }) do
-                @invocation.run!
-              end
-            end
-
-            test "run! raises PiAlreadyStartedError when called twice" do
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                @invocation.run!
-                assert_raises(PiInvocation::PiAlreadyStartedError) do
-                  @invocation.run!
-                end
-              end
-            end
-
-            test "run! sets started to true" do
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                @invocation.run!
-              end
-              assert @invocation.started?
-            end
-
-            test "run! sets completed to true on successful execution" do
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                @invocation.run!
-              end
-              assert @invocation.completed?
-              refute @invocation.failed?
-            end
-
-            test "run! sets failed to true on unsuccessful execution" do
-              CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
-                @invocation.run!
-              end
-              assert @invocation.failed?
-              refute @invocation.completed?
-            end
-
-            test "running? returns true during execution" do
-              CommandRunner.stub(:execute, ->(*) {
-                assert @invocation.started?
-                assert @invocation.running?
-                ["", "", success_status]
-              }) do
-                @invocation.run!
-              end
-              refute @invocation.running?
-            end
-
-            test "result returns Result object when completed successfully" do
-              CommandRunner.stub(:execute, ["", "", success_status]) do
-                @invocation.run!
-              end
-
-              result = @invocation.result
-              assert_kind_of PiInvocation::Result, result
-            end
-
-            test "command_line uses default pi command" do
-              command = @invocation.send(:command_line)
-              assert_equal "pi", command.first
-              assert_includes command, "--mode"
-              assert_includes command, "json"
-              assert_includes command, "-p"
-              assert_includes command, "--no-session"
-            end
-
-            test "command_line uses custom command when configured as string" do
-              @config.command("custom-pi --flag")
-              invocation = PiInvocation.new(@config, "Test prompt", nil)
-
-              command = invocation.send(:command_line)
-              assert_equal "custom-pi", command.first
-              assert_includes command, "--flag"
-            end
-
-            test "command_line uses custom command when configured as array" do
-              @config.command(["my-pi", "--opt"])
-              invocation = PiInvocation.new(@config, "Test prompt", nil)
-
-              command = invocation.send(:command_line)
-              assert_equal "my-pi", command.first
-              assert_includes command, "--opt"
-            end
-
-            test "command_line includes model when configured" do
-              @config.model("anthropic/claude-sonnet-4-20250514")
-              invocation = PiInvocation.new(@config, "Test prompt", nil)
-
-              command = invocation.send(:command_line)
-              model_index = command.index("--model")
-              assert model_index
-              assert_equal "anthropic/claude-sonnet-4-20250514", command[model_index + 1]
-            end
-
-            test "command_line includes replace_system_prompt when configured" do
-              @config.replace_system_prompt("Custom system prompt")
-              invocation = PiInvocation.new(@config, "Test prompt", nil)
-
-              command = invocation.send(:command_line)
-              prompt_index = command.index("--system-prompt")
-              assert prompt_index
-              assert_equal "Custom system prompt", command[prompt_index + 1]
-            end
-
-            test "command_line includes append_system_prompt when configured" do
-              @config.append_system_prompt("Additional instructions")
-              invocation = PiInvocation.new(@config, "Test prompt", nil)
-
-              command = invocation.send(:command_line)
-              prompt_index = command.index("--append-system-prompt")
-              assert prompt_index
-              assert_equal "Additional instructions", command[prompt_index + 1]
-            end
-
-            test "command_line includes fork flag when session is set" do
-              invocation = PiInvocation.new(@config, "Test prompt", "93b0c56b-b6a9-4b33-8dff-ce0fabceae6d")
-
-              command = invocation.send(:command_line)
-              assert_includes command, "--fork"
-              fork_index = command.index("--fork")
-              assert_equal "93b0c56b-b6a9-4b33-8dff-ce0fabceae6d", command[fork_index + 1]
-              refute_includes command, "--no-session"
-            end
-
-            test "command_line includes --no-session when no session is set" do
-              invocation = PiInvocation.new(@config, "Test prompt", nil)
-
-              command = invocation.send(:command_line)
-              assert_includes command, "--no-session"
-              refute_includes command, "--fork"
-            end
-
-            test "handle_message processes session event and sets session id" do
-              data = { type: "session", id: "test-session-uuid", version: 3 }
-
-              Event.expects(:<<).with { |payload| payload[:debug] == "New Pi Session ID: test-session-uuid" }
-              @invocation.send(:handle_message, data)
-
-              internal_result = @invocation.instance_variable_get(:@result)
-              assert_equal "test-session-uuid", internal_result.session
-            end
-
-            test "handle_message processes turn_start and increments turn count" do
-              @invocation.send(:handle_message, { type: "turn_start" })
-              @invocation.send(:handle_message, { type: "turn_start" })
-
-              num_turns = @invocation.instance_variable_get(:@num_turns)
-              assert_equal 2, num_turns
-            end
-
-            test "handle_message processes text_end and sets response" do
-              data = {
-                type: "message_update",
-                assistantMessageEvent: {
-                  type: "text_end",
-                  content: "Hello! How can I help?",
-                },
-              }
-
-              @invocation.send(:handle_message, data)
-
-              internal_result = @invocation.instance_variable_get(:@result)
-              assert_equal "Hello! How can I help?", internal_result.response
-            end
-
-            test "handle_message processes agent_end and extracts final response" do
-              data = {
-                type: "agent_end",
-                messages: [
-                  { role: "user", content: [{ type: "text", text: "hello" }] },
-                  { role: "assistant", content: [{ type: "text", text: "Hi there!" }] },
-                ],
-              }
-
-              @invocation.send(:handle_message, data)
-
-              internal_result = @invocation.instance_variable_get(:@result)
-              assert_equal "Hi there!", internal_result.response
-            end
-
-            test "handle_message processes message_end with assistant usage" do
-              data = {
-                type: "message_end",
-                message: {
-                  role: "assistant",
-                  model: "claude-sonnet-4-20250514",
-                  content: [{ type: "text", text: "Response text" }],
-                  usage: {
-                    input: 100,
-                    output: 50,
-                    cacheRead: 200,
-                    cacheWrite: 50,
-                    totalTokens: 400,
-                    cost: { input: 0.001, output: 0.002, total: 0.003 },
-                  },
-                },
-              }
-
-              @invocation.send(:handle_message, data)
-
-              acc = @invocation.instance_variable_get(:@model_usage_accumulator)
-              assert acc.key?("claude-sonnet-4-20250514")
-              assert_equal 100, acc["claude-sonnet-4-20250514"][:input]
-              assert_equal 50, acc["claude-sonnet-4-20250514"][:output]
-            end
-
-            test "accumulate_usage sums across multiple message_end events for the same model" do
-              # Mirrors a real pi invocation with tool use: pi emits one message_end per
-              # LLM call (turn 1 → tool call → turn 2 → tool result → turn 3 → final answer),
-              # each carrying independent per-message usage — NOT cumulative totals.
-              model = "claude-haiku-4-5-20251001"
-              turns = [
-                { input: 10, output: 92,  cacheRead: 0, cacheWrite: 9018, cost: { total: 0.01174 } },
-                { input: 14, output: 148, cacheRead: 0, cacheWrite: 0,    cost: { total: 0.00182 } },
-                { input: 13, output: 32,  cacheRead: 0, cacheWrite: 0,    cost: { total: 0.00130 } },
-              ]
-
-              turns.each do |usage|
-                @invocation.send(:accumulate_usage, model, usage)
-              end
-
-              acc = @invocation.instance_variable_get(:@model_usage_accumulator)
-              assert_equal 37,    acc[model][:input]
-              assert_equal 272,   acc[model][:output]
-              assert_equal 9018,  acc[model][:cache_write]
-              assert_in_delta 0.01486, acc[model][:cost], 0.00001
-              assert_in_delta 0.01486, @invocation.instance_variable_get(:@total_cost), 0.00001
-            end
-
-            test "accumulate_usage sums across multiple message_end events for different models" do
-              haiku_usage  = { input: 10, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } }
-              sonnet_usage = { input: 20, output: 80, cacheRead: 0, cacheWrite: 0, cost: { total: 0.004 } }
-
-              @invocation.send(:accumulate_usage, "claude-haiku-4-5-20251001",  haiku_usage)
-              @invocation.send(:accumulate_usage, "claude-sonnet-4-20250514",   sonnet_usage)
-              # second call for haiku — should add, not overwrite
-              @invocation.send(:accumulate_usage, "claude-haiku-4-5-20251001",  haiku_usage)
-
-              acc = @invocation.instance_variable_get(:@model_usage_accumulator)
-              assert_equal 20,  acc["claude-haiku-4-5-20251001"][:input]
-              assert_equal 100, acc["claude-haiku-4-5-20251001"][:output]
-              assert_in_delta 0.002, acc["claude-haiku-4-5-20251001"][:cost], 0.00001
-
-              assert_equal 20,  acc["claude-sonnet-4-20250514"][:input]
-              assert_equal 80,  acc["claude-sonnet-4-20250514"][:output]
-              assert_in_delta 0.004, acc["claude-sonnet-4-20250514"][:cost], 0.00001
-
-              # total_cost must be the sum across all models
-              assert_in_delta 0.006, @invocation.instance_variable_get(:@total_cost), 0.00001
-            end
-
-            test "accumulate_usage does not corrupt stats when usage fields are nil/missing" do
-              @invocation.send(:accumulate_usage, "some-model", { cost: { total: 0.005 } })
-              @invocation.send(:accumulate_usage, "some-model", { input: 5, output: 10, cost: { total: 0.002 } })
-
-              acc = @invocation.instance_variable_get(:@model_usage_accumulator)
-              assert_equal 5,  acc["some-model"][:input]
-              assert_equal 10, acc["some-model"][:output]
-              assert_in_delta 0.007, acc["some-model"][:cost], 0.00001
-            end
-
-            test "handle_message processes toolcall_end and stores in context" do
-              data = {
-                type: "message_update",
-                assistantMessageEvent: {
-                  type: "toolcall_end",
-                  toolCall: {
-                    id: "tool_123",
-                    name: "bash",
-                    arguments: { command: "ls -la" },
-                  },
-                },
-              }
-
-              @invocation.send(:handle_message, data)
-
-              context = @invocation.instance_variable_get(:@context)
-              assert_equal "bash", context.tool_call("tool_123").name
-            end
-
-            test "finalize_stats creates proper stats object" do
-              # Simulate accumulated usage
-              acc = @invocation.instance_variable_get(:@model_usage_accumulator)
-              acc["claude-sonnet-4-20250514"] = { input: 100, output: 50, cache_read: 200, cache_write: 50, cost: 0.003 }
-              @invocation.instance_variable_set(:@num_turns, 3)
-              @invocation.instance_variable_set(:@total_cost, 0.003)
-
-              @invocation.send(:finalize_stats!)
-
-              result = @invocation.instance_variable_get(:@result)
-              stats = result.stats
-              assert_equal 3, stats.num_turns
-              assert_equal 100, stats.usage.input_tokens
-              assert_equal 50, stats.usage.output_tokens
-              assert_in_delta 0.003, stats.usage.cost_usd
-              assert stats.model_usage.key?("claude-sonnet-4-20250514")
-            end
-
-            test "does not emit duplicate session events" do
-              data = { type: "session", id: "same-session" }
-
-              Event.expects(:<<).once
-              @invocation.send(:handle_message, data)
-              @invocation.send(:handle_message, data)
-            end
-
-            test "emits new session event when session changes" do
-              first = { type: "session", id: "session-1" }
-              second = { type: "session", id: "session-2" }
-
-              Event.expects(:<<).twice
-              @invocation.send(:handle_message, first)
-              @invocation.send(:handle_message, second)
+            ["", "", success_status]
+          }) do
+            @invocation.run!
+          end
+        end
+
+        test "run! raises PiAlreadyStartedError when called twice" do
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            @invocation.run!
+            assert_raises(Pi::PiInvocation::PiAlreadyStartedError) do
+              @invocation.run!
             end
           end
+        end
+
+        test "run! sets started to true" do
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            @invocation.run!
+          end
+          assert @invocation.started?
+        end
+
+        test "run! sets completed to true on successful execution" do
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            @invocation.run!
+          end
+          assert @invocation.completed?
+          refute @invocation.failed?
+        end
+
+        test "run! sets failed to true on unsuccessful execution" do
+          CommandRunner.stub(:execute, ["", "Error message", failure_status]) do
+            @invocation.run!
+          end
+          assert @invocation.failed?
+          refute @invocation.completed?
+        end
+
+        test "running? returns true during execution" do
+          CommandRunner.stub(:execute, ->(*) {
+            assert @invocation.started?
+            assert @invocation.running?
+            ["", "", success_status]
+          }) do
+            @invocation.run!
+          end
+          refute @invocation.running?
+        end
+
+        test "result returns Result object when completed successfully" do
+          CommandRunner.stub(:execute, ["", "", success_status]) do
+            @invocation.run!
+          end
+
+          result = @invocation.result
+          assert_kind_of Pi::PiInvocation::Result, result
+        end
+
+        test "command_line uses default pi command" do
+          command = @invocation.send(:command_line)
+          assert_equal "pi", command.first
+          assert_includes command, "--mode"
+          assert_includes command, "json"
+          assert_includes command, "-p"
+          assert_includes command, "--no-session"
+        end
+
+        test "command_line uses custom command when configured as string" do
+          @config.command("custom-pi --flag")
+          invocation = Pi::PiInvocation.new(@config, "Test prompt", nil)
+
+          command = invocation.send(:command_line)
+          assert_equal "custom-pi", command.first
+          assert_includes command, "--flag"
+        end
+
+        test "command_line uses custom command when configured as array" do
+          @config.command(["my-pi", "--opt"])
+          invocation = Pi::PiInvocation.new(@config, "Test prompt", nil)
+
+          command = invocation.send(:command_line)
+          assert_equal "my-pi", command.first
+          assert_includes command, "--opt"
+        end
+
+        test "command_line includes model when configured" do
+          @config.model("anthropic/claude-sonnet-4-20250514")
+          invocation = Pi::PiInvocation.new(@config, "Test prompt", nil)
+
+          command = invocation.send(:command_line)
+          model_index = command.index("--model")
+          assert model_index
+          assert_equal "anthropic/claude-sonnet-4-20250514", command[model_index + 1]
+        end
+
+        test "command_line includes replace_system_prompt when configured" do
+          @config.replace_system_prompt("Custom system prompt")
+          invocation = Pi::PiInvocation.new(@config, "Test prompt", nil)
+
+          command = invocation.send(:command_line)
+          prompt_index = command.index("--system-prompt")
+          assert prompt_index
+          assert_equal "Custom system prompt", command[prompt_index + 1]
+        end
+
+        test "command_line includes append_system_prompt when configured" do
+          @config.append_system_prompt("Additional instructions")
+          invocation = Pi::PiInvocation.new(@config, "Test prompt", nil)
+
+          command = invocation.send(:command_line)
+          prompt_index = command.index("--append-system-prompt")
+          assert prompt_index
+          assert_equal "Additional instructions", command[prompt_index + 1]
+        end
+
+        test "command_line includes fork flag when session is set" do
+          invocation = Pi::PiInvocation.new(@config, "Test prompt", "93b0c56b-b6a9-4b33-8dff-ce0fabceae6d")
+
+          command = invocation.send(:command_line)
+          assert_includes command, "--fork"
+          fork_index = command.index("--fork")
+          assert_equal "93b0c56b-b6a9-4b33-8dff-ce0fabceae6d", command[fork_index + 1]
+          refute_includes command, "--no-session"
+        end
+
+        test "command_line includes --no-session when no session is set" do
+          invocation = Pi::PiInvocation.new(@config, "Test prompt", nil)
+
+          command = invocation.send(:command_line)
+          assert_includes command, "--no-session"
+          refute_includes command, "--fork"
+        end
+
+        test "handle_message processes session event and sets session id" do
+          data = { type: "session", id: "test-session-uuid", version: 3 }
+
+          Event.expects(:<<).with { |payload| payload[:debug] == "New Pi Session ID: test-session-uuid" }
+          @invocation.send(:handle_message, data)
+
+          internal_result = @invocation.instance_variable_get(:@result)
+          assert_equal "test-session-uuid", internal_result.session
+        end
+
+        test "handle_message processes turn_start and increments turn count" do
+          @invocation.send(:handle_message, { type: "turn_start" })
+          @invocation.send(:handle_message, { type: "turn_start" })
+
+          num_turns = @invocation.instance_variable_get(:@num_turns)
+          assert_equal 2, num_turns
+        end
+
+        test "handle_message processes text_end and sets response" do
+          data = {
+            type: "message_update",
+            assistantMessageEvent: {
+              type: "text_end",
+              content: "Hello! How can I help?",
+            },
+          }
+
+          @invocation.send(:handle_message, data)
+
+          internal_result = @invocation.instance_variable_get(:@result)
+          assert_equal "Hello! How can I help?", internal_result.response
+        end
+
+        test "handle_message processes agent_end and extracts final response" do
+          data = {
+            type: "agent_end",
+            messages: [
+              { role: "user", content: [{ type: "text", text: "hello" }] },
+              { role: "assistant", content: [{ type: "text", text: "Hi there!" }] },
+            ],
+          }
+
+          @invocation.send(:handle_message, data)
+
+          internal_result = @invocation.instance_variable_get(:@result)
+          assert_equal "Hi there!", internal_result.response
+        end
+
+        test "handle_message processes message_end with assistant usage" do
+          data = {
+            type: "message_end",
+            message: {
+              role: "assistant",
+              model: "claude-sonnet-4-20250514",
+              content: [{ type: "text", text: "Response text" }],
+              usage: {
+                input: 100,
+                output: 50,
+                cacheRead: 200,
+                cacheWrite: 50,
+                totalTokens: 400,
+                cost: { input: 0.001, output: 0.002, total: 0.003 },
+              },
+            },
+          }
+
+          @invocation.send(:handle_message, data)
+
+          acc = @invocation.instance_variable_get(:@model_usage_accumulator)
+          assert acc.key?("claude-sonnet-4-20250514")
+          assert_equal 100, acc["claude-sonnet-4-20250514"][:input]
+          assert_equal 50, acc["claude-sonnet-4-20250514"][:output]
+        end
+
+        test "accumulate_usage sums across multiple message_end events for the same model" do
+          model = "claude-haiku-4-5-20251001"
+          turns = [
+            { input: 10, output: 92,  cacheRead: 0, cacheWrite: 9018, cost: { total: 0.01174 } },
+            { input: 14, output: 148, cacheRead: 0, cacheWrite: 0,    cost: { total: 0.00182 } },
+            { input: 13, output: 32,  cacheRead: 0, cacheWrite: 0,    cost: { total: 0.00130 } },
+          ]
+
+          turns.each do |usage|
+            @invocation.send(:accumulate_usage, model, usage)
+          end
+
+          acc = @invocation.instance_variable_get(:@model_usage_accumulator)
+          assert_equal 37,    acc[model][:input]
+          assert_equal 272,   acc[model][:output]
+          assert_equal 9018,  acc[model][:cache_write]
+          assert_in_delta 0.01486, acc[model][:cost], 0.00001
+          assert_in_delta 0.01486, @invocation.instance_variable_get(:@total_cost), 0.00001
+        end
+
+        test "accumulate_usage sums across multiple message_end events for different models" do
+          haiku_usage  = { input: 10, output: 50, cacheRead: 0, cacheWrite: 0, cost: { total: 0.001 } }
+          sonnet_usage = { input: 20, output: 80, cacheRead: 0, cacheWrite: 0, cost: { total: 0.004 } }
+
+          @invocation.send(:accumulate_usage, "claude-haiku-4-5-20251001",  haiku_usage)
+          @invocation.send(:accumulate_usage, "claude-sonnet-4-20250514",   sonnet_usage)
+          @invocation.send(:accumulate_usage, "claude-haiku-4-5-20251001",  haiku_usage)
+
+          acc = @invocation.instance_variable_get(:@model_usage_accumulator)
+          assert_equal 20,  acc["claude-haiku-4-5-20251001"][:input]
+          assert_equal 100, acc["claude-haiku-4-5-20251001"][:output]
+          assert_in_delta 0.002, acc["claude-haiku-4-5-20251001"][:cost], 0.00001
+
+          assert_equal 20,  acc["claude-sonnet-4-20250514"][:input]
+          assert_equal 80,  acc["claude-sonnet-4-20250514"][:output]
+          assert_in_delta 0.004, acc["claude-sonnet-4-20250514"][:cost], 0.00001
+
+          assert_in_delta 0.006, @invocation.instance_variable_get(:@total_cost), 0.00001
+        end
+
+        test "accumulate_usage does not corrupt stats when usage fields are nil/missing" do
+          @invocation.send(:accumulate_usage, "some-model", { cost: { total: 0.005 } })
+          @invocation.send(:accumulate_usage, "some-model", { input: 5, output: 10, cost: { total: 0.002 } })
+
+          acc = @invocation.instance_variable_get(:@model_usage_accumulator)
+          assert_equal 5,  acc["some-model"][:input]
+          assert_equal 10, acc["some-model"][:output]
+          assert_in_delta 0.007, acc["some-model"][:cost], 0.00001
+        end
+
+        test "handle_message processes toolcall_end and stores in context" do
+          data = {
+            type: "message_update",
+            assistantMessageEvent: {
+              type: "toolcall_end",
+              toolCall: {
+                id: "tool_123",
+                name: "bash",
+                arguments: { command: "ls -la" },
+              },
+            },
+          }
+
+          @invocation.send(:handle_message, data)
+
+          context = @invocation.instance_variable_get(:@context)
+          assert_equal "bash", context.tool_call("tool_123").name
+        end
+
+        test "finalize_stats creates proper stats object" do
+          acc = @invocation.instance_variable_get(:@model_usage_accumulator)
+          acc["claude-sonnet-4-20250514"] = { input: 100, output: 50, cache_read: 200, cache_write: 50, cost: 0.003 }
+          @invocation.instance_variable_set(:@num_turns, 3)
+          @invocation.instance_variable_set(:@total_cost, 0.003)
+
+          @invocation.send(:finalize_stats!)
+
+          result = @invocation.instance_variable_get(:@result)
+          stats = result.stats
+          assert_equal 3, stats.num_turns
+          assert_equal 100, stats.usage.input_tokens
+          assert_equal 50, stats.usage.output_tokens
+          assert_in_delta 0.003, stats.usage.cost_usd
+          assert stats.model_usage.key?("claude-sonnet-4-20250514")
+        end
+
+        test "does not emit duplicate session events" do
+          data = { type: "session", id: "same-session" }
+
+          Event.expects(:<<).once
+          @invocation.send(:handle_message, data)
+          @invocation.send(:handle_message, data)
+        end
+
+        test "emits new session event when session changes" do
+          first = { type: "session", id: "session-1" }
+          second = { type: "session", id: "session-2" }
+
+          Event.expects(:<<).twice
+          @invocation.send(:handle_message, first)
+          @invocation.send(:handle_message, second)
         end
       end
     end

--- a/test/roast/cogs/agent/providers/pi_test.rb
+++ b/test/roast/cogs/agent/providers/pi_test.rb
@@ -4,280 +4,278 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      module Providers
-        class PiTest < ActiveSupport::TestCase
-          def setup
-            @config = Agent::Config.new
-            @config.provider(:pi)
-            @config.no_display!
-            @provider = Pi.new(@config)
-          end
+    module Agent::Providers
+      class PiTest < ActiveSupport::TestCase
+        def setup
+          @config = Agent::Config.new
+          @config.provider(:pi)
+          @config.no_display!
+          @provider = Pi.new(@config)
+        end
 
-          def mock_status(success:)
-            status = stub("process_status")
-            status.stubs(success?: success)
-            status
-          end
+        def mock_status(success:)
+          status = stub("process_status")
+          status.stubs(success?: success)
+          status
+        end
 
-          test "invoke with single prompt runs a single invocation" do
-            input = Agent::Input.new
-            input.prompt = "Do something"
+        test "invoke with single prompt runs a single invocation" do
+          input = Agent::Input.new
+          input.prompt = "Do something"
 
-            CommandRunner.stubs(:execute).returns(["", "", mock_status(success: true)])
+          CommandRunner.stubs(:execute).returns(["", "", mock_status(success: true)])
 
-            output = @provider.invoke(input)
+          output = @provider.invoke(input)
 
-            assert_kind_of Agent::Output, output
-          end
+          assert_kind_of Agent::Output, output
+        end
 
-          test "invoke passes prompt as stdin to the invocation" do
-            input = Agent::Input.new
-            input.prompt = "Do something"
+        test "invoke passes prompt as stdin to the invocation" do
+          input = Agent::Input.new
+          input.prompt = "Do something"
 
-            stdin_received = nil
-            CommandRunner.stubs(:execute).with do |_args, **kwargs|
-              stdin_received = kwargs[:stdin_content]
-              true
-            end.returns(["", "", mock_status(success: true)])
+          stdin_received = nil
+          CommandRunner.stubs(:execute).with do |_args, **kwargs|
+            stdin_received = kwargs[:stdin_content]
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            @provider.invoke(input)
+          @provider.invoke(input)
 
-            assert_equal "Do something", stdin_received
-          end
+          assert_equal "Do something", stdin_received
+        end
 
-          test "invoke passes session from input to first invocation" do
-            input = Agent::Input.new
-            input.prompt = "Do something"
-            input.session = "existing_session"
+        test "invoke passes session from input to first invocation" do
+          input = Agent::Input.new
+          input.prompt = "Do something"
+          input.session = "existing_session"
 
-            args_received = nil
-            CommandRunner.stubs(:execute).with do |args, **_kwargs|
-              args_received = args
-              true
-            end.returns(["", "", mock_status(success: true)])
+          args_received = nil
+          CommandRunner.stubs(:execute).with do |args, **_kwargs|
+            args_received = args
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            @provider.invoke(input)
+          @provider.invoke(input)
 
-            assert_includes args_received, "--fork"
-            fork_index = args_received.index("--fork")
-            assert_equal "existing_session", args_received[fork_index + 1]
-          end
+          assert_includes args_received, "--fork"
+          fork_index = args_received.index("--fork")
+          assert_equal "existing_session", args_received[fork_index + 1]
+        end
 
-          test "invoke runs all prompts in order" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Summarize", "Format as JSON"]
+        test "invoke runs all prompts in order" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Summarize", "Format as JSON"]
 
-            prompts_received = []
-            CommandRunner.stubs(:execute).with do |_args, **kwargs|
-              prompts_received << kwargs[:stdin_content]
-              session_json = { type: "session", id: "session_#{prompts_received.size}" }.to_json
-              kwargs[:stdout_handler]&.call(session_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
+          prompts_received = []
+          CommandRunner.stubs(:execute).with do |_args, **kwargs|
+            prompts_received << kwargs[:stdin_content]
+            session_json = { type: "session", id: "session_#{prompts_received.size}" }.to_json
+            kwargs[:stdout_handler]&.call(session_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            @provider.invoke(input)
+          @provider.invoke(input)
 
-            assert_equal ["Main task", "Summarize", "Format as JSON"], prompts_received
-          end
+          assert_equal ["Main task", "Summarize", "Format as JSON"], prompts_received
+        end
 
-          test "invoke chains session from previous invocation result to next" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalizer"]
+        test "invoke chains session from previous invocation result to next" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalizer"]
 
-            sessions_seen = []
-            call_count = 0
-            CommandRunner.stubs(:execute).with do |args, **kwargs|
-              call_count += 1
-              if call_count > 1 && args.include?("--fork")
-                fork_index = args.index("--fork")
-                sessions_seen << args[fork_index + 1]
-              end
-              session_id = call_count == 1 ? "session_from_first" : "session_from_second"
-              session_json = { type: "session", id: session_id }.to_json
-              kwargs[:stdout_handler]&.call(session_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
-
-            @provider.invoke(input)
-
-            assert_equal ["session_from_first"], sessions_seen
-          end
-
-          test "invoke always uses --fork for session chaining" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalizer"]
-
-            fork_flags = []
-            CommandRunner.stubs(:execute).with do |args, **kwargs|
-              fork_flags << args.include?("--fork")
-              session_json = { type: "session", id: "session_1" }.to_json
-              kwargs[:stdout_handler]&.call(session_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
-
-            @provider.invoke(input)
-
-            # First invocation has no session, so --no-session (no --fork).
-            # Second invocation forks from the first session.
-            assert_equal [false, true], fork_flags
-          end
-
-          test "invoke uses --fork for first invocation when input has session" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalizer"]
-            input.session = "external_session"
-
-            fork_flags = []
-            CommandRunner.stubs(:execute).with do |args, **kwargs|
-              fork_flags << args.include?("--fork")
-              session_json = { type: "session", id: "new_session" }.to_json
-              kwargs[:stdout_handler]&.call(session_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
-
-            @provider.invoke(input)
-
-            assert_equal [true, true], fork_flags
-          end
-
-          test "invoke stops on first failed invocation" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalizer 1", "Finalizer 2"]
-
-            call_count = 0
-            CommandRunner.stubs(:execute).with do |_args, **_kwargs|
-              call_count += 1
-              true
-            end.returns(["", "Error occurred", mock_status(success: false)])
-
-            assert_raises(Pi::PiInvocation::PiFailedError) do
-              @provider.invoke(input)
+          sessions_seen = []
+          call_count = 0
+          CommandRunner.stubs(:execute).with do |args, **kwargs|
+            call_count += 1
+            if call_count > 1 && args.include?("--fork")
+              fork_index = args.index("--fork")
+              sessions_seen << args[fork_index + 1]
             end
+            session_id = call_count == 1 ? "session_from_first" : "session_from_second"
+            session_json = { type: "session", id: session_id }.to_json
+            kwargs[:stdout_handler]&.call(session_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            assert_equal 1, call_count
-          end
+          @provider.invoke(input)
 
-          test "invoke returns output from last invocation" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalize it"]
+          assert_equal ["session_from_first"], sessions_seen
+        end
 
-            call_count = 0
-            CommandRunner.stubs(:execute).with do |_args, **kwargs|
-              call_count += 1
-              result_text = call_count == 1 ? "intermediate" : "final result"
-              # Pi uses agent_end to extract the final response
-              agent_end_json = {
-                type: "agent_end",
-                messages: [
-                  { role: "assistant", content: [{ type: "text", text: result_text }] },
-                ],
-              }.to_json
-              kwargs[:stdout_handler]&.call(agent_end_json)
-              # Also emit a session so the chain can continue
-              session_json = { type: "session", id: "session_#{call_count}" }.to_json
-              kwargs[:stdout_handler]&.call(session_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
+        test "invoke always uses --fork for session chaining" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalizer"]
 
-            output = @provider.invoke(input)
+          fork_flags = []
+          CommandRunner.stubs(:execute).with do |args, **kwargs|
+            fork_flags << args.include?("--fork")
+            session_json = { type: "session", id: "session_1" }.to_json
+            kwargs[:stdout_handler]&.call(session_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            assert_equal "final result", output.response
-          end
+          @provider.invoke(input)
 
-          test "invoke sums stats across multiple invocations" do
-            input = Agent::Input.new
-            input.prompts = ["First", "Second"]
+          # First invocation has no session, so --no-session (no --fork).
+          # Second invocation forks from the first session.
+          assert_equal [false, true], fork_flags
+        end
 
-            call_count = 0
-            CommandRunner.stubs(:execute).with do |_args, **kwargs|
-              call_count += 1
-              # Simulate turn_start events: 3 turns for first invocation, 5 for second
-              num_turns = call_count == 1 ? 3 : 5
-              num_turns.times { kwargs[:stdout_handler]&.call({ type: "turn_start" }.to_json) }
-              usage_data = {
-                type: "message_end",
-                message: {
-                  role: "assistant",
-                  model: "claude-sonnet",
-                  content: [{ type: "text", text: call_count == 1 ? "intermediate" : "final" }],
-                  usage: {
-                    input: call_count == 1 ? 100 : 200,
-                    output: call_count == 1 ? 50 : 75,
-                    cacheRead: 0,
-                    cacheWrite: 0,
-                    cost: { total: call_count == 1 ? 0.01 : 0.02 },
-                  },
-                },
-              }.to_json
-              kwargs[:stdout_handler]&.call(usage_data)
-              session_json = { type: "session", id: "session_#{call_count}" }.to_json
-              kwargs[:stdout_handler]&.call(session_json)
-              true
-            end.returns(["", "", mock_status(success: true)])
+        test "invoke uses --fork for first invocation when input has session" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalizer"]
+          input.session = "external_session"
 
-            output = @provider.invoke(input)
+          fork_flags = []
+          CommandRunner.stubs(:execute).with do |args, **kwargs|
+            fork_flags << args.include?("--fork")
+            session_json = { type: "session", id: "new_session" }.to_json
+            kwargs[:stdout_handler]&.call(session_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
 
-            assert_equal 8, output.stats.num_turns
-            assert_in_delta 0.03, output.stats.usage.cost_usd
-            assert_equal 300, output.stats.model_usage["claude-sonnet"].input_tokens
-            assert_equal 125, output.stats.model_usage["claude-sonnet"].output_tokens
-          end
+          @provider.invoke(input)
 
-          test "invoke does not sum stats for single invocation" do
-            input = Agent::Input.new
-            input.prompt = "Only prompt"
+          assert_equal [true, true], fork_flags
+        end
 
-            CommandRunner.stubs(:execute).with do |_args, **kwargs|
-              kwargs[:stdout_handler]&.call({ type: "turn_start" }.to_json)
-              kwargs[:stdout_handler]&.call({ type: "turn_start" }.to_json)
-              kwargs[:stdout_handler]&.call({ type: "turn_start" }.to_json)
-              usage_data = {
-                type: "message_end",
-                message: {
-                  role: "assistant",
-                  model: "claude-sonnet",
-                  content: [{ type: "text", text: "done" }],
-                  usage: {
-                    input: 100,
-                    output: 50,
-                    cacheRead: 0,
-                    cacheWrite: 0,
-                    cost: { total: 0.01 },
-                  },
-                },
-              }.to_json
-              kwargs[:stdout_handler]&.call(usage_data)
-              true
-            end.returns(["", "", mock_status(success: true)])
+        test "invoke stops on first failed invocation" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalizer 1", "Finalizer 2"]
 
-            output = @provider.invoke(input)
+          call_count = 0
+          CommandRunner.stubs(:execute).with do |_args, **_kwargs|
+            call_count += 1
+            true
+          end.returns(["", "Error occurred", mock_status(success: false)])
 
-            assert_equal 3, output.stats.num_turns
-          end
-
-          test "invoke uses input session when no previous invocation session exists" do
-            input = Agent::Input.new
-            input.prompts = ["Main task", "Finalize"]
-            input.session = "input_session"
-
-            sessions_for_calls = []
-            CommandRunner.stubs(:execute).with do |args, **_kwargs|
-              if args.include?("--fork")
-                fork_index = args.index("--fork")
-                sessions_for_calls << args[fork_index + 1]
-              else
-                sessions_for_calls << nil
-              end
-              # Don't emit a session event, so no session chains forward
-              true
-            end.returns(["", "", mock_status(success: true)])
-
+          assert_raises(Pi::PiInvocation::PiFailedError) do
             @provider.invoke(input)
-
-            # Both calls should use the input session since no session was returned
-            assert_equal ["input_session", "input_session"], sessions_for_calls
           end
+
+          assert_equal 1, call_count
+        end
+
+        test "invoke returns output from last invocation" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalize it"]
+
+          call_count = 0
+          CommandRunner.stubs(:execute).with do |_args, **kwargs|
+            call_count += 1
+            result_text = call_count == 1 ? "intermediate" : "final result"
+            # Pi uses agent_end to extract the final response
+            agent_end_json = {
+              type: "agent_end",
+              messages: [
+                { role: "assistant", content: [{ type: "text", text: result_text }] },
+              ],
+            }.to_json
+            kwargs[:stdout_handler]&.call(agent_end_json)
+            # Also emit a session so the chain can continue
+            session_json = { type: "session", id: "session_#{call_count}" }.to_json
+            kwargs[:stdout_handler]&.call(session_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
+
+          output = @provider.invoke(input)
+
+          assert_equal "final result", output.response
+        end
+
+        test "invoke sums stats across multiple invocations" do
+          input = Agent::Input.new
+          input.prompts = ["First", "Second"]
+
+          call_count = 0
+          CommandRunner.stubs(:execute).with do |_args, **kwargs|
+            call_count += 1
+            # Simulate turn_start events: 3 turns for first invocation, 5 for second
+            num_turns = call_count == 1 ? 3 : 5
+            num_turns.times { kwargs[:stdout_handler]&.call({ type: "turn_start" }.to_json) }
+            usage_data = {
+              type: "message_end",
+              message: {
+                role: "assistant",
+                model: "claude-sonnet",
+                content: [{ type: "text", text: call_count == 1 ? "intermediate" : "final" }],
+                usage: {
+                  input: call_count == 1 ? 100 : 200,
+                  output: call_count == 1 ? 50 : 75,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  cost: { total: call_count == 1 ? 0.01 : 0.02 },
+                },
+              },
+            }.to_json
+            kwargs[:stdout_handler]&.call(usage_data)
+            session_json = { type: "session", id: "session_#{call_count}" }.to_json
+            kwargs[:stdout_handler]&.call(session_json)
+            true
+          end.returns(["", "", mock_status(success: true)])
+
+          output = @provider.invoke(input)
+
+          assert_equal 8, output.stats.num_turns
+          assert_in_delta 0.03, output.stats.usage.cost_usd
+          assert_equal 300, output.stats.model_usage["claude-sonnet"].input_tokens
+          assert_equal 125, output.stats.model_usage["claude-sonnet"].output_tokens
+        end
+
+        test "invoke does not sum stats for single invocation" do
+          input = Agent::Input.new
+          input.prompt = "Only prompt"
+
+          CommandRunner.stubs(:execute).with do |_args, **kwargs|
+            kwargs[:stdout_handler]&.call({ type: "turn_start" }.to_json)
+            kwargs[:stdout_handler]&.call({ type: "turn_start" }.to_json)
+            kwargs[:stdout_handler]&.call({ type: "turn_start" }.to_json)
+            usage_data = {
+              type: "message_end",
+              message: {
+                role: "assistant",
+                model: "claude-sonnet",
+                content: [{ type: "text", text: "done" }],
+                usage: {
+                  input: 100,
+                  output: 50,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  cost: { total: 0.01 },
+                },
+              },
+            }.to_json
+            kwargs[:stdout_handler]&.call(usage_data)
+            true
+          end.returns(["", "", mock_status(success: true)])
+
+          output = @provider.invoke(input)
+
+          assert_equal 3, output.stats.num_turns
+        end
+
+        test "invoke uses input session when no previous invocation session exists" do
+          input = Agent::Input.new
+          input.prompts = ["Main task", "Finalize"]
+          input.session = "input_session"
+
+          sessions_for_calls = []
+          CommandRunner.stubs(:execute).with do |args, **_kwargs|
+            if args.include?("--fork")
+              fork_index = args.index("--fork")
+              sessions_for_calls << args[fork_index + 1]
+            else
+              sessions_for_calls << nil
+            end
+            # Don't emit a session event, so no session chains forward
+            true
+          end.returns(["", "", mock_status(success: true)])
+
+          @provider.invoke(input)
+
+          # Both calls should use the input session since no session was returned
+          assert_equal ["input_session", "input_session"], sessions_for_calls
         end
       end
     end

--- a/test/roast/cogs/agent/stats_test.rb
+++ b/test/roast/cogs/agent/stats_test.rb
@@ -4,214 +4,212 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      class StatsTest < ActiveSupport::TestCase
-        def setup
-          @stats = Stats.new
-        end
+    class Agent::StatsTest < ActiveSupport::TestCase
+      def setup
+        @stats = Agent::Stats.new
+      end
 
-        test "initialize creates empty usage" do
-          assert_not_nil @stats.usage
-        end
+      test "initialize creates empty usage" do
+        assert_not_nil @stats.usage
+      end
 
-        test "initialize creates empty model_usage hash" do
-          assert_equal({}, @stats.model_usage)
-        end
+      test "initialize creates empty model_usage hash" do
+        assert_equal({}, @stats.model_usage)
+      end
 
-        test "to_s shows NO_VALUE for nil duration" do
-          output = @stats.to_s
+      test "to_s shows NO_VALUE for nil duration" do
+        output = @stats.to_s
 
-          assert_match(/Duration: ---/, output)
-        end
+        assert_match(/Duration: ---/, output)
+      end
 
-        test "to_s shows NO_VALUE for nil turns" do
-          output = @stats.to_s
+      test "to_s shows NO_VALUE for nil turns" do
+        output = @stats.to_s
 
-          assert_match(/Turns: ---/, output)
-        end
+        assert_match(/Turns: ---/, output)
+      end
 
-        test "to_s shows NO_VALUE for nil cost" do
-          output = @stats.to_s
+      test "to_s shows NO_VALUE for nil cost" do
+        output = @stats.to_s
 
-          assert_match(/Cost \(USD\): \$---/, output)
-        end
+        assert_match(/Cost \(USD\): \$---/, output)
+      end
 
-        test "to_s formats duration when present" do
-          @stats.duration_ms = 5000
+      test "to_s formats duration when present" do
+        @stats.duration_ms = 5000
 
-          output = @stats.to_s
+        output = @stats.to_s
 
-          assert_match(/Duration: 5 seconds/, output)
-        end
+        assert_match(/Duration: 5 seconds/, output)
+      end
 
-        test "to_s formats turns when present" do
-          @stats.num_turns = 3
+      test "to_s formats turns when present" do
+        @stats.num_turns = 3
 
-          output = @stats.to_s
+        output = @stats.to_s
 
-          assert_match(/Turns: 3/, output)
-        end
+        assert_match(/Turns: 3/, output)
+      end
 
-        test "to_s formats cost when present" do
-          @stats.usage.cost_usd = 0.123456
+      test "to_s formats cost when present" do
+        @stats.usage.cost_usd = 0.123456
 
-          output = @stats.to_s
+        output = @stats.to_s
 
-          assert_match(/Cost \(USD\): \$0\.123456/, output)
-        end
+        assert_match(/Cost \(USD\): \$0\.123456/, output)
+      end
 
-        test "to_s includes model usage when present" do
-          model_usage = Usage.new
-          model_usage.input_tokens = 1000
-          model_usage.output_tokens = 500
-          @stats.model_usage["claude-3-opus"] = model_usage
+      test "to_s includes model usage when present" do
+        model_usage = Agent::Usage.new
+        model_usage.input_tokens = 1000
+        model_usage.output_tokens = 500
+        @stats.model_usage["claude-3-opus"] = model_usage
 
-          output = @stats.to_s
+        output = @stats.to_s
 
-          assert_match(/Tokens \(claude-3-opus\):/, output)
-          assert_match(/in, 500 out/, output)
-        end
+        assert_match(/Tokens \(claude-3-opus\):/, output)
+        assert_match(/in, 500 out/, output)
+      end
 
-        test "to_s shows NO_VALUE for model with nil tokens" do
-          model_usage = Usage.new
-          @stats.model_usage["test-model"] = model_usage
+      test "to_s shows NO_VALUE for model with nil tokens" do
+        model_usage = Agent::Usage.new
+        @stats.model_usage["test-model"] = model_usage
 
-          output = @stats.to_s
+        output = @stats.to_s
 
-          assert_match(/Tokens \(test-model\): --- in, --- out/, output)
-        end
+        assert_match(/Tokens \(test-model\): --- in, --- out/, output)
+      end
 
-        test "to_s includes multiple models" do
-          model1 = Usage.new
-          model1.input_tokens = 1000
-          model1.output_tokens = 500
+      test "to_s includes multiple models" do
+        model1 = Agent::Usage.new
+        model1.input_tokens = 1000
+        model1.output_tokens = 500
 
-          model2 = Usage.new
-          model2.input_tokens = 2000
-          model2.output_tokens = 1000
+        model2 = Agent::Usage.new
+        model2.input_tokens = 2000
+        model2.output_tokens = 1000
 
-          @stats.model_usage["model1"] = model1
-          @stats.model_usage["model2"] = model2
+        @stats.model_usage["model1"] = model1
+        @stats.model_usage["model2"] = model2
 
-          output = @stats.to_s
+        output = @stats.to_s
 
-          assert_match(/Tokens \(model1\):/, output)
-          assert_match(/Tokens \(model2\):/, output)
-        end
+        assert_match(/Tokens \(model1\):/, output)
+        assert_match(/Tokens \(model2\):/, output)
+      end
 
-        test "+ sums duration_ms" do
-          a = Stats.new
-          a.duration_ms = 3000
-          b = Stats.new
-          b.duration_ms = 2000
+      test "+ sums duration_ms" do
+        a = Agent::Stats.new
+        a.duration_ms = 3000
+        b = Agent::Stats.new
+        b.duration_ms = 2000
 
-          result = a + b
+        result = a + b
 
-          assert_equal 5000, result.duration_ms
-        end
+        assert_equal 5000, result.duration_ms
+      end
 
-        test "+ sums num_turns" do
-          a = Stats.new
-          a.num_turns = 3
-          b = Stats.new
-          b.num_turns = 5
+      test "+ sums num_turns" do
+        a = Agent::Stats.new
+        a.num_turns = 3
+        b = Agent::Stats.new
+        b.num_turns = 5
 
-          result = a + b
+        result = a + b
 
-          assert_equal 8, result.num_turns
-        end
+        assert_equal 8, result.num_turns
+      end
 
-        test "+ sums usage" do
-          a = Stats.new
-          a.usage.input_tokens = 100
-          a.usage.cost_usd = 0.01
-          b = Stats.new
-          b.usage.input_tokens = 200
-          b.usage.cost_usd = 0.02
+      test "+ sums usage" do
+        a = Agent::Stats.new
+        a.usage.input_tokens = 100
+        a.usage.cost_usd = 0.01
+        b = Agent::Stats.new
+        b.usage.input_tokens = 200
+        b.usage.cost_usd = 0.02
 
-          result = a + b
+        result = a + b
 
-          assert_equal 300, result.usage.input_tokens
-          assert_in_delta 0.03, result.usage.cost_usd
-        end
+        assert_equal 300, result.usage.input_tokens
+        assert_in_delta 0.03, result.usage.cost_usd
+      end
 
-        test "+ merges model_usage for different models" do
-          a = Stats.new
-          usage_a = Usage.new
-          usage_a.input_tokens = 100
-          a.model_usage["model-a"] = usage_a
+      test "+ merges model_usage for different models" do
+        a = Agent::Stats.new
+        usage_a = Agent::Usage.new
+        usage_a.input_tokens = 100
+        a.model_usage["model-a"] = usage_a
 
-          b = Stats.new
-          usage_b = Usage.new
-          usage_b.input_tokens = 200
-          b.model_usage["model-b"] = usage_b
+        b = Agent::Stats.new
+        usage_b = Agent::Usage.new
+        usage_b.input_tokens = 200
+        b.model_usage["model-b"] = usage_b
 
-          result = a + b
+        result = a + b
 
-          assert_equal 100, result.model_usage["model-a"].input_tokens
-          assert_equal 200, result.model_usage["model-b"].input_tokens
-        end
+        assert_equal 100, result.model_usage["model-a"].input_tokens
+        assert_equal 200, result.model_usage["model-b"].input_tokens
+      end
 
-        test "+ sums model_usage for the same model" do
-          a = Stats.new
-          usage_a = Usage.new
-          usage_a.input_tokens = 100
-          usage_a.output_tokens = 50
-          a.model_usage["claude"] = usage_a
+      test "+ sums model_usage for the same model" do
+        a = Agent::Stats.new
+        usage_a = Agent::Usage.new
+        usage_a.input_tokens = 100
+        usage_a.output_tokens = 50
+        a.model_usage["claude"] = usage_a
 
-          b = Stats.new
-          usage_b = Usage.new
-          usage_b.input_tokens = 200
-          usage_b.output_tokens = 75
-          b.model_usage["claude"] = usage_b
+        b = Agent::Stats.new
+        usage_b = Agent::Usage.new
+        usage_b.input_tokens = 200
+        usage_b.output_tokens = 75
+        b.model_usage["claude"] = usage_b
 
-          result = a + b
+        result = a + b
 
-          assert_equal 300, result.model_usage["claude"].input_tokens
-          assert_equal 125, result.model_usage["claude"].output_tokens
-        end
+        assert_equal 300, result.model_usage["claude"].input_tokens
+        assert_equal 125, result.model_usage["claude"].output_tokens
+      end
 
-        test "+ returns nil for fields that are nil on both sides" do
-          a = Stats.new
-          b = Stats.new
+      test "+ returns nil for fields that are nil on both sides" do
+        a = Agent::Stats.new
+        b = Agent::Stats.new
 
-          result = a + b
+        result = a + b
 
-          assert_nil result.duration_ms
-          assert_nil result.num_turns
-        end
+        assert_nil result.duration_ms
+        assert_nil result.num_turns
+      end
 
-        test "+ does not mutate operands" do
-          a = Stats.new
-          a.duration_ms = 1000
-          a.num_turns = 2
-          b = Stats.new
-          b.duration_ms = 2000
-          b.num_turns = 3
+      test "+ does not mutate operands" do
+        a = Agent::Stats.new
+        a.duration_ms = 1000
+        a.num_turns = 2
+        b = Agent::Stats.new
+        b.duration_ms = 2000
+        b.num_turns = 3
 
-          _ = a + b
+        _ = a + b
 
-          assert_equal 1000, a.duration_ms
-          assert_equal 2, a.num_turns
-        end
+        assert_equal 1000, a.duration_ms
+        assert_equal 2, a.num_turns
+      end
 
-        test "to_s formats complete stats" do
-          @stats.duration_ms = 5000
-          @stats.num_turns = 3
-          @stats.usage.cost_usd = 0.05
+      test "to_s formats complete stats" do
+        @stats.duration_ms = 5000
+        @stats.num_turns = 3
+        @stats.usage.cost_usd = 0.05
 
-          model_usage = Usage.new
-          model_usage.input_tokens = 1000
-          model_usage.output_tokens = 500
-          @stats.model_usage["claude-3-opus"] = model_usage
+        model_usage = Agent::Usage.new
+        model_usage.input_tokens = 1000
+        model_usage.output_tokens = 500
+        @stats.model_usage["claude-3-opus"] = model_usage
 
-          output = @stats.to_s
+        output = @stats.to_s
 
-          assert_match(/Turns: 3/, output)
-          assert_match(/Duration: 5 seconds/, output)
-          assert_match(/Cost \(USD\): \$0\.05/, output)
-          assert_match(/Tokens \(claude-3-opus\):/, output)
-        end
+        assert_match(/Turns: 3/, output)
+        assert_match(/Duration: 5 seconds/, output)
+        assert_match(/Cost \(USD\): \$0\.05/, output)
+        assert_match(/Tokens \(claude-3-opus\):/, output)
       end
     end
   end

--- a/test/roast/cogs/agent/usage_test.rb
+++ b/test/roast/cogs/agent/usage_test.rb
@@ -4,74 +4,72 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Agent < Cog
-      class UsageTest < ActiveSupport::TestCase
-        test "+ sums input_tokens" do
-          a = Usage.new
-          a.input_tokens = 100
-          b = Usage.new
-          b.input_tokens = 200
+    class Agent::UsageTest < ActiveSupport::TestCase
+      test "+ sums input_tokens" do
+        a = Agent::Usage.new
+        a.input_tokens = 100
+        b = Agent::Usage.new
+        b.input_tokens = 200
 
-          result = a + b
+        result = a + b
 
-          assert_equal 300, result.input_tokens
-        end
+        assert_equal 300, result.input_tokens
+      end
 
-        test "+ sums output_tokens" do
-          a = Usage.new
-          a.output_tokens = 50
-          b = Usage.new
-          b.output_tokens = 75
+      test "+ sums output_tokens" do
+        a = Agent::Usage.new
+        a.output_tokens = 50
+        b = Agent::Usage.new
+        b.output_tokens = 75
 
-          result = a + b
+        result = a + b
 
-          assert_equal 125, result.output_tokens
-        end
+        assert_equal 125, result.output_tokens
+      end
 
-        test "+ sums cost_usd" do
-          a = Usage.new
-          a.cost_usd = 0.01
-          b = Usage.new
-          b.cost_usd = 0.02
+      test "+ sums cost_usd" do
+        a = Agent::Usage.new
+        a.cost_usd = 0.01
+        b = Agent::Usage.new
+        b.cost_usd = 0.02
 
-          result = a + b
+        result = a + b
 
-          assert_in_delta 0.03, result.cost_usd
-        end
+        assert_in_delta 0.03, result.cost_usd
+      end
 
-        test "+ treats nil as zero when other is non-nil" do
-          a = Usage.new
-          a.input_tokens = 100
-          b = Usage.new
+      test "+ treats nil as zero when other is non-nil" do
+        a = Agent::Usage.new
+        a.input_tokens = 100
+        b = Agent::Usage.new
 
-          result = a + b
+        result = a + b
 
-          assert_equal 100, result.input_tokens
-          assert_nil result.output_tokens
-        end
+        assert_equal 100, result.input_tokens
+        assert_nil result.output_tokens
+      end
 
-        test "+ returns nil when both values are nil" do
-          a = Usage.new
-          b = Usage.new
+      test "+ returns nil when both values are nil" do
+        a = Agent::Usage.new
+        b = Agent::Usage.new
 
-          result = a + b
+        result = a + b
 
-          assert_nil result.input_tokens
-          assert_nil result.output_tokens
-          assert_nil result.cost_usd
-        end
+        assert_nil result.input_tokens
+        assert_nil result.output_tokens
+        assert_nil result.cost_usd
+      end
 
-        test "+ does not mutate operands" do
-          a = Usage.new
-          a.input_tokens = 100
-          b = Usage.new
-          b.input_tokens = 200
+      test "+ does not mutate operands" do
+        a = Agent::Usage.new
+        a.input_tokens = 100
+        b = Agent::Usage.new
+        b.input_tokens = 200
 
-          _ = a + b
+        _ = a + b
 
-          assert_equal 100, a.input_tokens
-          assert_equal 200, b.input_tokens
-        end
+        assert_equal 100, a.input_tokens
+        assert_equal 200, b.input_tokens
       end
     end
   end

--- a/test/roast/cogs/chat/config_test.rb
+++ b/test/roast/cogs/chat/config_test.rb
@@ -4,361 +4,386 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Chat < Cog
-      class ConfigTest < ActiveSupport::TestCase
-        def setup
-          @config = Config.new
+    class Chat::ConfigTest < ActiveSupport::TestCase
+      def setup
+        @config = Chat::Config.new
+      end
+
+      # Provider configuration tests
+      test "provider sets provider value" do
+        @config.provider(:openai)
+
+        assert_equal :openai, @config.valid_provider!
+      end
+
+      test "use_default_provider! clears provider value" do
+        @config.provider(:custom_provider)
+        @config.use_default_provider!
+
+        assert_equal :openai, @config.valid_provider!
+      end
+
+      test "valid_provider! returns default when not set" do
+        assert_equal :openai, @config.valid_provider!
+      end
+
+      test "valid_provider! accepts and sets :openai" do
+        @config.provider(:openai)
+        assert_equal :openai, @config.valid_provider!
+      end
+
+      test "valid_provider! accepts and sets :anthropic" do
+        @config.provider(:anthropic)
+        assert_equal :anthropic, @config.valid_provider!
+      end
+
+      test "valid_provider! accepts and sets :perplexity" do
+        @config.provider(:perplexity)
+        assert_equal :perplexity, @config.valid_provider!
+      end
+
+      test "valid_provider! accepts and sets :gemini" do
+        @config.provider(:gemini)
+        assert_equal :gemini, @config.valid_provider!
+      end
+
+      test "valid_provider! raises on invalid provider" do
+        @config.provider(:invalid_provider)
+
+        error = assert_raises(ArgumentError) do
+          @config.valid_provider!
         end
 
-        # Provider configuration tests
+        assert_match(/invalid_provider.*not a valid provider/, error.message)
+      end
 
-        test "use_default_provider! clears provider value" do
-          @config.provider(:custom_provider)
-          @config.use_default_provider!
+      # API key configuration tests
+      test "api_key sets api key value" do
+        @config.api_key("test-key-123")
 
-          assert_equal :openai, @config.valid_provider!
-        end
+        assert_equal "test-key-123", @config.valid_api_key!
+      end
 
-        test "valid_provider! returns default when not set" do
-          assert_equal :openai, @config.valid_provider!
-        end
+      test "use_api_key_from_environment! clears explicit api key" do
+        @config.api_key("explicit-key")
+        @config.use_api_key_from_environment!
 
-        test "valid_provider! accepts and sets :openai" do
-          @config.provider(:openai)
-          assert_equal :openai, @config.valid_provider!
-        end
-
-        test "valid_provider! accepts and sets :anthropic" do
-          @config.provider(:anthropic)
-          assert_equal :anthropic, @config.valid_provider!
-        end
-
-        test "valid_provider! accepts and sets :perplexity" do
-          @config.provider(:perplexity)
-          assert_equal :perplexity, @config.valid_provider!
-        end
-
-        test "valid_provider! accepts and sets :gemini" do
-          @config.provider(:gemini)
-          assert_equal :gemini, @config.valid_provider!
-        end
-
-        test "valid_provider! raises on invalid provider" do
-          @config.provider(:invalid_provider)
-
-          error = assert_raises(ArgumentError) do
-            @config.valid_provider!
+        with_env("OPENAI_API_KEY", nil) do
+          error = assert_raises(Cog::Config::InvalidConfigError) do
+            @config.valid_api_key!
           end
-
-          assert_match(/invalid_provider.*not a valid provider/, error.message)
+          assert_equal "no api key provided", error.message
         end
+      end
 
-        # API key configuration tests
-        test "api_key sets api key value" do
-          @config.api_key("test-key-123")
-
-          assert_equal "test-key-123", @config.valid_api_key!
+      test "valid_api_key! returns environment value when not explicitly set" do
+        with_env("OPENAI_API_KEY", "env-api-key") do
+          assert_equal "env-api-key", @config.valid_api_key!
         end
+      end
 
-        test "use_api_key_from_environment! clears explicit api key" do
-          @config.api_key("explicit-key")
-          @config.use_api_key_from_environment!
-
-          with_env("OPENAI_API_KEY", nil) do
-            error = assert_raises(Cog::Config::InvalidConfigError) do
-              @config.valid_api_key!
-            end
-            assert_equal "no api key provided", error.message
+      test "valid_api_key! raises when no api key provided" do
+        with_env("OPENAI_API_KEY", nil) do
+          error = assert_raises(Cog::Config::InvalidConfigError) do
+            @config.valid_api_key!
           end
+          assert_equal "no api key provided", error.message
         end
+      end
 
-        test "valid_api_key! raises when no api key provided" do
-          with_env("OPENAI_API_KEY", nil) do
-            error = assert_raises(Cog::Config::InvalidConfigError) do
-              @config.valid_api_key!
-            end
-            assert_equal "no api key provided", error.message
-          end
+      test "valid_api_key! reads from anthropic environment variable when provider is anthropic" do
+        @config.provider(:anthropic)
+        with_env("ANTHROPIC_API_KEY", "anthropic-env-key") do
+          assert_equal "anthropic-env-key", @config.valid_api_key!
         end
+      end
 
-        test "valid_api_key! reads from anthropic environment variable when provider is anthropic" do
-          @config.provider(:anthropic)
-          with_env("ANTHROPIC_API_KEY", "anthropic-env-key") do
-            assert_equal "anthropic-env-key", @config.valid_api_key!
-          end
+      test "valid_api_key! reads from openai environment variable when provider is openai" do
+        @config.provider(:openai)
+        with_env("OPENAI_API_KEY", "openai-env-key") do
+          assert_equal "openai-env-key", @config.valid_api_key!
         end
+      end
 
-        test "valid_api_key! reads from openai environment variable when provider is openai" do
-          @config.provider(:openai)
-          with_env("OPENAI_API_KEY", "openai-env-key") do
-            assert_equal "openai-env-key", @config.valid_api_key!
-          end
+      test "valid_api_key! reads from perplexity environment variable when provider is perplexity" do
+        @config.provider(:perplexity)
+        with_env("PERPLEXITY_API_KEY", "perplexity-env-key") do
+          assert_equal "perplexity-env-key", @config.valid_api_key!
         end
+      end
 
-        test "valid_api_key! reads from perplexity environment variable when provider is perplexity" do
-          @config.provider(:perplexity)
-          with_env("PERPLEXITY_API_KEY", "perplexity-env-key") do
-            assert_equal "perplexity-env-key", @config.valid_api_key!
-          end
+      test "valid_api_key! reads from gemini environment variable when provider is gemini" do
+        @config.provider(:gemini)
+        with_env("GEMINI_API_KEY", "gemini-env-key") do
+          assert_equal "gemini-env-key", @config.valid_api_key!
         end
+      end
 
-        test "valid_api_key! reads from gemini environment variable when provider is gemini" do
-          @config.provider(:gemini)
-          with_env("GEMINI_API_KEY", "gemini-env-key") do
-            assert_equal "gemini-env-key", @config.valid_api_key!
-          end
-        end
+      # Base URL configuration tests
+      test "base_url sets base url value" do
+        @config.base_url("https://custom.api.com/v1")
 
-        # Base URL configuration tests
-        test "base_url sets base url value" do
-          @config.base_url("https://custom.api.com/v1")
+        assert_equal "https://custom.api.com/v1", @config.valid_base_url
+      end
 
-          assert_equal "https://custom.api.com/v1", @config.valid_base_url
-        end
+      test "use_default_base_url! clears explicit base url" do
+        @config.base_url("https://custom.api.com/v1")
+        @config.use_default_base_url!
 
-        test "use_default_base_url! clears explicit base url" do
-          @config.base_url("https://custom.api.com/v1")
-          @config.use_default_base_url!
+        assert_equal "https://api.openai.com/v1", @config.valid_base_url
+      end
 
+      test "valid_base_url returns default when not set" do
+        with_env("OPENAI_API_BASE", nil) do
           assert_equal "https://api.openai.com/v1", @config.valid_base_url
         end
+      end
 
-        test "valid_base_url returns anthropic default base url when provider is anthropic" do
-          @config.provider(:anthropic)
-          with_env("ANTHROPIC_API_BASE", nil) do
-            assert_equal "https://api.anthropic.com", @config.valid_base_url
-          end
+      test "valid_base_url returns environment value when set" do
+        with_env("OPENAI_API_BASE", "https://env.api.com/v1") do
+          assert_equal "https://env.api.com/v1", @config.valid_base_url
+        end
+      end
+
+      test "valid_base_url returns anthropic default base url when provider is anthropic" do
+        @config.provider(:anthropic)
+        with_env("ANTHROPIC_API_BASE", nil) do
+          assert_equal "https://api.anthropic.com", @config.valid_base_url
+        end
+      end
+
+      test "valid_base_url returns openai default base url when provider is openai" do
+        @config.provider(:openai)
+        with_env("OPENAI_API_BASE", nil) do
+          assert_equal "https://api.openai.com/v1", @config.valid_base_url
+        end
+      end
+
+      test "valid_base_url returns gemini default base url when provider is gemini" do
+        @config.provider(:gemini)
+        with_env("GEMINI_API_BASE", nil) do
+          assert_equal "https://generativelanguage.googleapis.com/v1beta", @config.valid_base_url
+        end
+      end
+
+      test "valid_base_url reads ANTHROPIC_API_BASE when provider is anthropic" do
+        @config.provider(:anthropic)
+        with_env("ANTHROPIC_API_BASE", "https://env.anthropic.com/v1") do
+          assert_equal "https://env.anthropic.com/v1", @config.valid_base_url
+        end
+      end
+
+      test "valid_base_url reads OPENAI_API_BASE when provider is openai" do
+        @config.provider(:openai)
+        with_env("OPENAI_API_BASE", "https://env.openai.com/v1") do
+          assert_equal "https://env.openai.com/v1", @config.valid_base_url
+        end
+      end
+
+      test "valid_base_url reads GEMINI_API_BASE when provider is gemini" do
+        @config.provider(:gemini)
+        with_env("GEMINI_API_BASE", "https://generativelanguage.googleapis.com/v1") do
+          assert_equal "https://generativelanguage.googleapis.com/v1", @config.valid_base_url
+        end
+      end
+
+      # Model configuration tests
+      test "model sets model value" do
+        @config.model("gpt-4")
+
+        assert_equal "gpt-4", @config.valid_model
+      end
+
+      test "use_default_model! resets model to provider default" do
+        @config.model("gpt-4")
+        @config.use_default_model!
+
+        assert_equal Chat::Config::PROVIDERS.dig(:openai, :default_model), @config.valid_model
+      end
+
+      test "valid_model returns default when not set" do
+        assert_equal "gpt-4o-mini", @config.valid_model
+      end
+
+      test "valid_model returns anthropic default model when provider is anthropic" do
+        @config.provider(:anthropic)
+        assert_equal "claude-haiku-4-5", @config.valid_model
+      end
+
+      test "valid_model returns openai default model when provider is openai" do
+        @config.provider(:openai)
+        assert_equal "gpt-4o-mini", @config.valid_model
+      end
+
+      test "valid_model returns perplexity default model when provider is perplexity" do
+        @config.provider(:perplexity)
+        assert_equal "sonar", @config.valid_model
+      end
+
+      test "valid_model returns gemini default model when provider is gemini" do
+        @config.provider(:gemini)
+        assert_equal "gemini-3.1-flash-lite", @config.valid_model
+      end
+
+      # Temperature configuration tests
+      test "temperature sets temperature value" do
+        @config.temperature(0.7)
+
+        assert_equal 0.7, @config.valid_temperature
+      end
+
+      test "temperature raises on value below 0" do
+        error = assert_raises(ArgumentError) do
+          @config.temperature(-0.1)
         end
 
-        test "valid_base_url returns openai default base url when provider is openai" do
-          @config.provider(:openai)
-          with_env("OPENAI_API_BASE", nil) do
-            assert_equal "https://api.openai.com/v1", @config.valid_base_url
-          end
+        assert_match(/temperature must be between 0.0 and 1.0/, error.message)
+      end
+
+      test "temperature raises on value above 1" do
+        error = assert_raises(ArgumentError) do
+          @config.temperature(1.5)
         end
 
-        test "valid_base_url returns gemini default base url when provider is gemini" do
-          @config.provider(:gemini)
-          with_env("GEMINI_API_BASE", nil) do
-            assert_equal "https://generativelanguage.googleapis.com/v1beta", @config.valid_base_url
-          end
-        end
+        assert_match(/temperature must be between 0.0 and 1.0/, error.message)
+      end
 
-        test "valid_base_url reads ANTHROPIC_API_BASE when provider is anthropic" do
-          @config.provider(:anthropic)
-          with_env("ANTHROPIC_API_BASE", "https://env.anthropic.com/v1") do
-            assert_equal "https://env.anthropic.com/v1", @config.valid_base_url
-          end
-        end
+      test "temperature accepts boundary value 0.0" do
+        @config.temperature(0.0)
 
-        test "valid_base_url reads OPENAI_API_BASE when provider is openai" do
-          @config.provider(:openai)
-          with_env("OPENAI_API_BASE", "https://env.openai.com/v1") do
-            assert_equal "https://env.openai.com/v1", @config.valid_base_url
-          end
-        end
+        assert_equal 0.0, @config.valid_temperature
+      end
 
-        test "valid_base_url reads GEMINI_API_BASE when provider is gemini" do
-          @config.provider(:gemini)
-          with_env("GEMINI_API_BASE", "https://generativelanguage.googleapis.com/v1") do
-            assert_equal "https://generativelanguage.googleapis.com/v1", @config.valid_base_url
-          end
-        end
+      test "temperature accepts boundary value 1.0" do
+        @config.temperature(1.0)
 
-        # Model configuration tests
-        test "model sets model value" do
-          @config.model("gpt-4")
+        assert_equal 1.0, @config.valid_temperature
+      end
 
-          assert_equal "gpt-4", @config.valid_model
-        end
+      test "use_default_temperature! clears temperature value" do
+        @config.temperature(0.5)
+        @config.use_default_temperature!
 
-        test "use_default_model! resets model to provider default" do
-          @config.model("gpt-4")
-          @config.use_default_model!
+        assert_nil @config.valid_temperature
+      end
 
-          assert_equal Config::PROVIDERS.dig(:openai, :default_model), @config.valid_model
-        end
+      test "valid_temperature returns nil when not set" do
+        assert_nil @config.valid_temperature
+      end
 
-        test "valid_model returns anthropic default model when provider is anthropic" do
-          @config.provider(:anthropic)
-          assert_equal "claude-haiku-4-5", @config.valid_model
-        end
+      # Model verification configuration tests
+      test "verify_model_exists! enables model verification" do
+        @config.verify_model_exists!
 
-        test "valid_model returns openai default model when provider is openai" do
-          @config.provider(:openai)
-          assert_equal "gpt-4o-mini", @config.valid_model
-        end
+        assert @config.verify_model_exists?
+      end
 
-        test "valid_model returns perplexity default model when provider is perplexity" do
-          @config.provider(:perplexity)
-          assert_equal "sonar", @config.valid_model
-        end
+      test "no_verify_model_exists! disables model verification" do
+        @config.verify_model_exists!
+        @config.no_verify_model_exists!
 
-        test "valid_model returns gemini default model when provider is gemini" do
-          @config.provider(:gemini)
-          assert_equal "gemini-3.1-flash-lite", @config.valid_model
-        end
+        refute @config.verify_model_exists?
+      end
 
-        # Temperature configuration tests
-        test "temperature sets temperature value" do
-          @config.temperature(0.7)
+      test "verify_model_exists? returns false by default" do
+        refute @config.verify_model_exists?
+      end
 
-          assert_equal 0.7, @config.valid_temperature
-        end
+      test "assume_model_exists! is alias for no_verify_model_exists!" do
+        @config.verify_model_exists!
+        @config.assume_model_exists!
 
-        test "temperature raises on value below 0" do
-          error = assert_raises(ArgumentError) do
-            @config.temperature(-0.1)
-          end
+        refute @config.verify_model_exists?
+      end
 
-          assert_match(/temperature must be between 0.0 and 1.0/, error.message)
-        end
+      # Display configuration tests
+      test "show_prompt! enables prompt display" do
+        @config.show_prompt!
 
-        test "temperature raises on value above 1" do
-          error = assert_raises(ArgumentError) do
-            @config.temperature(1.5)
-          end
+        assert @config.show_prompt?
+      end
 
-          assert_match(/temperature must be between 0.0 and 1.0/, error.message)
-        end
+      test "no_show_prompt! disables prompt display" do
+        @config.show_prompt!
+        @config.no_show_prompt!
 
-        test "temperature accepts boundary value 0.0" do
-          @config.temperature(0.0)
+        refute @config.show_prompt?
+      end
 
-          assert_equal 0.0, @config.valid_temperature
-        end
+      test "show_prompt? returns false by default" do
+        refute @config.show_prompt?
+      end
 
-        test "temperature accepts boundary value 1.0" do
-          @config.temperature(1.0)
+      test "show_response! enables response display" do
+        @config.show_response!
 
-          assert_equal 1.0, @config.valid_temperature
-        end
+        assert @config.show_response?
+      end
 
-        test "use_default_temperature! clears temperature value" do
-          @config.temperature(0.5)
-          @config.use_default_temperature!
+      test "no_show_response! disables response display" do
+        @config.no_show_response!
 
-          assert_nil @config.valid_temperature
-        end
+        refute @config.show_response?
+      end
 
-        test "valid_temperature returns nil when not set" do
-          assert_nil @config.valid_temperature
-        end
+      test "show_response? returns true by default" do
+        assert @config.show_response?
+      end
 
-        # Model verification configuration tests
-        test "verify_model_exists! enables model verification" do
-          @config.verify_model_exists!
+      test "show_stats! enables stats display" do
+        @config.show_stats!
 
-          assert @config.verify_model_exists?
-        end
+        assert @config.show_stats?
+      end
 
-        test "no_verify_model_exists! disables model verification" do
-          @config.verify_model_exists!
-          @config.no_verify_model_exists!
+      test "no_show_stats! disables stats display" do
+        @config.no_show_stats!
 
-          refute @config.verify_model_exists?
-        end
+        refute @config.show_stats?
+      end
 
-        test "verify_model_exists? returns false by default" do
-          refute @config.verify_model_exists?
-        end
+      test "show_stats? returns true by default" do
+        assert @config.show_stats?
+      end
 
-        test "assume_model_exists! is alias for no_verify_model_exists!" do
-          @config.verify_model_exists!
-          @config.assume_model_exists!
+      test "display! enables all display options" do
+        @config.no_display!
+        @config.display!
 
-          refute @config.verify_model_exists?
-        end
+        assert @config.show_prompt?
+        assert @config.show_response?
+        assert @config.show_stats?
+      end
 
-        # Display configuration tests
-        test "show_prompt! enables prompt display" do
-          @config.show_prompt!
+      test "no_display! disables all display options" do
+        @config.display!
+        @config.no_display!
 
-          assert @config.show_prompt?
-        end
+        refute @config.show_prompt?
+        refute @config.show_response?
+        refute @config.show_stats?
+      end
 
-        test "no_show_prompt! disables prompt display" do
-          @config.show_prompt!
-          @config.no_show_prompt!
+      test "quiet! is alias for no_display!" do
+        @config.display!
+        @config.quiet!
 
-          refute @config.show_prompt?
-        end
+        refute @config.show_prompt?
+        refute @config.show_response?
+        refute @config.show_stats?
+      end
 
-        test "show_prompt? returns false by default" do
-          refute @config.show_prompt?
-        end
+      test "display? returns true when any display option is enabled" do
+        @config.no_display!
+        @config.show_prompt!
 
-        test "show_response! enables response display" do
-          @config.show_response!
+        assert @config.display?
+      end
 
-          assert @config.show_response?
-        end
+      test "display? returns false when all display options are disabled" do
+        @config.no_display!
 
-        test "no_show_response! disables response display" do
-          @config.no_show_response!
-
-          refute @config.show_response?
-        end
-
-        test "show_response? returns true by default" do
-          assert @config.show_response?
-        end
-
-        test "show_stats! enables stats display" do
-          @config.show_stats!
-
-          assert @config.show_stats?
-        end
-
-        test "no_show_stats! disables stats display" do
-          @config.no_show_stats!
-
-          refute @config.show_stats?
-        end
-
-        test "show_stats? returns true by default" do
-          assert @config.show_stats?
-        end
-
-        test "display! enables all display options" do
-          @config.no_display!
-          @config.display!
-
-          assert @config.show_prompt?
-          assert @config.show_response?
-          assert @config.show_stats?
-        end
-
-        test "no_display! disables all display options" do
-          @config.display!
-          @config.no_display!
-
-          refute @config.show_prompt?
-          refute @config.show_response?
-          refute @config.show_stats?
-        end
-
-        test "quiet! is alias for no_display!" do
-          @config.display!
-          @config.quiet!
-
-          refute @config.show_prompt?
-          refute @config.show_response?
-          refute @config.show_stats?
-        end
-
-        test "display? returns true when any display option is enabled" do
-          @config.no_display!
-          @config.show_prompt!
-
-          assert @config.display?
-        end
-
-        test "display? returns false when all display options are disabled" do
-          @config.no_display!
-
-          refute @config.display?
-        end
+        refute @config.display?
       end
     end
   end

--- a/test/roast/cogs/chat/input_test.rb
+++ b/test/roast/cogs/chat/input_test.rb
@@ -4,107 +4,105 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Chat < Cog
-      class InputTest < ActiveSupport::TestCase
-        def setup
-          @input = Input.new
+    class Chat::InputTest < ActiveSupport::TestCase
+      def setup
+        @input = Chat::Input.new
+      end
+
+      test "initialize sets prompt to nil" do
+        assert_nil @input.prompt
+      end
+
+      test "prompt can be set" do
+        @input.prompt = "What is 2+2?"
+
+        assert_equal "What is 2+2?", @input.prompt
+      end
+
+      test "session can be set" do
+        session = Object.new
+        @input.session = session
+
+        assert_same session, @input.session
+      end
+
+      test "validate! raises error when prompt is nil" do
+        error = assert_raises(Cog::Input::InvalidInputError) do
+          @input.validate!
         end
 
-        test "initialize sets prompt to nil" do
-          assert_nil @input.prompt
+        assert_equal "'prompt' is required", error.message
+      end
+
+      test "validate! raises error when prompt is empty string" do
+        @input.prompt = ""
+
+        error = assert_raises(Cog::Input::InvalidInputError) do
+          @input.validate!
         end
 
-        test "prompt can be set" do
-          @input.prompt = "What is 2+2?"
+        assert_equal "'prompt' is required", error.message
+      end
 
-          assert_equal "What is 2+2?", @input.prompt
+      test "validate! raises error when prompt is whitespace only" do
+        @input.prompt = "   "
+
+        error = assert_raises(Cog::Input::InvalidInputError) do
+          @input.validate!
         end
 
-        test "session can be set" do
-          session = Object.new
-          @input.session = session
+        assert_equal "'prompt' is required", error.message
+      end
 
-          assert_same session, @input.session
+      test "validate! succeeds when prompt is present" do
+        @input.prompt = "What is 2+2?"
+
+        assert_nothing_raised do
+          @input.validate!
+        end
+      end
+
+      test "coerce sets prompt from string" do
+        @input.coerce("What is the meaning of life?")
+
+        assert_equal "What is the meaning of life?", @input.prompt
+      end
+
+      test "coerce does nothing for non-string values" do
+        @input.coerce(42)
+
+        assert_nil @input.prompt
+      end
+
+      test "coerce does nothing for nil" do
+        @input.coerce(nil)
+
+        assert_nil @input.prompt
+      end
+
+      test "valid_prompt! returns prompt when present" do
+        @input.prompt = "Test prompt"
+
+        assert_equal "Test prompt", @input.valid_prompt!
+      end
+
+      test "valid_prompt! raises error when prompt is nil" do
+        error = assert_raises(Cog::Input::InvalidInputError) do
+          @input.valid_prompt!
         end
 
-        test "validate! raises error when prompt is nil" do
-          error = assert_raises(Cog::Input::InvalidInputError) do
-            @input.validate!
-          end
+        assert_equal "'prompt' is required", error.message
+      end
 
-          assert_equal "'prompt' is required", error.message
-        end
+      test "valid_session returns session when set" do
+        session = Object.new
+        @input.session = session
 
-        test "validate! raises error when prompt is empty string" do
-          @input.prompt = ""
+        assert_same session, @input.valid_session
+      end
 
-          error = assert_raises(Cog::Input::InvalidInputError) do
-            @input.validate!
-          end
-
-          assert_equal "'prompt' is required", error.message
-        end
-
-        test "validate! raises error when prompt is whitespace only" do
-          @input.prompt = "   "
-
-          error = assert_raises(Cog::Input::InvalidInputError) do
-            @input.validate!
-          end
-
-          assert_equal "'prompt' is required", error.message
-        end
-
-        test "validate! succeeds when prompt is present" do
-          @input.prompt = "What is 2+2?"
-
-          assert_nothing_raised do
-            @input.validate!
-          end
-        end
-
-        test "coerce sets prompt from string" do
-          @input.coerce("What is the meaning of life?")
-
-          assert_equal "What is the meaning of life?", @input.prompt
-        end
-
-        test "coerce does nothing for non-string values" do
-          @input.coerce(42)
-
-          assert_nil @input.prompt
-        end
-
-        test "coerce does nothing for nil" do
-          @input.coerce(nil)
-
-          assert_nil @input.prompt
-        end
-
-        test "valid_prompt! returns prompt when present" do
-          @input.prompt = "Test prompt"
-
-          assert_equal "Test prompt", @input.valid_prompt!
-        end
-
-        test "valid_prompt! raises error when prompt is nil" do
-          error = assert_raises(Cog::Input::InvalidInputError) do
-            @input.valid_prompt!
-          end
-
-          assert_equal "'prompt' is required", error.message
-        end
-
-        test "valid_session returns session when set" do
-          session = Object.new
-          @input.session = session
-
-          assert_same session, @input.valid_session
-        end
-
-        test "valid_session returns nil when not set" do
-          assert_nil @input.valid_session
-        end
+      test "valid_session returns nil when not set" do
+        assert_nil @input.valid_session
       end
     end
   end

--- a/test/roast/cogs/chat/output_test.rb
+++ b/test/roast/cogs/chat/output_test.rb
@@ -4,66 +4,64 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Chat < Cog
-      class OutputTest < ActiveSupport::TestCase
-        def setup
-          @session = Session.new([])
-        end
+    class Chat::OutputTest < ActiveSupport::TestCase
+      def setup
+        @session = Chat::Session.new([])
+      end
 
-        test "initialize sets session and response" do
-          output = Output.new(@session, "Hello, world!")
+      test "initialize sets session and response" do
+        output = Chat::Output.new(@session, "Hello, world!")
 
-          assert_same @session, output.session
-          assert_equal "Hello, world!", output.response
-        end
+        assert_same @session, output.session
+        assert_equal "Hello, world!", output.response
+      end
 
-        test "provides text parsing from response" do
-          output = Output.new(@session, "  Test response  \n")
+      test "provides text parsing from response" do
+        output = Chat::Output.new(@session, "  Test response  \n")
 
-          assert_equal "Test response", output.text
-        end
+        assert_equal "Test response", output.text
+      end
 
-        test "provides line parsing from response" do
-          output = Output.new(@session, "  line1  \n  line2  ")
+      test "provides line parsing from response" do
+        output = Chat::Output.new(@session, "  line1  \n  line2  ")
 
-          assert_equal ["line1", "line2"], output.lines
-        end
+        assert_equal ["line1", "line2"], output.lines
+      end
 
-        test "provides JSON parsing from response" do
-          output = Output.new(@session, '{"key": "value"}')
+      test "provides JSON parsing from response" do
+        output = Chat::Output.new(@session, '{"key": "value"}')
 
-          assert_equal({ key: "value" }, output.json!)
-        end
+        assert_equal({ key: "value" }, output.json!)
+      end
 
-        test "provides safe JSON parsing from response" do
-          output = Output.new(@session, "not json")
+      test "provides safe JSON parsing from response" do
+        output = Chat::Output.new(@session, "not json")
 
-          assert_nil output.json
-        end
+        assert_nil output.json
+      end
 
-        test "provides float parsing from response" do
-          output = Output.new(@session, "42.5")
+      test "provides float parsing from response" do
+        output = Chat::Output.new(@session, "42.5")
 
-          assert_equal 42.5, output.float!
-        end
+        assert_equal 42.5, output.float!
+      end
 
-        test "provides safe float parsing from response" do
-          output = Output.new(@session, "not a number")
+      test "provides safe float parsing from response" do
+        output = Chat::Output.new(@session, "not a number")
 
-          assert_nil output.float
-        end
+        assert_nil output.float
+      end
 
-        test "provides integer parsing from response" do
-          output = Output.new(@session, "42")
+      test "provides integer parsing from response" do
+        output = Chat::Output.new(@session, "42")
 
-          assert_equal 42, output.integer!
-        end
+        assert_equal 42, output.integer!
+      end
 
-        test "provides safe integer parsing from response" do
-          output = Output.new(@session, "not a number")
+      test "provides safe integer parsing from response" do
+        output = Chat::Output.new(@session, "not a number")
 
-          assert_nil output.integer
-        end
+        assert_nil output.integer
       end
     end
   end

--- a/test/roast/cogs/chat/session_test.rb
+++ b/test/roast/cogs/chat/session_test.rb
@@ -4,160 +4,158 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Chat < Cog
-      class SessionTest < ActiveSupport::TestCase
-        def setup
-          configure_ruby_llm
+    class Chat::SessionTest < ActiveSupport::TestCase
+      def setup
+        configure_ruby_llm
 
-          @messages = [
-            RubyLLM::Message.new(role: "user", content: "Hello"),
-            RubyLLM::Message.new(role: "assistant", content: "Hi there!"),
-            RubyLLM::Message.new(role: "user", content: "How are you?"),
-            RubyLLM::Message.new(role: "assistant", content: "I'm doing well!"),
-          ]
-          @session = Session.new(@messages)
+        @messages = [
+          RubyLLM::Message.new(role: "user", content: "Hello"),
+          RubyLLM::Message.new(role: "assistant", content: "Hi there!"),
+          RubyLLM::Message.new(role: "user", content: "How are you?"),
+          RubyLLM::Message.new(role: "assistant", content: "I'm doing well!"),
+        ]
+        @session = Chat::Session.new(@messages)
+      end
+
+      test "initialize stores messages" do
+        assert_nothing_raised do
+          Chat::Session.new(@messages)
         end
+      end
 
-        test "initialize stores messages" do
-          assert_nothing_raised do
-            Session.new(@messages)
-          end
+      test "first returns session with first N messages" do
+        truncated = @session.first(3)
+
+        chat = create_chat
+        truncated.apply!(chat)
+
+        assert_equal 3, chat.messages.size
+        assert_equal "Hello", chat.messages[0].content
+        assert_equal "Hi there!", chat.messages[1].content
+        assert_equal "How are you?", chat.messages[2].content
+      end
+
+      test "first defaults to 2 messages" do
+        truncated = @session.first
+
+        chat = create_chat
+        truncated.apply!(chat)
+
+        assert_equal 2, chat.messages.size
+      end
+
+      test "first deep duplicates messages" do
+        truncated = @session.first(2)
+
+        chat = create_chat
+        truncated.apply!(chat)
+
+        # Modify original messages
+        @messages[0].content = "Modified"
+
+        # Truncated session should be unaffected
+        refute_equal "Modified", chat.messages[0].content
+      end
+
+      test "last returns session with last N messages" do
+        truncated = @session.last(2)
+
+        chat = create_chat
+        truncated.apply!(chat)
+
+        assert_equal 2, chat.messages.size
+        assert_equal "How are you?", chat.messages[0].content
+        assert_equal "I'm doing well!", chat.messages[1].content
+      end
+
+      test "last defaults to 2 messages" do
+        truncated = @session.last
+
+        chat = create_chat
+        truncated.apply!(chat)
+
+        assert_equal 2, chat.messages.size
+      end
+
+      test "last deep duplicates messages" do
+        truncated = @session.last(2)
+
+        chat = create_chat
+        truncated.apply!(chat)
+
+        # Modify original messages
+        @messages[3].content = "Modified"
+
+        # Truncated session should be unaffected
+        refute_equal "Modified", chat.messages[1].content
+      end
+
+      test "apply! sets messages on chat instance" do
+        chat = create_chat
+        chat.add_message(role: "user", content: "Old")
+
+        @session.apply!(chat)
+
+        assert_equal 4, chat.messages.size
+        assert_equal "Hello", chat.messages[0].content
+      end
+
+      test "apply! deep duplicates messages to chat" do
+        chat = create_chat
+        @session.apply!(chat)
+
+        # Modify original messages
+        @messages[0].content = "Modified"
+
+        # Chat should be unaffected
+        refute_equal "Modified", chat.messages[0].content
+      end
+
+      test "from_chat creates session from RubyLLM::Chat instance" do
+        chat = create_chat_with_messages
+
+        session = Chat::Session.from_chat(chat)
+
+        # Apply to another chat to verify
+        another_chat = create_chat
+        session.apply!(another_chat)
+
+        assert_equal 4, another_chat.messages.size
+      end
+
+      test "from_chat deep duplicates messages from chat" do
+        chat = create_chat_with_messages
+
+        session = Chat::Session.from_chat(chat)
+
+        # Modify the chat's messages
+        chat.messages[0].content = "Modified"
+
+        # Session should be unaffected
+        another_chat = create_chat
+        session.apply!(another_chat)
+        refute_equal "Modified", another_chat.messages[0].content
+      end
+
+      private
+
+      def configure_ruby_llm
+        RubyLLM.configure do |config|
+          config.openai_api_key = "test-key"
         end
+      end
 
-        test "first returns session with first N messages" do
-          truncated = @session.first(3)
+      def create_chat
+        RubyLLM::Chat.new(provider: :openai, assume_model_exists: true)
+      end
 
-          chat = create_chat
-          truncated.apply!(chat)
-
-          assert_equal 3, chat.messages.size
-          assert_equal "Hello", chat.messages[0].content
-          assert_equal "Hi there!", chat.messages[1].content
-          assert_equal "How are you?", chat.messages[2].content
-        end
-
-        test "first defaults to 2 messages" do
-          truncated = @session.first
-
-          chat = create_chat
-          truncated.apply!(chat)
-
-          assert_equal 2, chat.messages.size
-        end
-
-        test "first deep duplicates messages" do
-          truncated = @session.first(2)
-
-          chat = create_chat
-          truncated.apply!(chat)
-
-          # Modify original messages
-          @messages[0].content = "Modified"
-
-          # Truncated session should be unaffected
-          refute_equal "Modified", chat.messages[0].content
-        end
-
-        test "last returns session with last N messages" do
-          truncated = @session.last(2)
-
-          chat = create_chat
-          truncated.apply!(chat)
-
-          assert_equal 2, chat.messages.size
-          assert_equal "How are you?", chat.messages[0].content
-          assert_equal "I'm doing well!", chat.messages[1].content
-        end
-
-        test "last defaults to 2 messages" do
-          truncated = @session.last
-
-          chat = create_chat
-          truncated.apply!(chat)
-
-          assert_equal 2, chat.messages.size
-        end
-
-        test "last deep duplicates messages" do
-          truncated = @session.last(2)
-
-          chat = create_chat
-          truncated.apply!(chat)
-
-          # Modify original messages
-          @messages[3].content = "Modified"
-
-          # Truncated session should be unaffected
-          refute_equal "Modified", chat.messages[1].content
-        end
-
-        test "apply! sets messages on chat instance" do
-          chat = create_chat
-          chat.add_message(role: "user", content: "Old")
-
-          @session.apply!(chat)
-
-          assert_equal 4, chat.messages.size
-          assert_equal "Hello", chat.messages[0].content
-        end
-
-        test "apply! deep duplicates messages to chat" do
-          chat = create_chat
-          @session.apply!(chat)
-
-          # Modify original messages
-          @messages[0].content = "Modified"
-
-          # Chat should be unaffected
-          refute_equal "Modified", chat.messages[0].content
-        end
-
-        test "from_chat creates session from RubyLLM::Chat instance" do
-          chat = create_chat_with_messages
-
-          session = Session.from_chat(chat)
-
-          # Apply to another chat to verify
-          another_chat = create_chat
-          session.apply!(another_chat)
-
-          assert_equal 4, another_chat.messages.size
-        end
-
-        test "from_chat deep duplicates messages from chat" do
-          chat = create_chat_with_messages
-
-          session = Session.from_chat(chat)
-
-          # Modify the chat's messages
-          chat.messages[0].content = "Modified"
-
-          # Session should be unaffected
-          another_chat = create_chat
-          session.apply!(another_chat)
-          refute_equal "Modified", another_chat.messages[0].content
-        end
-
-        private
-
-        def configure_ruby_llm
-          RubyLLM.configure do |config|
-            config.openai_api_key = "test-key"
-          end
-        end
-
-        def create_chat
-          RubyLLM::Chat.new(provider: :openai, assume_model_exists: true)
-        end
-
-        def create_chat_with_messages
-          chat = create_chat
-          chat.add_message(role: "user", content: "Hello")
-          chat.add_message(role: "assistant", content: "Hi there!")
-          chat.add_message(role: "user", content: "How are you?")
-          chat.add_message(role: "assistant", content: "I'm doing well!")
-          chat
-        end
+      def create_chat_with_messages
+        chat = create_chat
+        chat.add_message(role: "user", content: "Hello")
+        chat.add_message(role: "assistant", content: "Hi there!")
+        chat.add_message(role: "user", content: "How are you?")
+        chat.add_message(role: "assistant", content: "I'm doing well!")
+        chat
       end
     end
   end

--- a/test/roast/cogs/cmd_test.rb
+++ b/test/roast/cogs/cmd_test.rb
@@ -4,317 +4,315 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Cmd < Cog
-      class ConfigTest < ActiveSupport::TestCase
-        def setup
-          @config = Config.new
+    class Cmd::ConfigTest < ActiveSupport::TestCase
+      def setup
+        @config = Cmd::Config.new
+      end
+
+      # fail_on_error configuration tests
+      test "fail_on_error? returns true by default" do
+        assert @config.fail_on_error?
+      end
+
+      test "fail_on_error! sets fail_on_error to true" do
+        @config.no_fail_on_error!
+        @config.fail_on_error!
+
+        assert @config.fail_on_error?
+      end
+
+      test "no_fail_on_error! sets fail_on_error to false" do
+        @config.no_fail_on_error!
+
+        refute @config.fail_on_error?
+      end
+
+      # show_stdout configuration tests
+      test "show_stdout? returns false by default" do
+        refute @config.show_stdout?
+      end
+
+      test "show_stdout! enables stdout display" do
+        @config.show_stdout!
+
+        assert @config.show_stdout?
+      end
+
+      test "no_show_stdout! disables stdout display" do
+        @config.show_stdout!
+        @config.no_show_stdout!
+
+        refute @config.show_stdout?
+      end
+
+      # show_stderr configuration tests
+      test "show_stderr? returns false by default" do
+        refute @config.show_stderr?
+      end
+
+      test "show_stderr! enables stderr display" do
+        @config.show_stderr!
+
+        assert @config.show_stderr?
+      end
+
+      test "no_show_stderr! disables stderr display" do
+        @config.show_stderr!
+        @config.no_show_stderr!
+
+        refute @config.show_stderr?
+      end
+
+      # display! and no_display! configuration tests
+      test "display! enables both stdout and stderr" do
+        @config.display!
+
+        assert @config.show_stdout?
+        assert @config.show_stderr?
+      end
+
+      test "no_display! disables both stdout and stderr" do
+        @config.display!
+        @config.no_display!
+
+        refute @config.show_stdout?
+        refute @config.show_stderr?
+      end
+
+      test "display? returns true when stdout is enabled" do
+        @config.show_stdout!
+
+        assert @config.display?
+      end
+
+      test "display? returns true when stderr is enabled" do
+        @config.show_stderr!
+
+        assert @config.display?
+      end
+
+      test "display? returns false when both are disabled" do
+        @config.no_display!
+
+        refute @config.display?
+      end
+
+      # Alias tests
+      test "quiet! is alias for no_display!" do
+        @config.display!
+        @config.quiet!
+
+        refute @config.show_stdout?
+        refute @config.show_stderr?
+      end
+    end
+
+    class Cmd::InputTest < ActiveSupport::TestCase
+      def setup
+        @input = Cmd::Input.new
+      end
+
+      # validate! tests
+      test "validate! raises error when command is nil" do
+        error = assert_raises(Cog::Input::InvalidInputError) do
+          @input.validate!
         end
 
-        # fail_on_error configuration tests
-        test "fail_on_error? returns true by default" do
-          assert @config.fail_on_error?
+        assert_equal "'command' is required", error.message
+      end
+
+      test "validate! raises error when command is empty string" do
+        @input.command = ""
+
+        error = assert_raises(Cog::Input::InvalidInputError) do
+          @input.validate!
         end
 
-        test "fail_on_error! sets fail_on_error to true" do
-          @config.no_fail_on_error!
-          @config.fail_on_error!
+        assert_equal "'command' is required", error.message
+      end
 
-          assert @config.fail_on_error?
+      test "validate! raises error when command is whitespace only" do
+        @input.command = "   "
+
+        error = assert_raises(Cog::Input::InvalidInputError) do
+          @input.validate!
         end
 
-        test "no_fail_on_error! sets fail_on_error to false" do
-          @config.no_fail_on_error!
+        assert_equal "'command' is required", error.message
+      end
 
-          refute @config.fail_on_error?
-        end
+      test "validate! succeeds when command is present" do
+        @input.command = "echo"
 
-        # show_stdout configuration tests
-        test "show_stdout? returns false by default" do
-          refute @config.show_stdout?
-        end
-
-        test "show_stdout! enables stdout display" do
-          @config.show_stdout!
-
-          assert @config.show_stdout?
-        end
-
-        test "no_show_stdout! disables stdout display" do
-          @config.show_stdout!
-          @config.no_show_stdout!
-
-          refute @config.show_stdout?
-        end
-
-        # show_stderr configuration tests
-        test "show_stderr? returns false by default" do
-          refute @config.show_stderr?
-        end
-
-        test "show_stderr! enables stderr display" do
-          @config.show_stderr!
-
-          assert @config.show_stderr?
-        end
-
-        test "no_show_stderr! disables stderr display" do
-          @config.show_stderr!
-          @config.no_show_stderr!
-
-          refute @config.show_stderr?
-        end
-
-        # display! and no_display! configuration tests
-        test "display! enables both stdout and stderr" do
-          @config.display!
-
-          assert @config.show_stdout?
-          assert @config.show_stderr?
-        end
-
-        test "no_display! disables both stdout and stderr" do
-          @config.display!
-          @config.no_display!
-
-          refute @config.show_stdout?
-          refute @config.show_stderr?
-        end
-
-        test "display? returns true when stdout is enabled" do
-          @config.show_stdout!
-
-          assert @config.display?
-        end
-
-        test "display? returns true when stderr is enabled" do
-          @config.show_stderr!
-
-          assert @config.display?
-        end
-
-        test "display? returns false when both are disabled" do
-          @config.no_display!
-
-          refute @config.display?
-        end
-
-        # Alias tests
-        test "quiet! is alias for no_display!" do
-          @config.display!
-          @config.quiet!
-
-          refute @config.show_stdout?
-          refute @config.show_stderr?
+        assert_nothing_raised do
+          @input.validate!
         end
       end
 
-      class InputTest < ActiveSupport::TestCase
-        def setup
-          @input = Input.new
-        end
+      # coerce tests
+      test "coerce sets command from string" do
+        @input.coerce("ls -la")
 
-        # validate! tests
-        test "validate! raises error when command is nil" do
-          error = assert_raises(Cog::Input::InvalidInputError) do
-            @input.validate!
-          end
+        assert_equal "ls -la", @input.command
+      end
 
-          assert_equal "'command' is required", error.message
-        end
+      test "coerce sets command and args from array" do
+        @input.coerce(["echo", "hello", "world"])
 
-        test "validate! raises error when command is empty string" do
-          @input.command = ""
+        assert_equal "echo", @input.command
+        assert_equal ["hello", "world"], @input.args
+      end
 
-          error = assert_raises(Cog::Input::InvalidInputError) do
-            @input.validate!
-          end
+      test "coerce converts array elements to strings" do
+        @input.coerce([:echo, 123, :test])
 
-          assert_equal "'command' is required", error.message
-        end
+        assert_equal "echo", @input.command
+        assert_equal ["123", "test"], @input.args
+      end
 
-        test "validate! raises error when command is whitespace only" do
-          @input.command = "   "
+      test "coerce does nothing for non-string non-array values" do
+        @input.coerce(42)
 
-          error = assert_raises(Cog::Input::InvalidInputError) do
-            @input.validate!
-          end
+        assert_nil @input.command
+        assert_equal [], @input.args
+      end
 
-          assert_equal "'command' is required", error.message
-        end
+      test "coerce does nothing for nil" do
+        @input.coerce(nil)
 
-        test "validate! succeeds when command is present" do
-          @input.command = "echo"
+        assert_nil @input.command
+        assert_equal [], @input.args
+      end
+    end
 
-          assert_nothing_raised do
-            @input.validate!
-          end
-        end
-
-        # coerce tests
-        test "coerce sets command from string" do
-          @input.coerce("ls -la")
-
-          assert_equal "ls -la", @input.command
-        end
-
-        test "coerce sets command and args from array" do
-          @input.coerce(["echo", "hello", "world"])
-
-          assert_equal "echo", @input.command
-          assert_equal ["hello", "world"], @input.args
-        end
-
-        test "coerce converts array elements to strings" do
-          @input.coerce([:echo, 123, :test])
-
-          assert_equal "echo", @input.command
-          assert_equal ["123", "test"], @input.args
-        end
-
-        test "coerce does nothing for non-string non-array values" do
-          @input.coerce(42)
-
-          assert_nil @input.command
-          assert_equal [], @input.args
-        end
-
-        test "coerce does nothing for nil" do
-          @input.coerce(nil)
-
-          assert_nil @input.command
-          assert_equal [], @input.args
+    class Cmd::OutputTest < ActiveSupport::TestCase
+      ProcessStatus = Struct.new(:exitstatus, :success, keyword_init: true) do
+        def success?
+          success
         end
       end
 
-      class OutputTest < ActiveSupport::TestCase
-        ProcessStatus = Struct.new(:exitstatus, :success, keyword_init: true) do
-          def success?
-            success
-          end
-        end
-
-        def setup
-          @status = ProcessStatus.new(exitstatus: 0, success: true)
-        end
-
-        test "initialize sets out, err, and status" do
-          output = Output.new("stdout content", "stderr content", @status)
-
-          assert_equal "stdout content", output.out
-          assert_equal "stderr content", output.err
-          assert_same @status, output.status
-        end
-
-        test "provides text parsing from stdout" do
-          output = Output.new("  Test output  \n", "", @status)
-
-          assert_equal "Test output", output.text
-        end
-
-        test "provides line parsing from stdout" do
-          output = Output.new("  line1  \n  line2  ", "", @status)
-
-          assert_equal ["line1", "line2"], output.lines
-        end
-
-        test "provides JSON parsing from stdout" do
-          output = Output.new('{"key": "value"}', "", @status)
-
-          assert_equal({ key: "value" }, output.json!)
-        end
-
-        test "provides safe JSON parsing from stdout" do
-          output = Output.new("not json", "", @status)
-
-          assert_nil output.json
-        end
-
-        test "provides float parsing from stdout" do
-          output = Output.new("42.5", "", @status)
-
-          assert_equal 42.5, output.float!
-        end
-
-        test "provides safe float parsing from stdout" do
-          output = Output.new("not a number", "", @status)
-
-          assert_nil output.float
-        end
-
-        test "provides integer parsing from stdout" do
-          output = Output.new("42", "", @status)
-
-          assert_equal 42, output.integer!
-        end
-
-        test "provides safe integer parsing from stdout" do
-          output = Output.new("not a number", "", @status)
-
-          assert_nil output.integer
-        end
+      def setup
+        @status = ProcessStatus.new(exitstatus: 0, success: true)
       end
 
-      class ExecuteTest < ActiveSupport::TestCase
-        test "run! executes command and captures stdout" do
-          cog = Cmd.new(:echo_test, ->(_input, _scope, _index) { "echo hello world" })
+      test "initialize sets out, err, and status" do
+        output = Cmd::Output.new("stdout content", "stderr content", @status)
 
-          run_cog(cog)
+        assert_equal "stdout content", output.out
+        assert_equal "stderr content", output.err
+        assert_same @status, output.status
+      end
 
-          assert cog.succeeded?
-          assert_equal "hello world", cog.output.text
-        end
+      test "provides text parsing from stdout" do
+        output = Cmd::Output.new("  Test output  \n", "", @status)
 
-        test "run! executes command with arguments from array" do
-          cog = Cmd.new(:echo_args, ->(_input, _scope, _index) { ["echo", "foo", "bar"] })
+        assert_equal "Test output", output.text
+      end
 
-          run_cog(cog)
+      test "provides line parsing from stdout" do
+        output = Cmd::Output.new("  line1  \n  line2  ", "", @status)
 
-          assert cog.succeeded?
-          assert_equal "foo bar", cog.output.text
-        end
+        assert_equal ["line1", "line2"], output.lines
+      end
 
-        test "run! marks cog as failed when command fails with fail_on_error" do
-          config = Cmd.config_class.new.tap(&:no_abort_on_failure!)
-          cog = Cmd.new(:failing_cmd, ->(_input, _scope, _index) { "exit 1" })
+      test "provides JSON parsing from stdout" do
+        output = Cmd::Output.new('{"key": "value"}', "", @status)
 
-          run_cog(cog, config:)
+        assert_equal({ key: "value" }, output.json!)
+      end
 
-          assert cog.failed?
-        end
+      test "provides safe JSON parsing from stdout" do
+        output = Cmd::Output.new("not json", "", @status)
 
-        test "run! succeeds when command fails with no_fail_on_error" do
-          cog = Cmd.new(:failing_cmd, ->(_input, _scope, _index) { "exit 42" })
-          config = Config.new
-          config.no_fail_on_error!
+        assert_nil output.json
+      end
 
-          run_cog(cog, config: config)
+      test "provides float parsing from stdout" do
+        output = Cmd::Output.new("42.5", "", @status)
 
-          assert cog.succeeded?
-          assert_equal 42, cog.output.status.exitstatus
-        end
+        assert_equal 42.5, output.float!
+      end
 
-        test "run! captures stderr" do
-          cog = Cmd.new(:stderr_test, ->(_input, _scope, _index) { "echo error >&2" })
-          config = Config.new
-          config.no_fail_on_error!
+      test "provides safe float parsing from stdout" do
+        output = Cmd::Output.new("not a number", "", @status)
 
-          run_cog(cog, config: config)
+        assert_nil output.float
+      end
 
-          assert cog.succeeded?
-          assert_equal "error\n", cog.output.err
-        end
+      test "provides integer parsing from stdout" do
+        output = Cmd::Output.new("42", "", @status)
 
-        test "run! allows setting command via input block" do
-          cog = Cmd.new(:input_block, ->(input, _scope, _index) {
-            input.command = "echo"
-            input.args = ["configured", "via", "input"]
-          })
+        assert_equal 42, output.integer!
+      end
 
-          run_cog(cog)
+      test "provides safe integer parsing from stdout" do
+        output = Cmd::Output.new("not a number", "", @status)
 
-          assert cog.succeeded?
-          assert_equal "configured via input", cog.output.text
-        end
+        assert_nil output.integer
+      end
+    end
+
+    class Cmd::ExecuteTest < ActiveSupport::TestCase
+      test "run! executes command and captures stdout" do
+        cog = Cmd.new(:echo_test, ->(_input, _scope, _index) { "echo hello world" })
+
+        run_cog(cog)
+
+        assert cog.succeeded?
+        assert_equal "hello world", cog.output.text
+      end
+
+      test "run! executes command with arguments from array" do
+        cog = Cmd.new(:echo_args, ->(_input, _scope, _index) { ["echo", "foo", "bar"] })
+
+        run_cog(cog)
+
+        assert cog.succeeded?
+        assert_equal "foo bar", cog.output.text
+      end
+
+      test "run! marks cog as failed when command fails with fail_on_error" do
+        config = Cmd.config_class.new.tap(&:no_abort_on_failure!)
+        cog = Cmd.new(:failing_cmd, ->(_input, _scope, _index) { "exit 1" })
+
+        run_cog(cog, config:)
+
+        assert cog.failed?
+      end
+
+      test "run! succeeds when command fails with no_fail_on_error" do
+        cog = Cmd.new(:failing_cmd, ->(_input, _scope, _index) { "exit 42" })
+        config = Cmd::Config.new
+        config.no_fail_on_error!
+
+        run_cog(cog, config: config)
+
+        assert cog.succeeded?
+        assert_equal 42, cog.output.status.exitstatus
+      end
+
+      test "run! captures stderr" do
+        cog = Cmd.new(:stderr_test, ->(_input, _scope, _index) { "echo error >&2" })
+        config = Cmd::Config.new
+        config.no_fail_on_error!
+
+        run_cog(cog, config: config)
+
+        assert cog.succeeded?
+        assert_equal "error\n", cog.output.err
+      end
+
+      test "run! allows setting command via input block" do
+        cog = Cmd.new(:input_block, ->(input, _scope, _index) {
+          input.command = "echo"
+          input.args = ["configured", "via", "input"]
+        })
+
+        run_cog(cog)
+
+        assert cog.succeeded?
+        assert_equal "configured via input", cog.output.text
       end
     end
   end

--- a/test/roast/cogs/ruby_test.rb
+++ b/test/roast/cogs/ruby_test.rb
@@ -4,177 +4,175 @@ require "test_helper"
 
 module Roast
   module Cogs
-    class Ruby < Cog
-      class InputTest < ActiveSupport::TestCase
-        def setup
-          @input = Input.new
-        end
+    class Ruby::InputTest < ActiveSupport::TestCase
+      def setup
+        @input = Ruby::Input.new
+      end
 
-        # validate! tests
-        test "validate! raises error when value is nil and coerce has not run" do
-          assert_raises(Cog::Input::InvalidInputError) do
-            @input.validate!
-          end
-        end
-
-        test "validate! succeeds when value is set" do
-          @input.value = "test"
-
-          assert_nothing_raised do
-            @input.validate!
-          end
-        end
-
-        test "validate! succeeds when value is nil but coerce has run" do
-          @input.coerce(nil)
-
-          assert_nothing_raised do
-            @input.validate!
-          end
-        end
-
-        # coerce tests
-        test "coerce sets value from input return value" do
-          @input.coerce("hello world")
-
-          assert_equal "hello world", @input.value
-        end
-
-        test "coerce accepts any Ruby object" do
-          object = { key: "value", count: 42 }
-          @input.coerce(object)
-
-          assert_same object, @input.value
+      # validate! tests
+      test "validate! raises error when value is nil and coerce has not run" do
+        assert_raises(Cog::Input::InvalidInputError) do
+          @input.validate!
         end
       end
 
-      class OutputTest < ActiveSupport::TestCase
-        # Constructor tests
-        test "initialize sets value" do
-          output = Output.new("test value")
+      test "validate! succeeds when value is set" do
+        @input.value = "test"
 
-          assert_equal "test value", output.value
-        end
-
-        # [] bracket access tests
-        test "bracket access returns hash value" do
-          output = Output.new({ name: "Alice", age: 30 })
-
-          assert_equal "Alice", output[:name]
-          assert_equal 30, output[:age]
-        end
-
-        # call tests
-        test "call invokes value when it is a Proc" do
-          output = Output.new(->(x) { x * 2 })
-
-          assert_equal 10, output.call(5)
-        end
-
-        test "call passes block to Proc value" do
-          output = Output.new(->(items, &block) { items.map(&block) })
-
-          assert_equal [2, 4, 6], output.call([1, 2, 3]) { |n| n * 2 }
-        end
-
-        test "call invokes Proc from hash when given symbol key" do
-          output = Output.new({ double: ->(_key, x) { x * 2 } })
-
-          assert_equal 10, output.call(:double, 5)
-        end
-
-        test "call raises ArgumentError when value is hash and first arg is not symbol" do
-          output = Output.new({ key: "value" })
-
-          assert_raises(ArgumentError) do
-            output.call("not a symbol")
-          end
-        end
-
-        test "call raises NoMethodError when hash key is not a Proc" do
-          output = Output.new({ key: "not a proc" })
-
-          assert_raises(NoMethodError) do
-            output.call(:key)
-          end
-        end
-
-        # method_missing delegation tests
-        test "method_missing delegates to value when value responds to method" do
-          output = Output.new("hello world")
-
-          assert_equal "HELLO WORLD", output.upcase
-          assert_equal 11, output.length
-        end
-
-        test "method_missing accesses hash key when value is hash" do
-          output = Output.new({ name: "Bob", score: 100 })
-
-          assert_equal "Bob", output.name
-          assert_equal 100, output.score
-        end
-
-        test "method_missing calls Proc in hash with arguments" do
-          output = Output.new({ greet: ->(name) { "Hello, #{name}!" } })
-
-          assert_equal "Hello, World!", output.greet("World")
-        end
-
-        test "method_missing raises NoMethodError for unknown method" do
-          output = Output.new("test")
-
-          assert_raises(NoMethodError) do
-            output.nonexistent_method
-          end
-        end
-
-        # respond_to_missing? tests
-        test "respond_to? returns true for methods on value" do
-          output = Output.new("hello")
-
-          assert output.respond_to?(:upcase)
-          assert output.respond_to?(:length)
-        end
-
-        test "respond_to? returns true for hash keys" do
-          output = Output.new({ name: "Alice" })
-
-          assert output.respond_to?(:name)
-        end
-
-        test "respond_to? returns false for unknown methods" do
-          output = Output.new("test")
-
-          refute output.respond_to?(:nonexistent_method)
-        end
-
-        test "respond_to? returns false for hash key that does not exist" do
-          output = Output.new({ name: "Alice" })
-
-          refute output.respond_to?(:missing_key)
+        assert_nothing_raised do
+          @input.validate!
         end
       end
 
-      class ExecuteTest < ActiveSupport::TestCase
-        test "execute returns Output with input value" do
-          cog = Ruby.new(:test_cog, ->(_input) {})
-          input = Input.new
-          input.value = { name: "test", count: 42 }
+      test "validate! succeeds when value is nil but coerce has run" do
+        @input.coerce(nil)
 
-          output = cog.execute(input)
-
-          assert_instance_of Output, output
-          assert_equal({ name: "test", count: 42 }, output.value)
+        assert_nothing_raised do
+          @input.validate!
         end
+      end
 
-        test "run! executes Ruby code and returns result in output" do
-          cog = Ruby.new(:compute_cog, ->(_input, _scope, _index) { [1, 2, 3, 4, 5].map { |n| n * 2 }.sum })
+      # coerce tests
+      test "coerce sets value from input return value" do
+        @input.coerce("hello world")
 
-          run_cog(cog)
+        assert_equal "hello world", @input.value
+      end
 
-          assert cog.succeeded?
-          assert_equal 30, cog.output.value
+      test "coerce accepts any Ruby object" do
+        object = { key: "value", count: 42 }
+        @input.coerce(object)
+
+        assert_same object, @input.value
+      end
+    end
+
+    class Ruby::OutputTest < ActiveSupport::TestCase
+      # Constructor tests
+      test "initialize sets value" do
+        output = Ruby::Output.new("test value")
+
+        assert_equal "test value", output.value
+      end
+
+      # [] bracket access tests
+      test "bracket access returns hash value" do
+        output = Ruby::Output.new({ name: "Alice", age: 30 })
+
+        assert_equal "Alice", output[:name]
+        assert_equal 30, output[:age]
+      end
+
+      # call tests
+      test "call invokes value when it is a Proc" do
+        output = Ruby::Output.new(->(x) { x * 2 })
+
+        assert_equal 10, output.call(5)
+      end
+
+      test "call passes block to Proc value" do
+        output = Ruby::Output.new(->(items, &block) { items.map(&block) })
+
+        assert_equal [2, 4, 6], output.call([1, 2, 3]) { |n| n * 2 }
+      end
+
+      test "call invokes Proc from hash when given symbol key" do
+        output = Ruby::Output.new({ double: ->(_key, x) { x * 2 } })
+
+        assert_equal 10, output.call(:double, 5)
+      end
+
+      test "call raises ArgumentError when value is hash and first arg is not symbol" do
+        output = Ruby::Output.new({ key: "value" })
+
+        assert_raises(ArgumentError) do
+          output.call("not a symbol")
         end
+      end
+
+      test "call raises NoMethodError when hash key is not a Proc" do
+        output = Ruby::Output.new({ key: "not a proc" })
+
+        assert_raises(NoMethodError) do
+          output.call(:key)
+        end
+      end
+
+      # method_missing delegation tests
+      test "method_missing delegates to value when value responds to method" do
+        output = Ruby::Output.new("hello world")
+
+        assert_equal "HELLO WORLD", output.upcase
+        assert_equal 11, output.length
+      end
+
+      test "method_missing accesses hash key when value is hash" do
+        output = Ruby::Output.new({ name: "Bob", score: 100 })
+
+        assert_equal "Bob", output.name
+        assert_equal 100, output.score
+      end
+
+      test "method_missing calls Proc in hash with arguments" do
+        output = Ruby::Output.new({ greet: ->(name) { "Hello, #{name}!" } })
+
+        assert_equal "Hello, World!", output.greet("World")
+      end
+
+      test "method_missing raises NoMethodError for unknown method" do
+        output = Ruby::Output.new("test")
+
+        assert_raises(NoMethodError) do
+          output.nonexistent_method
+        end
+      end
+
+      # respond_to_missing? tests
+      test "respond_to? returns true for methods on value" do
+        output = Ruby::Output.new("hello")
+
+        assert output.respond_to?(:upcase)
+        assert output.respond_to?(:length)
+      end
+
+      test "respond_to? returns true for hash keys" do
+        output = Ruby::Output.new({ name: "Alice" })
+
+        assert output.respond_to?(:name)
+      end
+
+      test "respond_to? returns false for unknown methods" do
+        output = Ruby::Output.new("test")
+
+        refute output.respond_to?(:nonexistent_method)
+      end
+
+      test "respond_to? returns false for hash key that does not exist" do
+        output = Ruby::Output.new({ name: "Alice" })
+
+        refute output.respond_to?(:missing_key)
+      end
+    end
+
+    class Ruby::ExecuteTest < ActiveSupport::TestCase
+      test "execute returns Output with input value" do
+        cog = Ruby.new(:test_cog, ->(_input) {})
+        input = Ruby::Input.new
+        input.value = { name: "test", count: 42 }
+
+        output = cog.execute(input)
+
+        assert_instance_of Ruby::Output, output
+        assert_equal({ name: "test", count: 42 }, output.value)
+      end
+
+      test "run! executes Ruby code and returns result in output" do
+        cog = Ruby.new(:compute_cog, ->(_input, _scope, _index) { [1, 2, 3, 4, 5].map { |n| n * 2 }.sum })
+
+        run_cog(cog)
+
+        assert cog.succeeded?
+        assert_equal 30, cog.output.value
       end
     end
   end

--- a/test/support/test_cog.rb
+++ b/test/support/test_cog.rb
@@ -25,11 +25,11 @@ module TestCogSupport
   end
 
   class TestCog < Roast::Cog
-    class Config < Roast::Cog::Config; end
-    class Input < TestInput; end
-
     def execute(input)
       TestOutput.new(input.value)
     end
   end
+
+  class TestCog::Config < Roast::Cog::Config; end
+  class TestCog::Input < TestInput; end
 end


### PR DESCRIPTION
Test classes defined like this

```
module Roast
  module Cogs
    class Agent < Cog
      class ConfigTest < ActiveSupport::TestCase
        ...
```

which re-open the `Agent` class (it's a class, not a module) result in some undesirable output from the RubyMine test runner.

Restructuring test classes to use the short-hand class name-spacing notation:

```
module Roast
  module Cogs
    class Agent::ConfigTest < ActiveSupport::TestCase
      ...
```

resolves the problem, since the class is not re-opened.