### PR TITLE
add glob tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -108,6 +108,28 @@ module Roast
               details ? "#{label} (#{details})" : label
             end
 
+            # Formats a Glob tool-use line.
+            #
+            # Input fields:
+            #   :pattern (String) – glob pattern to match    [required]
+            #   :path    (String) – directory to search in   [optional]
+            #
+            # Output: "GLOB <pattern>", with " (in <path>)" appended when :path
+            # is present.
+            #
+            # Pattern is not truncated because glob expressions are typically short
+            # and meaningful in their entirety, unlike shell commands.
+            #
+            # Examples:
+            #   GLOB **/*.rb (in lib/roast)
+            #   GLOB **/*.rb
+            #
+            #: () -> String
+            def format_glob
+              pattern, path = input.values_at(:pattern, :path)
+              path ? "GLOB #{pattern} (in #{path})" : "GLOB #{pattern}"
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{name}] #{input.inspect}"

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -122,6 +122,24 @@ module Roast
           assert_equal "READ", output
         end
 
+        # format_glob
+
+        test "format_glob renders the pattern only when no path given" do
+          tool_use = Claude::ToolUse.new(name: :glob, input: { pattern: "**/*.rb" })
+
+          output = tool_use.format
+
+          assert_equal "GLOB **/*.rb", output
+        end
+
+        test "format_glob appends the search path in parentheses" do
+          tool_use = Claude::ToolUse.new(name: :glob, input: { pattern: "**/*.rb", path: "lib/roast" })
+
+          output = tool_use.format
+
+          assert_equal "GLOB **/*.rb (in lib/roast)", output
+        end
+
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/922

Improves the formatting of the glob tool use message.

Current output:
![Pasted Graphic.png](https://app.graphite.com/user-attachments/assets/88cf6bd4-6224-4706-82e0-8dba0505545a.png)

New output:
![•I agenttrioger_all tools)  GLOBLibroastcoosagentprovidersclaudesessaesss.rb.png](https://app.graphite.com/user-attachments/assets/995d8fbc-8a74-42aa-a430-cfd538f50271.png)