### PR TITLE
Update deprecated model references with newer ones

### DIFF
--- a/test/roast/cogs/agent/providers/pi/pi_invocation_test.rb
+++ b/test/roast/cogs/agent/providers/pi/pi_invocation_test.rb
@@ -190,13 +190,13 @@ module Roast
         end
 
         test "command_line includes model when configured" do
-          @config.model("anthropic/claude-sonnet-4-20250514")
+          @config.model("anthropic/claude-sonnet-4-6")
           invocation = Pi::PiInvocation.new(@config, "Test prompt", nil)
 
           command = invocation.send(:command_line)
           model_index = command.index("--model")
           assert model_index
-          assert_equal "anthropic/claude-sonnet-4-20250514", command[model_index + 1]
+          assert_equal "anthropic/claude-sonnet-4-6", command[model_index + 1]
         end
 
         test "command_line includes replace_system_prompt when configured" do
@@ -290,7 +290,7 @@ module Roast
             type: "message_end",
             message: {
               role: "assistant",
-              model: "claude-sonnet-4-20250514",
+              model: "claude-sonnet-4-6",
               content: [{ type: "text", text: "Response text" }],
               usage: {
                 input: 100,
@@ -306,9 +306,9 @@ module Roast
           @invocation.send(:handle_message, data)
 
           acc = @invocation.instance_variable_get(:@model_usage_accumulator)
-          assert acc.key?("claude-sonnet-4-20250514")
-          assert_equal 100, acc["claude-sonnet-4-20250514"][:input]
-          assert_equal 50, acc["claude-sonnet-4-20250514"][:output]
+          assert acc.key?("claude-sonnet-4-6")
+          assert_equal 100, acc["claude-sonnet-4-6"][:input]
+          assert_equal 50, acc["claude-sonnet-4-6"][:output]
         end
 
         test "accumulate_usage sums across multiple message_end events for the same model" do
@@ -336,17 +336,17 @@ module Roast
           sonnet_usage = { input: 20, output: 80, cacheRead: 0, cacheWrite: 0, cost: { total: 0.004 } }
 
           @invocation.send(:accumulate_usage, "claude-haiku-4-5-20251001",  haiku_usage)
-          @invocation.send(:accumulate_usage, "claude-sonnet-4-20250514",   sonnet_usage)
-          @invocation.send(:accumulate_usage, "claude-haiku-4-5-20251001",  haiku_usage)
+          @invocation.send(:accumulate_usage, "claude-sonnet-4-6", sonnet_usage)
+          @invocation.send(:accumulate_usage, "claude-haiku-4-5-20251001", haiku_usage)
 
           acc = @invocation.instance_variable_get(:@model_usage_accumulator)
           assert_equal 20,  acc["claude-haiku-4-5-20251001"][:input]
           assert_equal 100, acc["claude-haiku-4-5-20251001"][:output]
           assert_in_delta 0.002, acc["claude-haiku-4-5-20251001"][:cost], 0.00001
 
-          assert_equal 20,  acc["claude-sonnet-4-20250514"][:input]
-          assert_equal 80,  acc["claude-sonnet-4-20250514"][:output]
-          assert_in_delta 0.004, acc["claude-sonnet-4-20250514"][:cost], 0.00001
+          assert_equal 20,  acc["claude-sonnet-4-6"][:input]
+          assert_equal 80,  acc["claude-sonnet-4-6"][:output]
+          assert_in_delta 0.004, acc["claude-sonnet-4-6"][:cost], 0.00001
 
           assert_in_delta 0.006, @invocation.instance_variable_get(:@total_cost), 0.00001
         end
@@ -382,7 +382,7 @@ module Roast
 
         test "finalize_stats creates proper stats object" do
           acc = @invocation.instance_variable_get(:@model_usage_accumulator)
-          acc["claude-sonnet-4-20250514"] = { input: 100, output: 50, cache_read: 200, cache_write: 50, cost: 0.003 }
+          acc["claude-sonnet-4-6"] = { input: 100, output: 50, cache_read: 200, cache_write: 50, cost: 0.003 }
           @invocation.instance_variable_set(:@num_turns, 3)
           @invocation.instance_variable_set(:@total_cost, 0.003)
 
@@ -394,7 +394,7 @@ module Roast
           assert_equal 100, stats.usage.input_tokens
           assert_equal 50, stats.usage.output_tokens
           assert_in_delta 0.003, stats.usage.cost_usd
-          assert stats.model_usage.key?("claude-sonnet-4-20250514")
+          assert stats.model_usage.key?("claude-sonnet-4-6")
         end
 
         test "does not emit duplicate session events" do

--- a/test/roast/cogs/chat/config_test.rb
+++ b/test/roast/cogs/chat/config_test.rb
@@ -189,13 +189,13 @@ module Roast
 
       # Model configuration tests
       test "model sets model value" do
-        @config.model("gpt-4")
+        @config.model("gpt-5.5")
 
-        assert_equal "gpt-4", @config.valid_model
+        assert_equal "gpt-5.5", @config.valid_model
       end
 
       test "use_default_model! resets model to provider default" do
-        @config.model("gpt-4")
+        @config.model("gpt-5.5")
         @config.use_default_model!
 
         assert_equal Chat::Config::PROVIDERS.dig(:openai, :default_model), @config.valid_model

--- a/tutorial/01_your_first_workflow/README.md
+++ b/tutorial/01_your_first_workflow/README.md
@@ -125,7 +125,7 @@ end
 Common options you can set:
 
 - `model "name"` - Which LLM model to use
-    - OpenAI: "gpt-4o-mini" (default), "gpt-4o", "gpt-4-turbo", etc.
+    - OpenAI: "gpt-4o-mini" (default), "gpt-4o", "gpt-5.5", etc.
     - Anthropic: "claude-haiku-4-5" (default), "claude-sonnet-4-6", "claude-opus-4-7", etc.
     - Perplexity: "sonar" (default), "sonar-pro", "sonar-deep-research", etc.
     - Gemini: "gemini-3.1-flash-lite" (default), "gemini-3-flash-preview", "gemini-3.1-pro-preview", etc.

--- a/tutorial/02_chaining_cogs/code_review.rb
+++ b/tutorial/02_chaining_cogs/code_review.rb
@@ -8,7 +8,7 @@
 
 config do
   agent do
-    model "claude-3-5-haiku-20241022"
+    model "claude-haiku-4-5-20251001"
     provider :claude
   end
 

--- a/tutorial/02_chaining_cogs/session_resumption.rb
+++ b/tutorial/02_chaining_cogs/session_resumption.rb
@@ -10,7 +10,7 @@ config do
     show_stats!
   end
   chat(:recall_code) do
-    model "gpt-4.1-nano"
+    model "gpt-5.4-nano"
   end
   agent do
     model "haiku"


### PR DESCRIPTION
Maintenance PR to keep model references in the code up to date.   
  
Changes generated from the internal/workflows/maintenance/deprecated_models_docs_updater.rb workflow