### PR TITLE
add taskcreate tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -333,6 +333,23 @@ module Roast
               "TASKUPDATE ##{input[:taskId]} → #{input[:status]}"
             end
 
+            # Formats a TaskCreate tool-use line.
+            #
+            # Input fields:
+            #   :subject (String) – title of the task to create   [required]
+            #
+            # Output: "TASKCREATE <subject>", with :subject truncated to
+            # TRUNCATE_LIMIT chars.
+            #
+            # Examples:
+            #   TASKCREATE Run formatter stress test
+            #   TASKCREATE Review multiline edit output in tmp/formatter_st...
+            #
+            #: () -> String
+            def format_taskcreate
+              "TASKCREATE #{truncate(input[:subject])}"
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{name}] #{input.inspect}"

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -389,6 +389,26 @@ module Roast
           assert_equal "TASKUPDATE #1 → completed", output
         end
 
+        # format_taskcreate
+
+        test "format_taskcreate renders the subject" do
+          tool_use = Claude::ToolUse.new(name: :taskcreate, input: { subject: "Run formatter stress test" })
+
+          output = tool_use.format
+
+          assert_equal "TASKCREATE Run formatter stress test", output
+        end
+
+        test "format_taskcreate truncates the subject" do
+          long = "a" * (Claude::ToolUse::TRUNCATE_LIMIT + 10)
+          truncated = "#{"a" * (Claude::ToolUse::TRUNCATE_LIMIT - 3)}..."
+          tool_use = Claude::ToolUse.new(name: :taskcreate, input: { subject: long })
+
+          output = tool_use.format
+
+          assert_equal "TASKCREATE #{truncated}", output
+        end
+
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/931

Improves the formatting of the taskcreate tool use message.

Current output:
![image.png](https://app.graphite.com/user-attachments/assets/947d3dca-7f0e-486a-83e3-45f77bad4213.png)

New output:
![image.png](https://app.graphite.com/user-attachments/assets/ea7d9b8b-9944-480e-a322-9d64ec08124b.png)