### PR TITLE
add skill tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -239,6 +239,25 @@ module Roast
               summary.empty? ? base : "#{base} (#{summary})"
             end
 
+            # Formats a Skill tool-use line.
+            #
+            # Input fields:
+            #   :skill (String) – name of the skill to invoke     [required]
+            #   :args  (String) – arguments passed to the skill   [optional]
+            #
+            # Output: "SKILL <skill>", with " (<args>)" appended when :args is
+            # present. :args is truncated to TRUNCATE_LIMIT chars; :skill is not.
+            #
+            # Examples:
+            #   SKILL pr-description (draft for the auth changes)
+            #   SKILL pr-description
+            #
+            #: () -> String
+            def format_skill
+              skill, args = input.values_at(:skill, :args)
+              args ? "SKILL #{skill} (#{truncate(args)})" : "SKILL #{skill}"
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{name}] #{input.inspect}"

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -283,6 +283,34 @@ module Roast
           assert_equal "TODOWRITE 3 todos (1 pending · 2 completed)", output
         end
 
+        # format_skill
+
+        test "format_skill renders the skill name alone when no args given" do
+          tool_use = Claude::ToolUse.new(name: :skill, input: { skill: "pr-description" })
+
+          output = tool_use.format
+
+          assert_equal "SKILL pr-description", output
+        end
+
+        test "format_skill appends args in parentheses" do
+          tool_use = Claude::ToolUse.new(name: :skill, input: { skill: "pr-description", args: "draft for auth" })
+
+          output = tool_use.format
+
+          assert_equal "SKILL pr-description (draft for auth)", output
+        end
+
+        test "format_skill truncates args but not the skill name" do
+          long = "a" * (Claude::ToolUse::TRUNCATE_LIMIT + 10)
+          truncated = "#{"a" * (Claude::ToolUse::TRUNCATE_LIMIT - 3)}..."
+          tool_use = Claude::ToolUse.new(name: :skill, input: { skill: long, args: long })
+
+          output = tool_use.format
+
+          assert_equal "SKILL #{long} (#{truncated})", output
+        end
+
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/927

Improves the formatting of the skill tool use message.

Current output:![• I, agent trigger_all tools) › UNKNOWN [skill] {skill keybindings-help}.png](https://app.graphite.com/user-attachments/assets/96c19b40-0e32-4bf9-89e8-5f802229b0c6.png)
￼New output:  
![• I, agenttrigger all tools) › SKILL keybindings-help.png](https://app.graphite.com/user-attachments/assets/bc71b2d5-cec7-4db9-8adb-df2a2cb61736.png)