### PR TITLE
add agent tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -287,6 +287,33 @@ module Roast
               details.empty? ? "TASK #{description}" : "TASK #{description} (#{details})"
             end
 
+            # Formats an Agent tool-use line.
+            #
+            # Input fields:
+            #   :description       (String) – short label for the work        [required]
+            #   :subagent_type     (String) – which agent type to spawn        [optional]
+            #   :run_in_background (bool)   – run the agent asynchronously     [optional]
+            #
+            # Output: "AGENT <description>", with " (<details>)" appended when any
+            # optional field is set: :subagent_type, then "background" (when
+            # :run_in_background is set) — joined with " · " in that order and shown
+            # as raw values (no key= labels). :description is truncated to
+            # TRUNCATE_LIMIT chars; :subagent_type is not.
+            #
+            # Examples:
+            #   AGENT Find all callers (Explore · background)
+            #   AGENT Summarize the diff
+            #
+            #: () -> String
+            def format_agent
+              description = truncate(input[:description])
+              details = [
+                input[:subagent_type],
+                ("background" if input[:run_in_background]),
+              ].compact.join(" · ")
+              details.empty? ? "AGENT #{description}" : "AGENT #{description} (#{details})"
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{name}] #{input.inspect}"

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -349,6 +349,36 @@ module Roast
           assert_equal "TASK #{truncated} (#{long} · #{long})", output
         end
 
+        # format_agent
+
+        test "format_agent renders the description alone with no optional fields" do
+          tool_use = Claude::ToolUse.new(name: :agent, input: { description: "Find all callers" })
+
+          output = tool_use.format
+
+          assert_equal "AGENT Find all callers", output
+        end
+
+        test "format_agent renders the description with all optional fields" do
+          input = { description: "Audit", run_in_background: true, subagent_type: "Explore" }
+          tool_use = Claude::ToolUse.new(name: :agent, input: input)
+
+          output = tool_use.format
+
+          assert_equal "AGENT Audit (Explore · background)", output
+        end
+
+        test "format_agent truncates the description but not the subagent type" do
+          long = "a" * (Claude::ToolUse::TRUNCATE_LIMIT + 10)
+          truncated = "#{"a" * (Claude::ToolUse::TRUNCATE_LIMIT - 3)}..."
+          input = { description: long, subagent_type: long }
+          tool_use = Claude::ToolUse.new(name: :agent, input: input)
+
+          output = tool_use.format
+
+          assert_equal "AGENT #{truncated} (#{long})", output
+        end
+
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/929

Improves the formatting of the agent tool use message.

Current output:
![image.png](https://app.graphite.com/user-attachments/assets/571329cd-38d5-4370-af7a-62acc20bcdb3.png)

New output:
![image.png](https://app.graphite.com/user-attachments/assets/88eac5fd-c01a-4f01-9490-5a20a752f387.png)