### PR TITLE
Use tag_text in error_lines

### DIFF
--- a/lib/roast/cogs/agent/providers/claude/tool_result.rb
+++ b/lib/roast/cogs/agent/providers/claude/tool_result.rb
@@ -327,7 +327,8 @@ module Roast
               summary.present? ? "#{prefix} #{summary}" : prefix
             end
 
-            # Renders "<TOOL> ERROR <message>" with any <tool_use_error> wrapper stripped.
+            # Renders "<TOOL> ERROR <message>" – the text inside the
+            # <tool_use_error> wrapper, or the whole content when it is unwrapped.
             #
             # Reads the instance's `content` and `tool_name` to produce a single-line
             # error summary. Error messages are intentionally NOT truncated so the full
@@ -339,7 +340,7 @@ module Roast
             #
             #: () -> String
             def error_line
-              message = content.to_s.gsub(%r{</?tool_use_error>}, "").strip
+              message = tag_text("tool_use_error") || content.to_s.strip
               "#{tool_name.to_s.upcase} ERROR #{message}".strip
             end
 

--- a/test/roast/cogs/agent/providers/claude/tool_result_test.rb
+++ b/test/roast/cogs/agent/providers/claude/tool_result_test.rb
@@ -103,6 +103,22 @@ module Roast
           assert_equal "BASH ERROR File has not been read yet.", output
         end
 
+        test "error_line preserves special characters in the tool_use_error body" do
+          tool_use_message = Claude::Messages::ToolUseMessage.new(
+            type: :tool_use,
+            hash: { name: "bash", input: {} },
+          )
+          tool_result = Claude::ToolResult.new(
+            tool_use: tool_use_message,
+            content: "<tool_use_error>parse error: a < b && c > d, see <ref>x</ref> & exit 1</tool_use_error>",
+            is_error: true,
+          )
+
+          output = tool_result.send(:error_line)
+
+          assert_equal "BASH ERROR parse error: a < b && c > d, see <ref>x</ref> & exit 1", output
+        end
+
         test "error_line handles nil content gracefully" do
           tool_use_message = Claude::Messages::ToolUseMessage.new(
             type: :tool_use,


### PR DESCRIPTION
Closes https://github.com/Shopify/roast/issues/994

Now that we have a clean helper to parse content within `<> </>` tags, we can use it to refactor our `error_lines` method to reduce code reuse and to make it cleaner.