### PR TITLE
Add taskoutput tool result formatter

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_result.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_result.rb
@@ -292,6 +292,25 @@ module Roast
               ok_line(preview)
             end
 
+            # Formats a TaskOutput tool-result line.
+            #
+            # Content: the polled task's payload – an XML-ish string carrying a
+            # <status> (or <retrieval_status>) tag and an <output> body.
+            #
+            # Output: "TASKOUTPUT OK <status>" – the text inside <status>, or
+            # inside <retrieval_status> when <status> is absent. The status is
+            # omitted when neither tag is present, leaving a bare "TASKOUTPUT OK".
+            #
+            # Examples:
+            #   TASKOUTPUT OK completed
+            #   TASKOUTPUT OK pending
+            #   TASKOUTPUT OK
+            #
+            #: () -> String
+            def format_taskoutput
+              ok_line(tag_text("status") || tag_text("retrieval_status"))
+            end
+
             #: () -> String
             def format_unknown
               "UNKNOWN [#{tool_name}] OK #{tool_use_description}\n#{content}"
@@ -322,6 +341,20 @@ module Roast
             def error_line
               message = content.to_s.gsub(%r{</?tool_use_error>}, "").strip
               "#{tool_name.to_s.upcase} ERROR #{message}".strip
+            end
+
+            # Returns the stripped text inside the first <tag>…</tag> pair in the
+            # result content, or nil when the tag is absent. The body is captured
+            # verbatim by a non-greedy match, so — unlike an XML parser — a body
+            # that itself contains bare angle brackets (such as an error message)
+            # is extracted intact.
+            #
+            # Matches a single, flat element: the lazy capture stops at the first
+            # closing </tag>, and nested same-name tags are not handled.
+            #
+            #: (String) -> String?
+            def tag_text(tag)
+              content.to_s[%r{<#{Regexp.escape(tag)}>(.*?)</#{Regexp.escape(tag)}>}m, 1]&.strip
             end
 
             # Truncates to TRUNCATE_LIMIT chars, appending "..." when cut. nil -> "".

--- a/test/roast/cogs/agent/providers/claude/tool_result_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_result_test.rb
@@ -928,6 +928,54 @@ module Roast
           assert_equal "TASK OK #{"x" * (Claude::ToolResult::TRUNCATE_LIMIT - 3)}...", output
         end
 
+        test "format_taskoutput surfaces the status tag" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "taskoutput", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: "<status>completed</status><output>done</output>",
+            is_error: false,
+          )
+
+          output = tool_result.format
+
+          assert_equal "TASKOUTPUT OK completed", output
+        end
+
+        test "format_taskoutput falls back to retrieval_status when status is absent" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "taskoutput", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: "<retrieval_status>pending</retrieval_status>",
+            is_error: false,
+          )
+
+          output = tool_result.format
+
+          assert_equal "TASKOUTPUT OK pending", output
+        end
+
+        test "format_taskoutput reports a bare OK when no status tag is present" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "taskoutput", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: "<output>just output</output>",
+            is_error: false,
+          )
+
+          output = tool_result.format
+
+          assert_equal "TASKOUTPUT OK", output
+        end
+
         test "ok_line renders a bare OK line when given no parts" do
           tool_use_message = Claude::Messages::ToolUseMessage.new(
             type: :tool_use,


### PR DESCRIPTION
Closes https://github.com/Shopify/roast/issues/978

Taskoutput's content is a String that resembles XML content, something like:  
`content: "<status>completed</status><output>Some output</output>"`  
However it is not proper XML. It contains no shared root and special characters are not escaped.

This implementation uses regex to extact the information we need from the content.

Prototypes [[1]](https://app.graphite.com/github/pr/Shopify/roast/960/%5BPROTOTYPE%5D-Taskoutput-tool-result-formatter-backed-by-nokogiri) [[2]](https://app.graphite.com/github/pr/Shopify/roast/983/%5BPROTOTYPE%5D-%5BWIP%5D-REXML-for-parsing-taskoutput-tool-results) [[3]](https://app.graphite.com/github/pr/Shopify/roast/984/%5BPROTOTYPE%5D-%5BWIP%5D-Regex-for-parsing-taskoutput-results) explored various options, but regex was ultimately the best suited for our current needs.