### PR TITLE
Centralize tool result error handling in format with error_line helper

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_result.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_result.rb
@@ -10,6 +10,9 @@ module Roast
             #: Symbol?
             attr_reader :tool_name
 
+            #: Hash[Symbol, untyped]
+            attr_reader :tool_use_input
+
             #: String?
             attr_reader :tool_use_description
 
@@ -22,24 +25,64 @@ module Roast
             #: (tool_use: Messages::ToolUseMessage?, content: String?, is_error: bool) -> void
             def initialize(tool_use:, content:, is_error:)
               @tool_name = tool_use&.name || :unknown
-              @tool_use_description = tool_use&.input&.fetch(:description, nil) #: String?
+              @tool_use_input = tool_use&.input || {} #: Hash[Symbol, untyped]
+              @tool_use_description = @tool_use_input[:description] #: String?
               @content = content
               @is_error = is_error
             end
 
             #: () -> String
             def format
+              return error_line if is_error
+
               format_method_name = "format_#{tool_name}".to_sym
               return send(format_method_name) if respond_to?(format_method_name, true)
 
               format_unknown
             end
 
+            TRUNCATE_LIMIT = 45
+
             private
 
             #: () -> String
             def format_unknown
-              "UNKNOWN [#{tool_name}] #{is_error ? " ERROR" : "OK"} #{tool_use_description || ""}\n#{content}"
+              "UNKNOWN [#{tool_name}] OK #{tool_use_description}\n#{content}"
+            end
+
+            # Renders "<TOOL> OK[ <part> · <part> · ...]"; the success-side twin of
+            # #error_line. Blank/nil parts are dropped and the rest joined with " · ",
+            # so callers pass each piece of the summary without minding separators.
+            #
+            #: (*String?) -> String
+            def ok_line(*parts)
+              summary = parts.select(&:present?).join(" · ")
+              prefix = "#{tool_name.to_s.upcase} OK"
+              summary.present? ? "#{prefix} #{summary}" : prefix
+            end
+
+            # Renders "<TOOL> ERROR <message>" with any <tool_use_error> wrapper stripped.
+            #
+            # Reads the instance's `content` and `tool_name` to produce a single-line
+            # error summary. Error messages are intentionally NOT truncated so the full
+            # diagnostic is preserved for debugging.
+            #
+            # Examples:
+            #   BASH ERROR File has not been read yet.
+            #   UNKNOWN ERROR command not found
+            #
+            #: () -> String
+            def error_line
+              message = content.to_s.gsub(%r{</?tool_use_error>}, "").strip
+              "#{tool_name.to_s.upcase} ERROR #{message}".strip
+            end
+
+            # Truncates to TRUNCATE_LIMIT chars, appending "..." when cut. nil -> "".
+            #
+            #: (String?) -> String
+            def truncate(str)
+              s = str.to_s
+              s.length > TRUNCATE_LIMIT ? "#{s[0...TRUNCATE_LIMIT - 3]}..." : s
             end
           end
         end

--- a/test/roast/cogs/agent/providers/claude/tool_result_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_result_test.rb
@@ -19,6 +19,7 @@ module Roast
 
           assert_equal :bash, tool_result.tool_name
           assert_equal "List files", tool_result.tool_use_description
+          assert_equal({ description: "List files" }, tool_result.tool_use_input)
           assert_equal "file1.txt\nfile2.txt", tool_result.content
           refute tool_result.is_error
         end
@@ -32,6 +33,7 @@ module Roast
 
           assert_equal :unknown, tool_result.tool_name
           assert_nil tool_result.tool_use_description
+          assert_equal({}, tool_result.tool_use_input)
         end
 
         test "initialize with tool_use without description" do
@@ -85,6 +87,64 @@ module Roast
           assert_match(/error details/, output)
         end
 
+        test "error_line strips the tool_use_error wrapper and upcases the tool name" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "bash", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: "<tool_use_error>File has not been read yet.</tool_use_error>",
+            is_error: true,
+          )
+
+          output = tool_result.send(:error_line)
+
+          assert_equal "BASH ERROR File has not been read yet.", output
+        end
+
+        test "error_line handles nil content gracefully" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "read", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: nil,
+            is_error: true,
+          )
+
+          output = tool_result.send(:error_line)
+
+          assert_equal "READ ERROR", output
+        end
+
+        test "format error path keeps the full content" do
+          tool_result = Claude::ToolResult.new(
+            tool_use: nil,
+            content: "Error: command failed\n  at line 3\n  exit status 1",
+            is_error: true,
+          )
+
+          output = tool_result.format
+
+          assert_equal "UNKNOWN ERROR Error: command failed\n  at line 3\n  exit status 1", output
+        end
+
+        test "format routes errors through the error_line helper" do
+          tool_result = Claude::ToolResult.new(
+            tool_use: nil,
+            content: "error details",
+            is_error: true,
+          )
+
+          tool_result.expects(:error_line).returns("ERROR LINE")
+
+          output = tool_result.format
+
+          assert_equal "ERROR LINE", output
+        end
+
         test "format includes description when present" do
           tool_use_message = Claude::Messages::ToolUseMessage.new(
             type: :tool_use,
@@ -99,6 +159,109 @@ module Roast
           output = tool_result.format
 
           assert_match(/Run command/, output)
+        end
+
+        test "ok_line renders a bare OK line when given no parts" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "bash", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: nil,
+            is_error: false,
+          )
+
+          output = tool_result.send(:ok_line)
+
+          assert_equal "BASH OK", output
+        end
+
+        test "ok_line appends a single part and upcases the tool name" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "bash", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: nil,
+            is_error: false,
+          )
+
+          output = tool_result.send(:ok_line, "3 files")
+
+          assert_equal "BASH OK 3 files", output
+        end
+
+        test "ok_line joins multiple parts with a dot separator" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "bash", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: nil,
+            is_error: false,
+          )
+
+          output = tool_result.send(:ok_line, "3 lines", "preview text")
+
+          assert_equal "BASH OK 3 lines · preview text", output
+        end
+
+        test "ok_line drops blank and nil parts before joining" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "bash", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: nil,
+            is_error: false,
+          )
+
+          output = tool_result.send(:ok_line, "3 lines", "", nil)
+
+          assert_equal "BASH OK 3 lines", output
+        end
+
+        test "truncate returns strings within the limit unchanged" do
+          tool_result = Claude::ToolResult.new(
+            tool_use: nil,
+            content: nil,
+            is_error: false,
+          )
+          string_at_limit = "a" * Claude::ToolResult::TRUNCATE_LIMIT
+
+          output = tool_result.send(:truncate, string_at_limit)
+
+          assert_equal string_at_limit, output
+        end
+
+        test "truncate cuts longer strings to the limit with an ellipsis" do
+          tool_result = Claude::ToolResult.new(
+            tool_use: nil,
+            content: nil,
+            is_error: false,
+          )
+          limit = Claude::ToolResult::TRUNCATE_LIMIT
+
+          output = tool_result.send(:truncate, "a" * (limit + 10))
+
+          assert_equal "#{"a" * (limit - 3)}...", output
+          assert_equal limit, output.length
+        end
+
+        test "truncate maps nil to an empty string" do
+          tool_result = Claude::ToolResult.new(
+            tool_use: nil,
+            content: nil,
+            is_error: false,
+          )
+
+          output = tool_result.send(:truncate, nil)
+
+          assert_equal "", output
         end
       end
     end


### PR DESCRIPTION
Part of https://github.com/Shopify/roast/issues/919

Foundation PR for the tool result formatter implementations.