### PR TITLE
Add read tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -76,6 +76,38 @@ module Roast
               description ? "#{label} (#{description})" : label
             end
 
+            # Formats a Read tool-use line.
+            #
+            # Input fields:
+            #   :file_path (String)  – absolute path to read         [required]
+            #   :offset    (Integer) – 1-based first line            [optional]
+            #   :limit     (Integer) – max number of lines to read   [optional]
+            #
+            # Output: "READ <file_path>", with a line range appended when :offset
+            # and/or :limit is given:
+            #   :limit set    → " (lines <start>–<end>)", start = :offset (default
+            #                   1), end = start + :limit - 1
+            #   :offset only  → " (from line <offset>)" (reads to end of file)
+            # With neither, the bare "READ <file_path>".
+            #
+            # Examples:
+            #   READ /app/models/user.rb (lines 30–80)
+            #   READ /app/models/user.rb (from line 30)
+            #   READ /app/models/user.rb
+            #
+            #: () -> String
+            def format_read
+              file_path, offset, limit = input.values_at(:file_path, :offset, :limit)
+              details = if limit
+                offset ||= 1
+                "lines #{offset}–#{offset + limit - 1}"
+              elsif offset
+                "from line #{offset}"
+              end
+              label = file_path.to_s.empty? ? "READ" : "READ #{file_path}"
+              details ? "#{label} (#{details})" : label
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{name}] #{input.inspect}"

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -80,6 +80,48 @@ module Roast
           assert_equal "BASH", output
         end
 
+        # format_read
+
+        test "format_read shows a closed range when offset and limit are set" do
+          tool_use = Claude::ToolUse.new(name: :read, input: { file_path: "/a.rb", offset: 30, limit: 51 })
+
+          output = tool_use.format
+
+          assert_equal "READ /a.rb (lines 30–80)", output
+        end
+
+        test "format_read defaults offset to 1 when only limit is given" do
+          tool_use = Claude::ToolUse.new(name: :read, input: { file_path: "/a.rb", limit: 50 })
+
+          output = tool_use.format
+
+          assert_equal "READ /a.rb (lines 1–50)", output
+        end
+
+        test "format_read shows an open-ended range from offset when limit is absent" do
+          tool_use = Claude::ToolUse.new(name: :read, input: { file_path: "/a.rb", offset: 30 })
+
+          output = tool_use.format
+
+          assert_equal "READ /a.rb (from line 30)", output
+        end
+
+        test "format_read renders a bare line with only a file path" do
+          tool_use = Claude::ToolUse.new(name: :read, input: { file_path: "/a.rb" })
+
+          output = tool_use.format
+
+          assert_equal "READ /a.rb", output
+        end
+
+        test "format_read has no trailing space when the file path is absent" do
+          tool_use = Claude::ToolUse.new(name: :read, input: {})
+
+          output = tool_use.format
+
+          assert_equal "READ", output
+        end
+
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
close https://github.com/Shopify/roast/issues/921

Improves the formatting of the read tool use message.

Current output:
![Pasted Graphic 2.png](https://app.graphite.com/user-attachments/assets/e21efe90-b94c-41c9-97d7-b795a7a7ced2.png)

New output:
![Pasted Graphic 13.png](https://app.graphite.com/user-attachments/assets/f363e544-ec53-45a8-b97b-d1143b857aa7.png)