### PR TITLE
add write tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -162,6 +162,31 @@ module Roast
               modifiers.empty? ? base : "#{base} (#{modifiers})"
             end
 
+            # Formats a Write tool-use line.
+            #
+            # Input fields:
+            #   :file_path (String) – absolute path to write   [required]
+            #   :content   (String) – full file contents       [required]
+            #
+            # Output: 'WRITE <file_path> "<preview>" (+<n> lines)', where
+            # <preview> is the first line of :content (stripped, truncated to
+            # TRUNCATE_LIMIT chars) and <n> is the total number of lines written
+            # (singular " line" when <n> is 1). The count is always shown.
+            #
+            # Examples:
+            #   WRITE /app/models/user.rb "class User < ApplicationRecord" (+10 lines)
+            #   WRITE /config/app.yml "enabled: true" (+1 line)
+            #
+            #: () -> String
+            def format_write
+              file_path, content = input.values_at(:file_path, :content)
+              lines = content.to_s.lines
+              preview = truncate(lines.first.to_s.strip)
+              count = lines.length
+              line_label = count == 1 ? "line" : "lines"
+              "WRITE #{file_path} \"#{preview}\" (+#{count} #{line_label})"
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{name}] #{input.inspect}"

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -212,14 +212,6 @@ module Roast
           assert_equal "WRITE /a.rb \"#{truncated}\" (+1 line)", output
         end
 
-        test "format_write shows a zero count when content is absent" do
-          tool_use = Claude::ToolUse.new(name: :write, input: { file_path: "/a.rb" })
-
-          output = tool_use.format
-
-          assert_equal "WRITE /a.rb \"\" (+0 lines)", output
-        end
-
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -184,6 +184,42 @@ module Roast
           assert_equal "GREP \"#{truncated}\" #{long}", output
         end
 
+        # format_write
+
+        test "format_write shows the preview and a singular count for one line" do
+          tool_use = Claude::ToolUse.new(name: :write, input: { file_path: "/a.rb", content: "hello" })
+
+          output = tool_use.format
+
+          assert_equal "WRITE /a.rb \"hello\" (+1 line)", output
+        end
+
+        test "format_write strips the preview and counts every line" do
+          tool_use = Claude::ToolUse.new(name: :write, input: { file_path: "/a.rb", content: "  def foo\n  bar\n  baz" })
+
+          output = tool_use.format
+
+          assert_equal "WRITE /a.rb \"def foo\" (+3 lines)", output
+        end
+
+        test "format_write truncates the preview" do
+          long = "a" * (Claude::ToolUse::TRUNCATE_LIMIT + 10)
+          truncated = "#{"a" * (Claude::ToolUse::TRUNCATE_LIMIT - 3)}..."
+          tool_use = Claude::ToolUse.new(name: :write, input: { file_path: "/a.rb", content: long })
+
+          output = tool_use.format
+
+          assert_equal "WRITE /a.rb \"#{truncated}\" (+1 line)", output
+        end
+
+        test "format_write shows a zero count when content is absent" do
+          tool_use = Claude::ToolUse.new(name: :write, input: { file_path: "/a.rb" })
+
+          output = tool_use.format
+
+          assert_equal "WRITE /a.rb \"\" (+0 lines)", output
+        end
+
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/924

Improves the formatting of the write tool use message.

Current output:
![image.png](https://app.graphite.com/user-attachments/assets/108610f2-c4e7-4b3b-b3f8-99a7dc2fbc6d.png)

New output:![image.png](https://app.graphite.com/user-attachments/assets/56e43675-4532-4aaf-80ce-f3bc5f7232d5.png)