### PR TITLE
add grep tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -130,6 +130,38 @@ module Roast
               path ? "GLOB #{pattern} (in #{path})" : "GLOB #{pattern}"
             end
 
+            # Formats a Grep tool-use line.
+            #
+            # Input fields:
+            #   :pattern (String) – regex to search for          [required]
+            #   :path    (String) – file or directory to search  [optional]
+            #   :glob    (String) – filter files by glob         [optional]
+            #   :type    (String) – filter files by type         [optional]
+            #   :"-i"    (bool)   – case-insensitive match        [optional]
+            #
+            # Output: 'GREP "<pattern>"', then " <path>" when :path is present,
+            # then " (<modifiers>)" when any of :glob, :type, :"-i" are set —
+            # joined with " · " in that order. :pattern is truncated to
+            # TRUNCATE_LIMIT chars; other grep options (such as :"-n") are not
+            # displayed, as they shape grep's output rather than the search itself.
+            #
+            # Examples:
+            #   GREP "def format" lib/roast (glob=*.rb · -i)
+            #   GREP "TODO"
+            #
+            #: () -> String
+            def format_grep
+              pattern, path = input.values_at(:pattern, :path)
+              base = "GREP \"#{truncate(pattern)}\""
+              base = "#{base} #{path}" if path
+              modifiers = [
+                ("glob=#{input[:glob]}" if input[:glob]),
+                ("type=#{input[:type]}" if input[:type]),
+                ("-i" if input[:"-i"]),
+              ].compact.join(" · ")
+              modifiers.empty? ? base : "#{base} (#{modifiers})"
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{name}] #{input.inspect}"

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -140,6 +140,50 @@ module Roast
           assert_equal "GLOB **/*.rb (in lib/roast)", output
         end
 
+        # format_grep
+
+        test "format_grep renders the quoted pattern alone with no path or modifiers" do
+          tool_use = Claude::ToolUse.new(name: :grep, input: { pattern: "TODO" })
+
+          output = tool_use.format
+
+          assert_equal "GREP \"TODO\"", output
+        end
+
+        test "format_grep appends the search path after the pattern" do
+          tool_use = Claude::ToolUse.new(name: :grep, input: { pattern: "TODO", path: "lib/roast" })
+
+          output = tool_use.format
+
+          assert_equal "GREP \"TODO\" lib/roast", output
+        end
+
+        test "format_grep wraps a modifier with the path present" do
+          tool_use = Claude::ToolUse.new(name: :grep, input: { pattern: "TODO", path: "lib", glob: "*.rb" })
+
+          output = tool_use.format
+
+          assert_equal "GREP \"TODO\" lib (glob=*.rb)", output
+        end
+
+        test "format_grep joins glob, type, and case-insensitive modifiers in order" do
+          tool_use = Claude::ToolUse.new(name: :grep, input: { pattern: "TODO", glob: "*.rb", type: "ruby", "-i": true })
+
+          output = tool_use.format
+
+          assert_equal "GREP \"TODO\" (glob=*.rb · type=ruby · -i)", output
+        end
+
+        test "format_grep truncates the pattern but not the path" do
+          long = "a" * (Claude::ToolUse::TRUNCATE_LIMIT + 10)
+          truncated = "#{"a" * (Claude::ToolUse::TRUNCATE_LIMIT - 3)}..."
+          tool_use = Claude::ToolUse.new(name: :grep, input: { pattern: long, path: long })
+
+          output = tool_use.format
+
+          assert_equal "GREP \"#{truncated}\" #{long}", output
+        end
+
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/923

Improves the formatting of the grep tool use message.

Current output:
![image.png](https://app.graphite.com/user-attachments/assets/70152ffd-8e77-4a20-8b41-39c025fef499.png)

New output:
![image.png](https://app.graphite.com/user-attachments/assets/b315e10e-6f70-4186-a0fa-6b74b93a9f50.png)