### PR TITLE
add bash tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -27,11 +27,53 @@ module Roast
               format_unknown
             end
 
+            # Truncate long formatted tool-use strings to keep terminal output to generally one line, accounting for logger prefixing.
+            TRUNCATE_LIMIT = 45
+
             private
 
+            # Truncates a string to at most TRUNCATE_LIMIT characters, appending
+            # "..." when the string is cut. The returned string — including the
+            # ellipsis — is guaranteed to be ≤ TRUNCATE_LIMIT characters.
+            #
+            # nil is coerced to "" (so callers needn't nil-check).
+            # Strings at or below the limit are returned unchanged.
+            #
+            # Input:
+            #   str (String?) – the string to truncate
+            #
+            # Output: the (possibly shortened) string
+            #
+            # Examples:
+            #   truncate("ls -la")           # => "ls -la"
+            #   truncate("a" * 50)           # => "aaa...aaa..." (45 chars)
+            #   truncate(nil)                # => ""
+            #
+            #: (String?) -> String
+            def truncate(str)
+              s = str.to_s
+              s.length > TRUNCATE_LIMIT ? "#{s[0...TRUNCATE_LIMIT - 3]}..." : s
+            end
+
+            # Formats a Bash tool-use line.
+            #
+            # Input fields:
+            #   :command     (String) – shell command to execute      [required]
+            #   :description (String) – human-readable label          [optional]
+            #
+            # Output: "BASH <command>", with " (<description>)" appended when
+            # :description is present. :command is truncated to TRUNCATE_LIMIT chars.
+            #
+            # Examples:
+            #   BASH ls -la (List directory contents)
+            #   BASH ls -la
+            #
             #: () -> String
             def format_bash
-              "BASH #{input.inspect}"
+              command = truncate(input[:command])
+              description = input[:description]
+              label = command.empty? ? "BASH" : "BASH #{command}"
+              description ? "#{label} (#{description})" : label
             end
 
             #: () -> String

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -13,13 +13,71 @@ module Roast
           assert_equal({ command: "ls" }, tool_use.input)
         end
 
-        test "format calls format_bash for bash tool" do
-          tool_use = Claude::ToolUse.new(name: :bash, input: { command: "ls" })
+        test "truncate returns the string unchanged at or below the limit" do
+          tool_use = Claude::ToolUse.new(name: :bash, input: {})
+          str = "a" * Claude::ToolUse::TRUNCATE_LIMIT
+
+          output = tool_use.send(:truncate, str)
+
+          assert_equal str, output
+        end
+
+        test "truncate appends ellipsis and stays at the limit for strings over it" do
+          tool_use = Claude::ToolUse.new(name: :bash, input: {})
+          str = "a" * (Claude::ToolUse::TRUNCATE_LIMIT + 1)
+
+          output = tool_use.send(:truncate, str)
+
+          assert_equal "#{"a" * (Claude::ToolUse::TRUNCATE_LIMIT - 3)}...", output
+        end
+
+        test "truncate handles nil without crashing" do
+          tool_use = Claude::ToolUse.new(name: :bash, input: {})
+
+          output = tool_use.send(:truncate, nil)
+
+          assert_equal "", output
+        end
+
+        test "truncate returns an empty string for an empty input" do
+          tool_use = Claude::ToolUse.new(name: :bash, input: {})
+          assert_equal "", tool_use.send(:truncate, "")
+        end
+
+        # format_bash
+
+        test "format_bash renders the command only when no description given" do
+          tool_use = Claude::ToolUse.new(name: :bash, input: { command: "ls -la" })
 
           output = tool_use.format
 
-          assert_match(/BASH/, output)
-          assert_match(/command.*ls/, output)
+          assert_equal "BASH ls -la", output
+        end
+
+        test "format_bash appends description in parentheses" do
+          tool_use = Claude::ToolUse.new(name: :bash, input: { command: "ls -la", description: "List directory contents" })
+
+          output = tool_use.format
+
+          assert_equal "BASH ls -la (List directory contents)", output
+        end
+
+        test "format_bash truncates command but not description" do
+          long = "a" * (Claude::ToolUse::TRUNCATE_LIMIT + 10)
+          truncated = "#{"a" * (Claude::ToolUse::TRUNCATE_LIMIT - 3)}..."
+          tool_use = Claude::ToolUse.new(name: :bash, input: { command: long, description: long })
+
+          output = tool_use.format
+
+          assert_equal "BASH #{truncated} (#{long})", output
+        end
+
+        test "format_bash has no trailing space when the command is absent" do
+          tool_use = Claude::ToolUse.new(name: :bash, input: {})
+
+          output = tool_use.format
+
+          assert_equal "BASH", output
         end
 
         test "format calls format_unknown for unknown tool" do


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/920

Improves the formatting of the bash tool use message.

Current output:
![Pasted Graphic 3.png](https://app.graphite.com/user-attachments/assets/bc15c907-5899-4763-ab99-537089659260.png)

New output:
![nd bol... Istress Besting the bask Sersaller with de lentlanally lang sassand string se verify.png](https://app.graphite.com/user-attachments/assets/19dfa6af-5785-4c91-bf05-d62351e68581.png)