### PR TITLE
Fix blank error message on failed Claude agent runs

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/messages/result_message.rb
+++ b/lib/roast/cogs/agent/providers/claude/messages/result_message.rb
@@ -31,7 +31,7 @@ module Roast
                 @content = hash.delete(:result) || ""
                 @success = hash.delete(:success) || subtype == "success"
                 if hash.delete(:is_error) || subtype == "error"
-                  @content = @content || hash.dig(:error, :message) || "Unknown error"
+                  @content = @content.presence || hash.dig(:error, :message) || "Unknown error"
                   hash.delete(:error)
                 end
 

--- a/test/roast/cogs/agent/providers/claude/messages/result_message_test.rb
+++ b/test/roast/cogs/agent/providers/claude/messages/result_message_test.rb
@@ -14,12 +14,12 @@ module Roast
           assert_equal "Task completed", message.content
         end
 
-        test "initialize with error subtype sets content to empty string when no result" do
+        test "initialize with error subtype falls back to error message when no result" do
           hash = { subtype: "error", error: { message: "Something went wrong" } }
           message = ResultMessage.new(type: :result, hash:)
 
           refute message.success
-          assert_equal "", message.content
+          assert_equal "Something went wrong", message.content
         end
 
         test "initialize with is_error sets content from result" do
@@ -29,11 +29,11 @@ module Roast
           assert_equal "Error result", message.content
         end
 
-        test "initialize with is_error and no result sets content to empty string" do
+        test "initialize with is_error and no result falls back to Unknown error" do
           hash = { is_error: true }
           message = ResultMessage.new(type: :result, hash:)
 
-          assert_equal "", message.content
+          assert_equal "Unknown error", message.content
         end
 
         test "initialize sets content from result field" do


### PR DESCRIPTION
When content is nil, we're setting it as `""`, which makes `@content` evaluate to true and we never hit the `|| hash.dig(:error, :message) || "Unknown error"` branches.