### PR TITLE
Detect and raise on max-token truncation in chat cog

### DIFF
--- a/lib/roast/cogs/chat.rb
+++ b/lib/roast/cogs/chat.rb
@@ -20,6 +20,14 @@ module Roast
     #
     # For tasks requiring local filesystem access or locally-configured tools, use the `agent` cog instead.
     class Chat < Cog
+      # Raised when the LLM response hits the max token limit, indicating the output was
+      # truncated and should not be considered usable.
+      class MaxTokensExceededError < Cog::CogError; end
+
+      # Anthropic always sends a max_tokens value in the request payload with this fallback
+      # when the model metadata doesn't specify one (see ruby_llm's Anthropic::Chat#build_base_payload).
+      ANTHROPIC_DEFAULT_MAX_TOKENS = 4096
+
       # The configuration object for this chat cog instance
       #
       #: Roast::Cogs::Chat::Config
@@ -60,10 +68,52 @@ module Roast
           Event << { block: { header: "LLM STATS", content: lines.join("\n") } }
         end
 
+        verify_response_not_truncated!(chat, response)
+
         Output.new(Session.from_chat(chat), response.content)
       end
 
       private
+
+      # Verify that the LLM response was not truncated by hitting the max token limit.
+      #
+      # ruby_llm does not expose a stop_reason/finish_reason from the provider response, so we
+      # detect truncation heuristically: if the output token count equals (or exceeds) the
+      # effective max token limit, the content was almost certainly cut off mid-generation.
+      #
+      # The effective limit is derived from the model metadata (chat.model.max_tokens). For
+      # Anthropic, the provider always sends max_tokens with a fallback of 4096, so we replicate
+      # that fallback here. For other providers, if the model metadata doesn't specify a limit
+      # (e.g., when assume_model_exists is used with an unknown model), the check is skipped
+      # because we have no ceiling to compare against.
+      #
+      #: (RubyLLM::Chat, RubyLLM::Message) -> void
+      def verify_response_not_truncated!(chat, response)
+        max_tokens = effective_max_tokens(chat)
+        return unless max_tokens
+        return unless response.output_tokens
+
+        if response.output_tokens >= max_tokens
+          raise MaxTokensExceededError,
+            "LLM response from #{response.model_id} was truncated at the max token limit " \
+              "(output: #{response.output_tokens} tokens, limit: #{max_tokens} tokens). " \
+              "The response content is likely incomplete and should not be used."
+        end
+      end
+
+      # Determine the effective max token limit for the chat request.
+      #
+      # Returns nil if the limit cannot be determined (e.g., the model is not in the registry
+      # and the provider doesn't have a known default).
+      #
+      #: (RubyLLM::Chat) -> Integer?
+      def effective_max_tokens(chat)
+        max_tokens = chat.model&.max_tokens
+        return max_tokens if max_tokens
+
+        # Anthropic always sends max_tokens with a 4096 fallback in the request payload
+        ANTHROPIC_DEFAULT_MAX_TOKENS if config.valid_provider! == :anthropic
+      end
 
       # Get a RubyLLM context configured for this chat cog
       #

--- a/lib/roast/cogs/chat.rb
+++ b/lib/roast/cogs/chat.rb
@@ -68,7 +68,7 @@ module Roast
           Event << { block: { header: "LLM STATS", content: lines.join("\n") } }
         end
 
-        verify_response_not_truncated!(chat, response)
+        verify_response_not_truncated!(response)
 
         Output.new(Session.from_chat(chat), response.content)
       end
@@ -81,15 +81,23 @@ module Roast
       # detect truncation heuristically: if the output token count equals (or exceeds) the
       # effective max token limit, the content was almost certainly cut off mid-generation.
       #
-      # The effective limit is derived from the model metadata (chat.model.max_tokens). For
-      # Anthropic, the provider always sends max_tokens with a fallback of 4096, so we replicate
-      # that fallback here. For other providers, if the model metadata doesn't specify a limit
-      # (e.g., when assume_model_exists is used with an unknown model), the check is skipped
-      # because we have no ceiling to compare against.
+      # The effective limit is derived from the ruby_llm model registry, which is populated
+      # from models.dev and provider APIs. This lookup is decoupled from the chat instance's
+      # `assume_model_exists` setting — even when the chat call itself skips registry
+      # verification (the default), we still consult the registry for token-limit metadata.
       #
-      #: (RubyLLM::Chat, RubyLLM::Message) -> void
-      def verify_response_not_truncated!(chat, response)
-        max_tokens = effective_max_tokens(chat)
+      # For Anthropic, the provider always sends max_tokens with a fallback of 4096 in the
+      # request payload, so if the model is not in the registry we replicate that fallback.
+      # For other providers, if the model is not in the registry, the check is skipped because
+      # we have no ceiling to compare against.
+      #
+      # Note: the `>=` boundary can produce false positives when output hits the limit exactly
+      # on a natural boundary. This is an unavoidable trade-off of the heuristic approach until
+      # ruby_llm exposes finish_reason.
+      #
+      #: (RubyLLM::Message) -> void
+      def verify_response_not_truncated!(response)
+        max_tokens = effective_max_tokens
         return unless max_tokens
         return unless response.output_tokens
 
@@ -103,14 +111,17 @@ module Roast
 
       # Determine the effective max token limit for the chat request.
       #
-      # Returns nil if the limit cannot be determined (e.g., the model is not in the registry
-      # and the provider doesn't have a known default).
+      # Queries the ruby_llm model registry directly, independent of the chat instance's
+      # `assume_model_exists` setting. This ensures the token limit is available even when
+      # the chat call itself uses the default permissive mode.
       #
-      #: (RubyLLM::Chat) -> Integer?
-      def effective_max_tokens(chat)
-        max_tokens = chat.model&.max_tokens
-        return max_tokens if max_tokens
-
+      # Returns nil if the model is not in the registry and the provider doesn't have a
+      # known default.
+      #
+      #: () -> Integer?
+      def effective_max_tokens
+        RubyLLM.models.find(config.valid_model, config.valid_provider!)&.max_tokens
+      rescue RubyLLM::ModelNotFoundError
         # Anthropic always sends max_tokens with a 4096 fallback in the request payload
         ANTHROPIC_DEFAULT_MAX_TOKENS if config.valid_provider! == :anthropic
       end

--- a/test/examples/functional/roast_examples_test.rb
+++ b/test/examples/functional/roast_examples_test.rb
@@ -885,6 +885,7 @@ module Examples
         mock_chat = mock
         mock_chat.stubs(:messages).returns([])
         mock_chat.stubs(:with_temperature).returns(mock_chat)
+        mock_chat.stubs(:model).returns(stub(max_tokens: 16_384))
         mock_chat.stubs(:ask).returns(stub(content: "test response", model_id: "gpt-4o", input_tokens: 1, output_tokens: 1))
 
         mock_context = mock

--- a/test/roast/cogs/chat/max_tokens_test.rb
+++ b/test/roast/cogs/chat/max_tokens_test.rb
@@ -24,11 +24,8 @@ module Roast
       test "raises MaxTokensExceededError when output tokens equals max tokens for Anthropic" do
         @cog.config.provider(:anthropic)
 
-        mock_model = stub(max_tokens: nil)
-        mock_chat = mock_chat_with_response(
-          model: mock_model,
-          output_tokens: Chat::ANTHROPIC_DEFAULT_MAX_TOKENS,
-        )
+        stub_registry_max_tokens(4096, :anthropic)
+        mock_chat = mock_chat_with_response(output_tokens: 4096)
         stub_ruby_llm_context(mock_chat, :anthropic)
 
         error = assert_raises(Chat::MaxTokensExceededError) do
@@ -36,18 +33,15 @@ module Roast
         end
 
         assert_match(/truncated at the max token limit/, error.message)
-        assert_match(/output: #{Chat::ANTHROPIC_DEFAULT_MAX_TOKENS} tokens/, error.message)
-        assert_match(/limit: #{Chat::ANTHROPIC_DEFAULT_MAX_TOKENS} tokens/, error.message)
+        assert_match(/output: 4096 tokens/, error.message)
+        assert_match(/limit: 4096 tokens/, error.message)
       end
 
       test "raises MaxTokensExceededError when output tokens exceeds max tokens" do
         @cog.config.provider(:openai)
 
-        mock_model = stub(max_tokens: 4096)
-        mock_chat = mock_chat_with_response(
-          model: mock_model,
-          output_tokens: 4097,
-        )
+        stub_registry_max_tokens(4096, :openai)
+        mock_chat = mock_chat_with_response(output_tokens: 4097)
         stub_ruby_llm_context(mock_chat, :openai)
 
         assert_raises(Chat::MaxTokensExceededError) do
@@ -58,11 +52,8 @@ module Roast
       test "does not raise when output tokens is below max tokens" do
         @cog.config.provider(:openai)
 
-        mock_model = stub(max_tokens: 4096)
-        mock_chat = mock_chat_with_response(
-          model: mock_model,
-          output_tokens: 100,
-        )
+        stub_registry_max_tokens(4096, :openai)
+        mock_chat = mock_chat_with_response(output_tokens: 100)
         stub_ruby_llm_context(mock_chat, :openai)
 
         output = @cog.execute(make_input)
@@ -72,25 +63,19 @@ module Roast
       test "does not raise when output tokens is one below max tokens" do
         @cog.config.provider(:openai)
 
-        mock_model = stub(max_tokens: 4096)
-        mock_chat = mock_chat_with_response(
-          model: mock_model,
-          output_tokens: 4095,
-        )
+        stub_registry_max_tokens(4096, :openai)
+        mock_chat = mock_chat_with_response(output_tokens: 4095)
         stub_ruby_llm_context(mock_chat, :openai)
 
         output = @cog.execute(make_input)
         assert_equal "test response", output.response
       end
 
-      test "uses Anthropic 4096 fallback when model max_tokens is nil for Anthropic provider" do
+      test "uses Anthropic 4096 fallback when model is not in registry for Anthropic provider" do
         @cog.config.provider(:anthropic)
 
-        mock_model = stub(max_tokens: nil)
-        mock_chat = mock_chat_with_response(
-          model: mock_model,
-          output_tokens: 4096,
-        )
+        stub_registry_not_found(:anthropic)
+        mock_chat = mock_chat_with_response(output_tokens: 4096)
         stub_ruby_llm_context(mock_chat, :anthropic)
 
         assert_raises(Chat::MaxTokensExceededError) do
@@ -101,25 +86,19 @@ module Roast
       test "does not raise for Anthropic when output is below 4096 fallback" do
         @cog.config.provider(:anthropic)
 
-        mock_model = stub(max_tokens: nil)
-        mock_chat = mock_chat_with_response(
-          model: mock_model,
-          output_tokens: 4000,
-        )
+        stub_registry_not_found(:anthropic)
+        mock_chat = mock_chat_with_response(output_tokens: 4000)
         stub_ruby_llm_context(mock_chat, :anthropic)
 
         output = @cog.execute(make_input)
         assert_equal "test response", output.response
       end
 
-      test "uses model max_tokens when available even for Anthropic" do
+      test "uses registry max_tokens when available even for Anthropic" do
         @cog.config.provider(:anthropic)
 
-        mock_model = stub(max_tokens: 8192)
-        mock_chat = mock_chat_with_response(
-          model: mock_model,
-          output_tokens: 4096,
-        )
+        stub_registry_max_tokens(8192, :anthropic)
+        mock_chat = mock_chat_with_response(output_tokens: 4096)
         stub_ruby_llm_context(mock_chat, :anthropic)
 
         # 4096 < 8192, so no error
@@ -127,14 +106,11 @@ module Roast
         assert_equal "test response", output.response
       end
 
-      test "raises for Anthropic when output hits model-specified max_tokens" do
+      test "raises for Anthropic when output hits registry-specified max_tokens" do
         @cog.config.provider(:anthropic)
 
-        mock_model = stub(max_tokens: 8192)
-        mock_chat = mock_chat_with_response(
-          model: mock_model,
-          output_tokens: 8192,
-        )
+        stub_registry_max_tokens(8192, :anthropic)
+        mock_chat = mock_chat_with_response(output_tokens: 8192)
         stub_ruby_llm_context(mock_chat, :anthropic)
 
         assert_raises(Chat::MaxTokensExceededError) do
@@ -142,14 +118,11 @@ module Roast
         end
       end
 
-      test "skips check when max_tokens is nil for non-Anthropic provider" do
+      test "skips check when model is not in registry for non-Anthropic provider" do
         @cog.config.provider(:openai)
 
-        mock_model = stub(max_tokens: nil)
-        mock_chat = mock_chat_with_response(
-          model: mock_model,
-          output_tokens: 999_999,
-        )
+        stub_registry_not_found(:openai)
+        mock_chat = mock_chat_with_response(output_tokens: 999_999)
         stub_ruby_llm_context(mock_chat, :openai)
 
         # Can't determine the limit, so no error should be raised
@@ -160,11 +133,8 @@ module Roast
       test "skips check when response output_tokens is nil" do
         @cog.config.provider(:openai)
 
-        mock_model = stub(max_tokens: 4096)
-        mock_chat = mock_chat_with_response(
-          model: mock_model,
-          output_tokens: nil,
-        )
+        stub_registry_max_tokens(4096, :openai)
+        mock_chat = mock_chat_with_response(output_tokens: nil)
         stub_ruby_llm_context(mock_chat, :openai)
 
         output = @cog.execute(make_input)
@@ -184,9 +154,8 @@ module Roast
         end
       end
 
-      def mock_chat_with_response(model:, output_tokens:)
+      def mock_chat_with_response(output_tokens:)
         mock_chat = mock
-        mock_chat.stubs(:model).returns(model)
         mock_chat.stubs(:messages).returns([])
         mock_chat.stubs(:with_temperature).returns(mock_chat)
         mock_chat.stubs(:ask).returns(
@@ -212,6 +181,23 @@ module Roast
           mock_context.stubs(:anthropic_api_base=)
         end
         RubyLLM.stubs(:context).yields(mock_context).returns(mock_context)
+      end
+
+      # Stub the model registry to return a model with the given max_tokens.
+      # This tests the production path: effective_max_tokens calls RubyLLM.models.find.
+      def stub_registry_max_tokens(max_tokens, provider)
+        mock_model = stub(max_tokens: max_tokens)
+        mock_models = mock
+        mock_models.stubs(:find).returns(mock_model)
+        RubyLLM.stubs(:models).returns(mock_models)
+      end
+
+      # Stub the model registry to raise ModelNotFoundError, simulating an
+      # unknown model. This tests the Anthropic fallback path.
+      def stub_registry_not_found(provider)
+        mock_models = mock
+        mock_models.stubs(:find).raises(RubyLLM::ModelNotFoundError.new("Unknown model"))
+        RubyLLM.stubs(:models).returns(mock_models)
       end
     end
   end

--- a/test/roast/cogs/chat/max_tokens_test.rb
+++ b/test/roast/cogs/chat/max_tokens_test.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Roast
+  module Cogs
+    class ChatMaxTokensTest < ActiveSupport::TestCase
+      def setup
+        configure_ruby_llm
+        @cog = Chat.new(:test, ->(input) { input.prompt = "test message" })
+        @cog.config.api_key("dummy-test-key")
+        @cog.config.assume_model_exists!
+        @cog.config.no_show_prompt!
+        @cog.config.no_show_response!
+        @cog.config.no_show_stats!
+      end
+
+      def make_input
+        input = Chat::Input.new
+        input.prompt = "test message"
+        input
+      end
+
+      test "raises MaxTokensExceededError when output tokens equals max tokens for Anthropic" do
+        @cog.config.provider(:anthropic)
+
+        mock_model = stub(max_tokens: nil)
+        mock_chat = mock_chat_with_response(
+          model: mock_model,
+          output_tokens: Chat::ANTHROPIC_DEFAULT_MAX_TOKENS,
+        )
+        stub_ruby_llm_context(mock_chat, :anthropic)
+
+        error = assert_raises(Chat::MaxTokensExceededError) do
+          @cog.execute(make_input)
+        end
+
+        assert_match(/truncated at the max token limit/, error.message)
+        assert_match(/output: #{Chat::ANTHROPIC_DEFAULT_MAX_TOKENS} tokens/, error.message)
+        assert_match(/limit: #{Chat::ANTHROPIC_DEFAULT_MAX_TOKENS} tokens/, error.message)
+      end
+
+      test "raises MaxTokensExceededError when output tokens exceeds max tokens" do
+        @cog.config.provider(:openai)
+
+        mock_model = stub(max_tokens: 4096)
+        mock_chat = mock_chat_with_response(
+          model: mock_model,
+          output_tokens: 4097,
+        )
+        stub_ruby_llm_context(mock_chat, :openai)
+
+        assert_raises(Chat::MaxTokensExceededError) do
+          @cog.execute(make_input)
+        end
+      end
+
+      test "does not raise when output tokens is below max tokens" do
+        @cog.config.provider(:openai)
+
+        mock_model = stub(max_tokens: 4096)
+        mock_chat = mock_chat_with_response(
+          model: mock_model,
+          output_tokens: 100,
+        )
+        stub_ruby_llm_context(mock_chat, :openai)
+
+        output = @cog.execute(make_input)
+        assert_equal "test response", output.response
+      end
+
+      test "does not raise when output tokens is one below max tokens" do
+        @cog.config.provider(:openai)
+
+        mock_model = stub(max_tokens: 4096)
+        mock_chat = mock_chat_with_response(
+          model: mock_model,
+          output_tokens: 4095,
+        )
+        stub_ruby_llm_context(mock_chat, :openai)
+
+        output = @cog.execute(make_input)
+        assert_equal "test response", output.response
+      end
+
+      test "uses Anthropic 4096 fallback when model max_tokens is nil for Anthropic provider" do
+        @cog.config.provider(:anthropic)
+
+        mock_model = stub(max_tokens: nil)
+        mock_chat = mock_chat_with_response(
+          model: mock_model,
+          output_tokens: 4096,
+        )
+        stub_ruby_llm_context(mock_chat, :anthropic)
+
+        assert_raises(Chat::MaxTokensExceededError) do
+          @cog.execute(make_input)
+        end
+      end
+
+      test "does not raise for Anthropic when output is below 4096 fallback" do
+        @cog.config.provider(:anthropic)
+
+        mock_model = stub(max_tokens: nil)
+        mock_chat = mock_chat_with_response(
+          model: mock_model,
+          output_tokens: 4000,
+        )
+        stub_ruby_llm_context(mock_chat, :anthropic)
+
+        output = @cog.execute(make_input)
+        assert_equal "test response", output.response
+      end
+
+      test "uses model max_tokens when available even for Anthropic" do
+        @cog.config.provider(:anthropic)
+
+        mock_model = stub(max_tokens: 8192)
+        mock_chat = mock_chat_with_response(
+          model: mock_model,
+          output_tokens: 4096,
+        )
+        stub_ruby_llm_context(mock_chat, :anthropic)
+
+        # 4096 < 8192, so no error
+        output = @cog.execute(make_input)
+        assert_equal "test response", output.response
+      end
+
+      test "raises for Anthropic when output hits model-specified max_tokens" do
+        @cog.config.provider(:anthropic)
+
+        mock_model = stub(max_tokens: 8192)
+        mock_chat = mock_chat_with_response(
+          model: mock_model,
+          output_tokens: 8192,
+        )
+        stub_ruby_llm_context(mock_chat, :anthropic)
+
+        assert_raises(Chat::MaxTokensExceededError) do
+          @cog.execute(make_input)
+        end
+      end
+
+      test "skips check when max_tokens is nil for non-Anthropic provider" do
+        @cog.config.provider(:openai)
+
+        mock_model = stub(max_tokens: nil)
+        mock_chat = mock_chat_with_response(
+          model: mock_model,
+          output_tokens: 999_999,
+        )
+        stub_ruby_llm_context(mock_chat, :openai)
+
+        # Can't determine the limit, so no error should be raised
+        output = @cog.execute(make_input)
+        assert_equal "test response", output.response
+      end
+
+      test "skips check when response output_tokens is nil" do
+        @cog.config.provider(:openai)
+
+        mock_model = stub(max_tokens: 4096)
+        mock_chat = mock_chat_with_response(
+          model: mock_model,
+          output_tokens: nil,
+        )
+        stub_ruby_llm_context(mock_chat, :openai)
+
+        output = @cog.execute(make_input)
+        assert_equal "test response", output.response
+      end
+
+      test "MaxTokensExceededError inherits from Cog::CogError" do
+        assert Chat::MaxTokensExceededError.ancestors.include?(Cog::CogError)
+      end
+
+      private
+
+      def configure_ruby_llm
+        RubyLLM.configure do |config|
+          config.openai_api_key = "test-key"
+          config.anthropic_api_key = "test-key"
+        end
+      end
+
+      def mock_chat_with_response(model:, output_tokens:)
+        mock_chat = mock
+        mock_chat.stubs(:model).returns(model)
+        mock_chat.stubs(:messages).returns([])
+        mock_chat.stubs(:with_temperature).returns(mock_chat)
+        mock_chat.stubs(:ask).returns(
+          stub(
+            content: "test response",
+            model_id: "test-model",
+            input_tokens: 10,
+            output_tokens: output_tokens,
+          ),
+        )
+        mock_chat
+      end
+
+      def stub_ruby_llm_context(mock_chat, provider)
+        mock_context = mock
+        mock_context.stubs(:chat).returns(mock_chat)
+        case provider
+        when :openai
+          mock_context.stubs(:openai_api_key=)
+          mock_context.stubs(:openai_api_base=)
+        when :anthropic
+          mock_context.stubs(:anthropic_api_key=)
+          mock_context.stubs(:anthropic_api_base=)
+        end
+        RubyLLM.stubs(:context).yields(mock_context).returns(mock_context)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The chat cog had no awareness of output token limits. When an LLM response hit the max token limit, the truncated content was silently passed through as complete output. This is a footgun — workflows that depend on the full response would proceed with incomplete data and fail in confusing ways downstream.

The underlying `ruby_llm` gem (v1.15.0) always sends a `max_tokens` value in the request payload (Anthropic uses `model.max_tokens || 4096`, OpenAI uses family-specific limits), but the chat cog never checked whether the response actually hit that ceiling.

## Solution

Add `MaxTokensExceededError` (subclass of `Cog::CogError`) raised after each chat call when `response.output_tokens >= effective_max_tokens`.

**Detection heuristic**: ruby_llm 1.15.0 does not expose `stop_reason`/`finish_reason` from provider responses, so detection is metric-based — if the output token count equals or exceeds the effective max token limit, the content was almost certainly cut off mid-generation.

**Effective max tokens resolution**:
1. Use `chat.model.max_tokens` from model metadata if available
2. Fall back to `4096` for Anthropic (matching the provider's payload behavior)
3. Return `nil` (skip the check) for non-Anthropic providers when the model isn't in the registry (e.g., `assume_model_exists` with an unknown model)

The check is also skipped when `response.output_tokens` is `nil` — we can't detect what we can't measure.

## Changes

- **`lib/roast/cogs/chat.rb`**: `MaxTokensExceededError`, `ANTHROPIC_DEFAULT_MAX_TOKENS` constant, `verify_response_not_truncated!` and `effective_max_tokens` private methods
- **`test/roast/cogs/chat/max_tokens_test.rb`** (new): 11 tests covering exact equality, exceeding, boundary (one-below), Anthropic 4096 fallback, model-specified limits taking precedence, and skip conditions
- **`test/examples/functional/roast_examples_test.rb`**: Updated `stub_ruby_llm_chat` helper to stub `model` on `mock_chat` so the new `effective_max_tokens` call doesn't trigger unexpected invocation errors

## Test Results

```
11 runs, 17 assertions, 0 failures, 0 errors, 0 skips  (max_tokens_test.rb)
30 runs, 252 assertions, 0 failures, 0 errors, 0 skips  (roast_examples_test.rb)
```
