### PR TITLE
add taskoutput tool use formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_use.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_use.rb
@@ -350,6 +350,45 @@ module Roast
               "TASKCREATE #{truncate(input[:subject])}"
             end
 
+            # Formats a TaskOutput tool-use line.
+            #
+            # Input fields:
+            #   :task_id (String)  – id of the task to read        [required]
+            #   :block   (bool)    – wait for the task to complete [optional]
+            #   :timeout (Integer) – max wait in milliseconds      [optional]
+            #
+            # Output: "TASKOUTPUT #<task_id>", with " (<details>)" appended for any
+            # set options. :block renders its mode only when explicitly set — "sync"
+            # (true) or "async" (false) — and nothing when omitted. :timeout follows
+            # as "<n>s timeout" (whole seconds drop the decimal). Modifiers join with
+            # " · " in that order. :task_id is truncated to TRUNCATE_LIMIT chars.
+            #
+            # Examples:
+            #   TASKOUTPUT #abc123 (sync · 120s timeout)
+            #   TASKOUTPUT #abc123 (async · 5s timeout)
+            #   TASKOUTPUT #abc123
+            #
+            #: () -> String
+            def format_taskoutput
+              task_id = truncate(input[:task_id])
+              timeout_ms = input[:timeout]
+              timeout_str = if timeout_ms
+                seconds = ActiveSupport::NumberHelper.number_to_rounded(
+                  timeout_ms / 1000.0,
+                  delimiter: "",
+                  precision: 3,
+                  strip_insignificant_zeros: true,
+                )
+                "#{seconds}s timeout"
+              end
+              block_label = case input[:block]
+              when true then "sync"
+              when false then "async"
+              end
+              details = [block_label, timeout_str].compact.join(" · ")
+              details.empty? ? "TASKOUTPUT ##{task_id}" : "TASKOUTPUT ##{task_id} (#{details})"
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{name}] #{input.inspect}"

--- a/test/roast/cogs/agent/providers/claude/tool_use_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_use_test.rb
@@ -409,6 +409,67 @@ module Roast
           assert_equal "TASKCREATE #{truncated}", output
         end
 
+        # format_taskoutput
+
+        test "format_taskoutput renders the task id alone with no options" do
+          tool_use = Claude::ToolUse.new(name: :taskoutput, input: { task_id: "abc123" })
+
+          output = tool_use.format
+
+          assert_equal "TASKOUTPUT #abc123", output
+        end
+
+        test "format_taskoutput marks a blocking call as sync" do
+          tool_use = Claude::ToolUse.new(name: :taskoutput, input: { task_id: "abc123", block: true })
+
+          output = tool_use.format
+
+          assert_equal "TASKOUTPUT #abc123 (sync)", output
+        end
+
+        test "format_taskoutput marks a non-blocking call as async" do
+          tool_use = Claude::ToolUse.new(name: :taskoutput, input: { task_id: "abc123", block: false })
+
+          output = tool_use.format
+
+          assert_equal "TASKOUTPUT #abc123 (async)", output
+        end
+
+        test "format_taskoutput renders a whole-second timeout without a decimal" do
+          tool_use = Claude::ToolUse.new(name: :taskoutput, input: { task_id: "abc123", timeout: 1000 })
+
+          output = tool_use.format
+
+          assert_equal "TASKOUTPUT #abc123 (1s timeout)", output
+        end
+
+        test "format_taskoutput renders a fractional-second timeout with a decimal" do
+          tool_use = Claude::ToolUse.new(name: :taskoutput, input: { task_id: "abc123", timeout: 1500 })
+
+          output = tool_use.format
+
+          assert_equal "TASKOUTPUT #abc123 (1.5s timeout)", output
+        end
+
+        test "format_taskoutput joins sync and timeout in order" do
+          input = { task_id: "abc123", block: true, timeout: 30000 }
+          tool_use = Claude::ToolUse.new(name: :taskoutput, input: input)
+
+          output = tool_use.format
+
+          assert_equal "TASKOUTPUT #abc123 (sync · 30s timeout)", output
+        end
+
+        test "format_taskoutput truncates the task id" do
+          long = "a" * (Claude::ToolUse::TRUNCATE_LIMIT + 10)
+          truncated = "#{"a" * (Claude::ToolUse::TRUNCATE_LIMIT - 3)}..."
+          tool_use = Claude::ToolUse.new(name: :taskoutput, input: { task_id: long })
+
+          output = tool_use.format
+
+          assert_equal "TASKOUTPUT ##{truncated}", output
+        end
+
         test "format calls format_unknown for unknown tool" do
           tool_use = Claude::ToolUse.new(name: :unknown_tool, input: { arg: "value" })
 


### PR DESCRIPTION
closes https://github.com/Shopify/roast/issues/932

Improves the formatting of the taskoutput tool use message.

Current output:
![image.png](https://app.graphite.com/user-attachments/assets/003a1635-5b02-486b-a9fe-6e6adcbc88e9.png)

New output:
![image.png](https://app.graphite.com/user-attachments/assets/9f3ca17d-52e2-4475-a2e5-8e2c82b355aa.png)