### PR TITLE
Fix valid_provider! raising ArgumentError instead of InvalidConfigError

### DIFF
--- a/lib/roast/cogs/agent/config.rb
+++ b/lib/roast/cogs/agent/config.rb
@@ -51,7 +51,7 @@ module Roast
         def valid_provider!
           provider = @values[:provider] || VALID_PROVIDERS.first
           unless VALID_PROVIDERS.include?(provider)
-            raise ArgumentError, "'#{provider}' is not a valid provider. Available providers include: #{VALID_PROVIDERS.join(", ")}"
+            raise InvalidConfigError, "'#{provider}' is not a valid provider. Available providers include: #{VALID_PROVIDERS.join(", ")}"
           end
 
           provider

--- a/lib/roast/cogs/chat/config.rb
+++ b/lib/roast/cogs/chat/config.rb
@@ -67,7 +67,7 @@ module Roast
         def valid_provider!
           provider = @values[:provider] || PROVIDERS.keys.first
           unless PROVIDERS.include?(provider)
-            raise ArgumentError, "'#{provider}' is not a valid provider. Available providers include: #{PROVIDERS.keys.join(", ")}"
+            raise InvalidConfigError, "'#{provider}' is not a valid provider. Available providers include: #{PROVIDERS.keys.join(", ")}"
           end
 
           provider

--- a/test/roast/cogs/agent/config_test.rb
+++ b/test/roast/cogs/agent/config_test.rb
@@ -31,7 +31,7 @@ module Roast
       test "valid_provider! raises on invalid provider" do
         @config.provider(:invalid_provider)
 
-        error = assert_raises(ArgumentError) do
+        error = assert_raises(Cog::Config::InvalidConfigError) do
           @config.valid_provider!
         end
 

--- a/test/roast/cogs/chat/config_test.rb
+++ b/test/roast/cogs/chat/config_test.rb
@@ -50,7 +50,7 @@ module Roast
       test "valid_provider! raises on invalid provider" do
         @config.provider(:invalid_provider)
 
-        error = assert_raises(ArgumentError) do
+        error = assert_raises(Cog::Config::InvalidConfigError) do
           @config.valid_provider!
         end
 


### PR DESCRIPTION
## Problem

Both `Chat::Config#valid_provider!` and `Agent::Config#valid_provider!`
raise `ArgumentError` when given an invalid provider name, despite their
doc comments explicitly promising `InvalidConfigError`:

```ruby
# Note: this method will return the name of a valid provider
# or raise an `InvalidConfigError`.
def valid_provider!
  # ...
  raise ArgumentError, "'...' is not a valid provider..."
end
```

This means any caller writing `rescue InvalidConfigError` — following
the documented contract — will not catch invalid provider errors. The
exception escapes as an unhandled `ArgumentError` instead of flowing
through the `ConfigError` hierarchy like every other config validation.

## Fix

Changed both methods to raise `InvalidConfigError` (which they inherit
from `Cog::Config` via the class hierarchy). This is consistent with:

- `Chat::Config#valid_api_key!` (line 124), which already raises
`InvalidConfigError` for missing API keys
- `Map::Config#valid_parallel!` (line 89)
- `Config#working_directory` (lines 297–298)
- All `Config#validate!` overrides across the cog tree

Updated the corresponding tests in both `chat/config_test.rb` and
`agent/config_test.rb` to assert `Cog::Config::InvalidConfigError`
instead of `ArgumentError`.