### PR TITLE
add task tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -258,6 +258,35 @@ module Roast
               args ? "SKILL #{skill} (#{truncate(args)})" : "SKILL #{skill}"
             end
 
+            # Formats a Task tool-use line.
+            #
+            # Input fields:
+            #   :description       (String) – short label for the task       [required]
+            #   :subagent_type     (String) – which agent type to spawn       [optional]
+            #   :run_in_background (bool)   – run the agent asynchronously    [optional]
+            #   :model             (String) – model override for the agent    [optional]
+            #
+            # Output: "TASK <description>", with " (<details>)" appended when any
+            # optional field is set: :subagent_type, then "background" (when
+            # :run_in_background is set), then :model — joined with " · " in that
+            # order and shown as raw values (no key= labels). :description is
+            # truncated to TRUNCATE_LIMIT chars; the other fields are not.
+            #
+            # Examples:
+            #   TASK Find all callers (Explore · background · opus)
+            #   TASK Summarize the diff
+            #
+            #: () -> String
+            def format_task
+              description = truncate(input[:description])
+              details = [
+                input[:subagent_type],
+                ("background" if input[:run_in_background]),
+                input[:model],
+              ].compact.join(" · ")
+              details.empty? ? "TASK #{description}" : "TASK #{description} (#{details})"
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{name}] #{input.inspect}"

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -311,6 +311,44 @@ module Roast
           assert_equal "SKILL #{long} (#{truncated})", output
         end
 
+        # format_task
+
+        test "format_task renders the description alone with no optional fields" do
+          tool_use = Claude::ToolUse.new(name: :task, input: { description: "Find all callers" })
+
+          output = tool_use.format
+
+          assert_equal "TASK Find all callers", output
+        end
+
+        test "format_task joins subagent type, background, and model in order" do
+          input = { description: "Audit", run_in_background: true, subagent_type: "Explore", model: "opus" }
+          tool_use = Claude::ToolUse.new(name: :task, input: input)
+
+          output = tool_use.format
+
+          assert_equal "TASK Audit (Explore · background · opus)", output
+        end
+
+        test "format_task omits background when run_in_background is false" do
+          tool_use = Claude::ToolUse.new(name: :task, input: { description: "Audit", run_in_background: false })
+
+          output = tool_use.format
+
+          assert_equal "TASK Audit", output
+        end
+
+        test "format_task truncates the description but not the subagent type or model" do
+          long = "a" * (Claude::ToolUse::TRUNCATE_LIMIT + 10)
+          truncated = "#{"a" * (Claude::ToolUse::TRUNCATE_LIMIT - 3)}..."
+          input = { description: long, subagent_type: long, model: long }
+          tool_use = Claude::ToolUse.new(name: :task, input: input)
+
+          output = tool_use.format
+
+          assert_equal "TASK #{truncated} (#{long} · #{long})", output
+        end
+
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/928

Improves the formatting of the task tool use message.

Note: I was not able to trigger this tool call on my setup. We have logs showing that this tool was called multiple times in various workflows in the past (the logs show all the fields in the call, so we are able to know what we need to capture). It may be deprecated, only available or some (older?) versions. I think it's still good to add it just to make sure we cover all grounds, but this is something to keep in mind.