### PR TITLE
add taskupdate tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -314,6 +314,25 @@ module Roast
               details.empty? ? "AGENT #{description}" : "AGENT #{description} (#{details})"
             end
 
+            # Formats a TaskUpdate tool-use line.
+            #
+            # Input fields:
+            #   :taskId (Integer) – id of the task to update   [required]
+            #   :status (String)  – the task's new status      [required]
+            #
+            # Output: "TASKUPDATE #<taskId> → <status>" — the id is prefixed with
+            # "#" and joined to the status with " → ". Both fields are always
+            # shown and neither is truncated.
+            #
+            # Examples:
+            #   TASKUPDATE #1 → completed
+            #   TASKUPDATE #2 → in_progress
+            #
+            #: () -> String
+            def format_taskupdate
+              "TASKUPDATE ##{input[:taskId]} → #{input[:status]}"
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{name}] #{input.inspect}"

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -379,6 +379,16 @@ module Roast
           assert_equal "AGENT #{truncated} (#{long})", output
         end
 
+        # format_taskupdate
+
+        test "format_taskupdate renders the task id and status" do
+          tool_use = Claude::ToolUse.new(name: :taskupdate, input: { taskId: 1, status: "completed" })
+
+          output = tool_use.format
+
+          assert_equal "TASKUPDATE #1 → completed", output
+        end
+
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/930

Improves the formatting of the taskupdate tool use message.

Current output:
![image.png](https://app.graphite.com/user-attachments/assets/9d8e4bb6-36cc-4c1c-bf72-4902016aa58a.png)

New output:
￼![image.png](https://app.graphite.com/user-attachments/assets/410013bc-18f6-443e-a7bc-86aa6f856aa7.png)