### PR TITLE
[PROTOTYPE] tool_use formatter implementation

### DIFF
--- a/examples/tool_use_formatter_test.rb
+++ b/examples/tool_use_formatter_test.rb
@@ -1,0 +1,30 @@
+# typed: true
+# frozen_string_literal: true
+
+#: self as Roast::Workflow
+
+config do
+  agent do
+    provider :claude
+    show_progress!
+    dump_raw_agent_messages_to "tmp/tool-formatter-test.log"
+  end
+end
+
+execute do
+  agent(:trigger_all_tools) do
+    <<~PROMPT
+      Please do the following steps in order, using tools for each one:
+
+      1. Use Glob to find all .rb files under lib/roast/cogs/agent/providers/claude/
+      2. Use Grep to search for "def format" in lib/roast/cogs/agent/providers/claude/
+      3. Use Read to read lib/roast/cogs/agent/providers/claude/tool_use.rb
+      4. Use Bash to run: echo "hello from bash"
+      5. Use Write to create tmp/formatter_test.txt with the content "line one\nline two\nline three"
+      6. Use Edit to change "line two" to "line TWO" in tmp/formatter_test.txt
+      7. Use TodoWrite to set one in_progress todo: "Review formatter output"
+
+      Do all steps sequentially and confirm each one is done.
+    PROMPT
+  end
+end

--- a/examples/tool_use_formatter_test.rb
+++ b/examples/tool_use_formatter_test.rb
@@ -20,7 +20,7 @@ execute do
 
       2. Use Grep to search for the pattern "def format" in lib/roast/cogs/agent/providers/claude/ with glob filter "*.rb" and case-insensitive flag enabled.
 
-      3. Use Read to read lib/roast/cogs/agent/providers/claude/tool_use.rb, lines 30 to 80 only (offset 29, limit 51).
+      3. Use Read to read lib/roast/cogs/agent/providers/claude/tool_use.rb, lines 30 to 80 only
 
       4. Use Bash to run: echo "this is a very long bash command output that tests whether our truncation logic handles long command strings gracefully without breaking the formatter" with description "Stress testing the bash formatter with an intentionally long command string to verify truncation at 50 characters"
 

--- a/examples/tool_use_formatter_test.rb
+++ b/examples/tool_use_formatter_test.rb
@@ -14,17 +14,53 @@ end
 execute do
   agent(:trigger_all_tools) do
     <<~PROMPT
-      Please do the following steps in order, using tools for each one:
+      Please do ALL of the following steps in order, using the exact tools specified. Do not use Bash as a substitute for Glob, Grep, Read, Write, or Edit.
 
-      1. Use Glob to find all .rb files under lib/roast/cogs/agent/providers/claude/
-      2. Use Grep to search for "def format" in lib/roast/cogs/agent/providers/claude/
-      3. Use Read to read lib/roast/cogs/agent/providers/claude/tool_use.rb
-      4. Use Bash to run: echo "hello from bash"
-      5. Use Write to create tmp/formatter_test.txt with the content "line one\nline two\nline three"
-      6. Use Edit to change "line two" to "line TWO" in tmp/formatter_test.txt
-      7. Use TodoWrite to set one in_progress todo: "Review formatter output"
+      1. Use Glob to find all .rb files under lib/roast/cogs/agent/providers/claude/messages/
 
-      Do all steps sequentially and confirm each one is done.
+      2. Use Grep to search for the pattern "def format" in lib/roast/cogs/agent/providers/claude/ with glob filter "*.rb" and case-insensitive flag enabled.
+
+      3. Use Read to read lib/roast/cogs/agent/providers/claude/tool_use.rb, lines 30 to 80 only (offset 29, limit 51).
+
+      4. Use Bash to run: echo "this is a very long bash command output that tests whether our truncation logic handles long command strings gracefully without breaking the formatter" with description "Stress testing the bash formatter with an intentionally long command string to verify truncation at 50 characters"
+
+      5. Use Write to create tmp/formatter_stress_test.txt with exactly this content (10 long lines):
+      line 001: The quick brown fox jumps over the lazy dog while the formatter watches carefully to see if long lines get truncated properly
+      line 002: Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+      line 003: Pack my box with five dozen liquor jugs as the formatter stress test begins its long and arduous journey through truncation
+      line 004: How vexingly quick daft zebras jump when the tool use formatter is watching and waiting to see what happens with long content
+      line 005: The five boxing wizards jump quickly past the formatter which is now handling extremely long first-line content in write calls
+      line 006: Sphinx of black quartz judge my vow and also test whether the formatter correctly truncates this extremely verbose line content
+      line 007: Waltz nymphs for quick jigs vex bud as the formatter continues to handle more and more lines with increasingly long content
+      line 008: Bright vixens jump dozy fowl quack as this formatter test reaches line eight with content that keeps going and going endlessly
+      line 009: Glib jocks quiz nymph to vex dwarf and the formatter must handle this penultimate line which is also quite long in character count
+      line 010: Jackdaws love my big sphinx of quartz and this is the final line of the stress test file which the formatter must handle gracefully
+
+      6. Use Edit to replace lines 4 through 9 (a 6-line block) with uppercased first words:
+      old_string should be exactly:
+      line 004: How vexingly quick daft zebras jump when the tool use formatter is watching and waiting to see what happens with long content
+      line 005: The five boxing wizards jump quickly past the formatter which is now handling extremely long first-line content in write calls
+      line 006: Sphinx of black quartz judge my vow and also test whether the formatter correctly truncates this extremely verbose line content
+      line 007: Waltz nymphs for quick jigs vex bud as the formatter continues to handle more and more lines with increasingly long content
+      line 008: Bright vixens jump dozy fowl quack as this formatter test reaches line eight with content that keeps going and going endlessly
+      line 009: Glib jocks quiz nymph to vex dwarf and the formatter must handle this penultimate line which is also quite long in character count
+
+      new_string should be:
+      line 004: HOW vexingly quick daft zebras jump when the tool use formatter is watching and waiting to see what happens with long content
+      line 005: THE five boxing wizards jump quickly past the formatter which is now handling extremely long first-line content in write calls
+      line 006: SPHINX of black quartz judge my vow and also test whether the formatter correctly truncates this extremely verbose line content
+      line 007: WALTZ nymphs for quick jigs vex bud as the formatter continues to handle more and more lines with increasingly long content
+      line 008: BRIGHT vixens jump dozy fowl quack as this formatter test reaches line eight with content that keeps going and going endlessly
+      line 009: GLIB jocks quiz nymph to vex dwarf and the formatter must handle this penultimate line which is also quite long in character count
+
+      7. Use TodoWrite to set these five todos:
+         - "Run formatter stress test" (status: completed, activeForm: "Running formatter stress test")
+         - "Review multiline edit output in tmp/formatter_stress_test.txt to verify all 6 lines were uppercased correctly" (status: in_progress, activeForm: "Reviewing multiline edit output in tmp/formatter_stress_test.txt")
+         - "Write tool result formatters for all tool types including bash read glob grep write edit todowrite skill task agent taskoutput" (status: pending, activeForm: "Writing tool result formatters")
+         - "Update snapshot file for team review and share with the broader engineering team for feedback on formatting decisions" (status: pending, activeForm: "Updating snapshot file")
+         - "Open PR for tool use formatter implementation and request reviews from team members who were consulted during design" (status: pending, activeForm: "Opening PR for tool use formatter")
+
+      Confirm each step as you go.
     PROMPT
   end
 end

--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -49,6 +49,16 @@ module Roast
             end
 
             #: () -> String
+            def format_taskcreate
+              "TASKCREATE #{truncate(input[:subject])}"
+            end
+
+            #: () -> String
+            def format_taskupdate
+              "TASKUPDATE ##{input[:taskId]} → #{input[:status]}"
+            end
+
+            #: () -> String
             def format_agent
               description = truncate(input[:description])
               details = [
@@ -87,13 +97,11 @@ module Roast
 
             #: () -> String
             def format_edit
-              file_path = input[:file_path]
-              old_lines = input[:old_string].to_s.lines
-              new_lines = input[:new_string].to_s.lines
-              replace_all = input[:replace_all] ? " · replace_all" : ""
-              old_desc = old_lines.length == 1 ? "\"#{truncate(old_lines.first.to_s.strip)}\"" : "#{old_lines.length} lines"
-              new_desc = new_lines.length == 1 ? "\"#{truncate(new_lines.first.to_s.strip)}\"" : "#{new_lines.length} lines"
-              "EDIT #{file_path}#{replace_all}\n  - #{old_desc}\n  + #{new_desc}"
+              old_count = input[:old_string].to_s.lines.length
+              new_count = input[:new_string].to_s.lines.length
+              details = "-#{old_count} +#{new_count} lines"
+              details += " · replace all" if input[:replace_all]
+              "EDIT #{input[:file_path]} (#{details})"
             end
 
             #: () -> String
@@ -133,8 +141,8 @@ module Roast
               limit = input[:limit]
               offset = input[:offset]
               details = if limit
-                offset ||= 0
-                "lines #{offset + 1}–#{offset + limit}"
+                offset ||= 1
+                "lines #{offset}–#{offset + limit - 1}"
               end
               details ? "READ #{file_path} (#{details})" : "READ #{file_path}"
             end

--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -30,6 +30,14 @@ module Roast
             private
 
             #: () -> String
+            def format_read
+              file_path = input[:file_path]
+              limit = input[:limit] ? input[:limit] : nil
+              offset = input[:offset] ? input[:offset] : nil
+              "READ #{file_path} #{"with limit: #{limit}" if limit} #{"with offset: #{offset}" if offset}"
+            end
+
+            #: () -> String
             def format_bash
               "BASH #{input.inspect}"
             end

--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -29,17 +29,112 @@ module Roast
 
             private
 
+            #: (String?) -> String
+            def truncate(str)
+              char_limit = 50
+              s = str.to_s
+              s.length > char_limit ? "#{s[0..char_limit - 3]}..." : s
+            end
+
+            #: () -> String
+            def format_taskoutput
+              task_id = truncate(input[:task_id])
+              details = [
+                ("blocking" if input[:block]),
+                ("#{input[:timeout]}ms" if input[:timeout]),
+              ].compact.join(" · ")
+              "TASKOUTPUT #{task_id}\n  #{details}"
+            end
+
+            #: () -> String
+            def format_agent
+              description = truncate(input[:description])
+              details = [
+                ("background" if input[:run_in_background]),
+                input[:subagent_type],
+              ].compact.join(" · ")
+              "AGENT #{description}\n  #{details}"
+            end
+
+            #: () -> String
+            def format_task
+              description = truncate(input[:description])
+              details = [
+                ("background" if input[:run_in_background]),
+                input[:subagent_type],
+                input[:model],
+              ].compact.join(" · ")
+              "TASK #{description}\n  #{details}"
+            end
+
+            #: () -> String
+            def format_skill
+              "SKILL #{input[:skill]}\n  #{truncate(input[:args])}"
+            end
+
+            #: () -> String
+            def format_todowrite
+              todos = input[:todos] || []
+              counts = todos
+                .group_by { |t| t[:status] || t["status"] }
+                .transform_values(&:length)
+              summary = counts.map { |status, n| "#{n} #{status}" }.join(" · ")
+              "TODOWRITE #{todos.length} todos\n  #{summary}"
+            end
+
+            #: () -> String
+            def format_edit
+              file_path = input[:file_path]
+              old_lines = input[:old_string].to_s.lines
+              new_lines = input[:new_string].to_s.lines
+              old_hint = truncate(old_lines.first.to_s.strip)
+              new_hint = truncate(new_lines.first.to_s.strip)
+              old_suffix = old_lines.length > 1 ? " (+#{old_lines.length - 1} lines)" : ""
+              new_suffix = new_lines.length > 1 ? " (+#{new_lines.length - 1} lines)" : ""
+              replace_all = input[:replace_all] ? " · replace_all" : ""
+              "EDIT #{file_path}#{replace_all}\n  - \"#{old_hint}\"#{old_suffix}\n  + \"#{new_hint}\"#{new_suffix}"
+            end
+
+            #: () -> String
+            def format_write
+              file_path = input[:file_path]
+              preview = truncate(input[:content].to_s.lines.first.to_s.strip)
+              "WRITE #{file_path}\n  #{preview}"
+            end
+
+            #: () -> String
+            def format_grep
+              modifiers = [
+                ("glob=#{input[:glob]}" if input[:glob]),
+                ("type=#{input[:type]}" if input[:type]),
+                ("-i" if input[:i]),
+              ].compact.join(" · ")
+              second_line = modifiers.empty? ? nil : "  #{modifiers}"
+              ["GREP \"#{truncate(input[:pattern])}\" #{input[:path]}", second_line].compact.join("\n")
+            end
+
+            #: () -> String
+            def format_glob
+              "GLOB #{input[:pattern]}\n  #{input[:path]}"
+            end
+
             #: () -> String
             def format_read
               file_path = input[:file_path]
-              limit = input[:limit] ? input[:limit] : nil
-              offset = input[:offset] ? input[:offset] : nil
-              "READ #{file_path} #{"with limit: #{limit}" if limit} #{"with offset: #{offset}" if offset}"
+              limit = input[:limit]
+              offset = input[:offset]
+              details = if limit
+                offset ||= 0
+                "lines #{offset + 1}–#{offset + limit}"
+              end
+              details ? "READ #{file_path}\n  #{details}" : "READ #{file_path}"
             end
 
             #: () -> String
             def format_bash
-              "BASH #{input.inspect}"
+              command = truncate(input[:command])
+              description = input[:description]
+              description ? "BASH #{command}\n  #{description}" : "BASH #{command}"
             end
 
             #: () -> String

--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -39,11 +39,13 @@ module Roast
             #: () -> String
             def format_taskoutput
               task_id = truncate(input[:task_id])
-              details = [
-                ("blocking" if input[:block]),
-                ("#{input[:timeout]}ms" if input[:timeout]),
-              ].compact.join(" · ")
-              "TASKOUTPUT #{task_id}\n  #{details}"
+              timeout_ms = input[:timeout]
+              timeout_str = if timeout_ms
+                secs = timeout_ms / 1000.0
+                secs == secs.to_i ? "#{secs.to_i}s timeout" : "#{secs}s timeout"
+              end
+              details = [("sync" if input[:block]), timeout_str].compact.join(" · ")
+              details.empty? ? "TASKOUTPUT ##{task_id}" : "TASKOUTPUT ##{task_id} (#{details})"
             end
 
             #: () -> String
@@ -53,7 +55,7 @@ module Roast
                 ("background" if input[:run_in_background]),
                 input[:subagent_type],
               ].compact.join(" · ")
-              "AGENT #{description}\n  #{details}"
+              details.empty? ? "AGENT #{description}" : "AGENT #{description} (#{details})"
             end
 
             #: () -> String
@@ -64,12 +66,13 @@ module Roast
                 input[:subagent_type],
                 input[:model],
               ].compact.join(" · ")
-              "TASK #{description}\n  #{details}"
+              details.empty? ? "TASK #{description}" : "TASK #{description} (#{details})"
             end
 
             #: () -> String
             def format_skill
-              "SKILL #{input[:skill]}\n  #{truncate(input[:args])}"
+              args = input[:args]
+              args ? "SKILL #{input[:skill]} (#{truncate(args)})" : "SKILL #{input[:skill]}"
             end
 
             #: () -> String
@@ -79,7 +82,7 @@ module Roast
                 .group_by { |t| t[:status] || t["status"] }
                 .transform_values(&:length)
               summary = counts.map { |status, n| "#{n} #{status}" }.join(" · ")
-              "TODOWRITE #{todos.length} todos\n  #{summary}"
+              summary.empty? ? "TODOWRITE #{todos.length} todos" : "TODOWRITE #{todos.length} todos (#{summary})"
             end
 
             #: () -> String
@@ -87,19 +90,24 @@ module Roast
               file_path = input[:file_path]
               old_lines = input[:old_string].to_s.lines
               new_lines = input[:new_string].to_s.lines
-              old_hint = truncate(old_lines.first.to_s.strip)
-              new_hint = truncate(new_lines.first.to_s.strip)
-              old_suffix = old_lines.length > 1 ? " (+#{old_lines.length - 1} lines)" : ""
-              new_suffix = new_lines.length > 1 ? " (+#{new_lines.length - 1} lines)" : ""
               replace_all = input[:replace_all] ? " · replace_all" : ""
-              "EDIT #{file_path}#{replace_all}\n  - \"#{old_hint}\"#{old_suffix}\n  + \"#{new_hint}\"#{new_suffix}"
+              old_desc = old_lines.length == 1 ? "\"#{truncate(old_lines.first.to_s.strip)}\"" : "#{old_lines.length} lines"
+              new_desc = new_lines.length == 1 ? "\"#{truncate(new_lines.first.to_s.strip)}\"" : "#{new_lines.length} lines"
+              "EDIT #{file_path}#{replace_all}\n  - #{old_desc}\n  + #{new_desc}"
             end
 
             #: () -> String
             def format_write
               file_path = input[:file_path]
-              preview = truncate(input[:content].to_s.lines.first.to_s.strip)
-              "WRITE #{file_path}\n  #{preview}"
+              lines = input[:content].to_s.lines
+              preview = truncate(lines.first.to_s.strip)
+              extra = lines.length - 1
+              suffix = if extra > 0
+                " (+#{extra} #{extra == 1 ? "line" : "lines"})"
+              else
+                ""
+              end
+              "WRITE #{file_path} \"#{preview}\"#{suffix}"
             end
 
             #: () -> String
@@ -109,13 +117,14 @@ module Roast
                 ("type=#{input[:type]}" if input[:type]),
                 ("-i" if input[:i]),
               ].compact.join(" · ")
-              second_line = modifiers.empty? ? nil : "  #{modifiers}"
-              ["GREP \"#{truncate(input[:pattern])}\" #{input[:path]}", second_line].compact.join("\n")
+              base = "GREP \"#{truncate(input[:pattern])}\" #{input[:path]}"
+              modifiers.empty? ? base : "#{base} (#{modifiers})"
             end
 
             #: () -> String
             def format_glob
-              "GLOB #{input[:pattern]}\n  #{input[:path]}"
+              path = input[:path]
+              path ? "GLOB #{input[:pattern]} (in #{path})" : "GLOB #{input[:pattern]}"
             end
 
             #: () -> String
@@ -127,14 +136,14 @@ module Roast
                 offset ||= 0
                 "lines #{offset + 1}–#{offset + limit}"
               end
-              details ? "READ #{file_path}\n  #{details}" : "READ #{file_path}"
+              details ? "READ #{file_path} (#{details})" : "READ #{file_path}"
             end
 
             #: () -> String
             def format_bash
               command = truncate(input[:command])
               description = input[:description]
-              description ? "BASH #{command}\n  #{description}" : "BASH #{command}"
+              description ? "BASH #{command} (#{description})" : "BASH #{command}"
             end
 
             #: () -> String

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -24,6 +24,13 @@ module Roast
               assert_match(/command.*ls/, output)
             end
 
+            test "format calls format_read for read tool" do
+              tool_use = ToolUse.new(name: :read, input: { file_path: "/tmp/file.txt", limit: 100 })
+              output = tool_use.format
+              puts output
+              assert true
+            end
+
             test "format calls format_unknown for unknown tool" do
               tool_use = ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -170,6 +170,32 @@ module Roast
               puts output
               assert true
             end
+
+            test "format calls format_taskcreate for taskcreate tool" do
+              tool_use = ToolUse.new(name: :taskcreate, input: {
+                subject: "Write tool result formatters for all tool types including bash read glob grep write edit",
+                description: "Write tool result formatters for all tool types including bash read glob grep write edit",
+                activeForm: "Writing tool result formatters",
+              })
+
+              output = tool_use.format
+
+              puts output
+              assert true
+            end
+
+            test "format calls format_taskupdate for taskupdate tool" do
+              tool_use = ToolUse.new(name: :taskupdate, input: {
+                taskId: "1",
+                status: "completed",
+              })
+
+              output = tool_use.format
+
+              puts output
+              assert true
+            end
+
             test "format calls format_unknown for unknown tool" do
               tool_use = ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -16,12 +16,12 @@ module Roast
             end
 
             test "format calls format_bash for bash tool" do
-              tool_use = ToolUse.new(name: :bash, input: { command: "ls" })
+              tool_use = ToolUse.new(name: :bash, input: { command: "ls", description: "Get log" })
 
               output = tool_use.format
 
-              assert_match(/BASH/, output)
-              assert_match(/command.*ls/, output)
+              puts output
+              assert true
             end
 
             test "format calls format_read for read tool" do
@@ -31,6 +31,145 @@ module Roast
               assert true
             end
 
+            test "format calls format_glob for glob tool" do
+              tool_use = ToolUse.new(name: :glob, input: { pattern: "**/*read_only_associations*", path: "/tmp/file.txt" })
+              output = tool_use.format
+              puts output
+              assert true
+            end
+
+            test "format calls format_grep for grep tool" do
+              tool_use = ToolUse.new(
+                name: :grep,
+                input: {
+                  pattern: "class Foo",
+                  path: "/tmp/project",
+                  output_mode: "files_with_matches",
+                  glob: "*.rb",
+                  type: "ruby",
+                  i: true,
+                  n: true,
+                  A: 2,
+                  B: 2,
+                  C: 3,
+                  context: 3,
+                  multiline: false,
+                  head_limit: 100,
+                  offset: 0,
+                },
+              )
+
+              output = tool_use.format
+
+              puts output
+
+              assert true
+            end
+
+            test "format calls format_write for write tool" do
+              tool_use = ToolUse.new(name: :write, input:
+              {
+                file_path: "/tmp/file.txt",
+                content: "Some long string with some new lines to go with it to get even y\n and even more text taht definitely exceeds 50 characters",
+              })
+              output = tool_use.format
+
+              puts output
+
+              assert true
+            end
+
+            test "format calls foramt_edit for edit tool" do
+              tool_use = ToolUse.new(name: :edit, input: {
+                replace_all: false,
+                file_path: "/tmp/file.txt",
+                old_string: "Simple text",
+                new_string: "Much more complex and different text",
+              })
+
+              output = tool_use.format
+
+              puts output
+              assert true
+            end
+
+            test "format calls format_todowrite for todowrite tool" do
+              tool_use = ToolUse.new(name: :todowrite, input: {
+                todos: [
+                  {
+                    content: "Fetch GitHub issue and read comment templates",
+                    status: "in_progress",
+                    activeForm: "Fetching GitHub issue and reading comment templates",
+                  },
+                  {
+                    content: "Check project status in Shopify/projects/13178",
+                    status: "pending",
+                    activeForm: "Checking project status",
+                  },
+                  {
+                    content: "Parse comments for prior work and create working directory",
+                    status: "pending",
+                    activeForm: "Parsing comments and creating working directory",
+                  },
+                ],
+              })
+
+              output = tool_use.format
+
+              puts output
+              assert true
+            end
+
+            test "format calls format_skill for skill tool" do
+              tool_use = ToolUse.new(name: :skill, input: {
+                skill: "github-skill",
+                args: "get-issue-status --org Shopify",
+              })
+
+              output = tool_use.format
+              puts output
+              assert true
+            end
+
+            test "format calls format_task for task tool" do
+              tool_use = ToolUse.new(name: :task, input: {
+                description: "Checks ClassOne for callbacks",
+                prompt: "In the current codebase, look at the class named ClassOne and output whether it contains callbacks.",
+                subagent_type: "Explore",
+                model: "haiku",
+                run_in_background: false,
+              })
+
+              output = tool_use.format
+
+              puts output
+              assert true
+            end
+
+            test "format calls format_agent for agent tool" do
+              tool_use = ToolUse.new(name: :agent, input: {
+                description: "Checks ClassOne for callbacks",
+                prompt: "In the current codebase, look at the class named ClassOne and output whether it contains callbacks.",
+                subagent_type: "Explore",
+              })
+
+              output = tool_use.format
+              puts output
+              assert true
+            end
+
+            test "format calls format_taskoutput for taskoutput tool" do
+              tool_use = ToolUse.new(name: :taskoutput, input: {
+                block: true,
+                task_id: "a628911abed3cf145",
+                timeout: 30000,
+              })
+
+              output = tool_use.format
+
+              puts output
+              assert true
+            end
             test "format calls format_unknown for unknown tool" do
               tool_use = ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
Playground for tool use implementations. Most files are just for testing, the relevant one to look at is `tool_use.rb`

`tool_use_foramtter_test.rb` was created to see the tool uses in action.  
  
Proposed design: 

Single line tool use messages with truncation for long pieces of data.   
![image.png](https://app.graphite.com/user-attachments/assets/a3b9e9a9-c92c-416a-91ff-4351ed578822.png)

Things that were considered:

Dual-line tool use: This was a good idea but it made the output harder to understand.  
![image.png](https://app.graphite.com/user-attachments/assets/82885104-d93c-4b6c-b046-53dc00e1a673.png)

Single-line without truncation:  
Long tool_use messages would mess up the visual coherence of the terminal output.  
