### PR TITLE
Make Pi the default agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Ruby-based domain-specific language for creating structured AI workflows. Buil
 Roast lets you orchestrate AI workflows by combining "cogs" - building blocks that interact with LLMs, run code, execute commands, and process data. Write workflows that:
 
 - **Chain AI steps together** - Output from one cog flows seamlessly to the next
-- **Run coding agents locally** - Full filesystem access with Claude Code or other providers
+- **Run coding agents locally** - Full filesystem access with Pi, Claude Code, or other providers
 - **Process collections** - Map operations over arrays with serial or parallel execution
 - **Control flow intelligently** - Conditional execution, iteration, and error handling
 - **Reuse workflow components** - Create modular, parameterized scopes
@@ -48,7 +48,7 @@ bin/roast execute analyze_codebase.rb
 ## Core Cogs
 
 - **`chat`** - Send prompts to cloud-based LLMs (OpenAI, Anthropic, Perplexity & Gemini)
-- **`agent`** - Run local coding agents with filesystem access (Claude Code CLI, etc.)
+- **`agent`** - Run local coding agents with filesystem access (Pi CLI, Claude Code CLI, etc.)
 - **`ruby`** - Execute custom Ruby code within workflows
 - **`cmd`** - Run shell commands and capture output
 - **`map`** - Process collections in serial or parallel
@@ -70,7 +70,7 @@ gem 'roast-ai'
 
 - Ruby 3.0+
 - API keys or local credentials for your AI provider
-- Claude Code CLI installed (for the default agent provider)
+- Pi CLI installed (for the default agent provider)
 
 ## Provider Configuration
 
@@ -100,7 +100,7 @@ end
 
 ### Agent cog
 
-The `agent` cog runs local agent CLIs. It defaults to `:claude` and currently supports:
+The `agent` cog runs local agent CLIs. It defaults to `:pi` and currently supports:
 
 - `:claude` - Claude Code CLI
 - `:pi` - Pi CLI
@@ -126,7 +126,7 @@ Roast currently supports four LLM providers for the `chat` cog: **OpenAI**, **An
 
 The default model is set per-provider and can only be overridden inside a `config` block. See the [tutorial](https://github.com/Shopify/roast/blob/main/tutorial/01_your_first_workflow/README.md#adding-configuration) for examples.
 
-The `agent` cog is powered by the Claude Code CLI by default, which handles its own authentication.
+The `agent` cog is powered by the Pi CLI by default, which handles its own authentication.
 
 ## Getting Started
 

--- a/examples/simple_agent.rb
+++ b/examples/simple_agent.rb
@@ -6,7 +6,7 @@
 config do
   agent do
     provider :claude
-    model "haiku"
+    model "anthropic/haiku"
     append_system_prompt "Always respond in haiku form"
     show_prompt!
     dump_raw_agent_messages_to "tmp/claude-messages.log"

--- a/internal/documentation/comments/doc-comments-external.md
+++ b/internal/documentation/comments/doc-comments-external.md
@@ -165,7 +165,7 @@ shortened names can be confusing. Use the complete module path.
 ```ruby
 # Configure the cog to use the default provider when invoking an agent
 #
-# The default provider used by Roast is Anthropic Claude Code (`:claude`).
+# The default provider used by Roast is Pi (`:pi`).
 #: () -> void
 def use_default_provider!
   @values[:provider] = nil
@@ -386,7 +386,7 @@ end
 # Configure the cog to use a specified provider when invoking an agent
 #
 # The provider is the source of the agent tool itself.
-# If no provider is specified, Anthropic Claude Code (`:claude`) will be used as the default provider.
+# If no provider is specified, Pi (`:pi`) will be used as the default provider.
 #
 # A provider must be properly installed on your system in order for Roast to be able to use it.
 #
@@ -519,7 +519,7 @@ Methods in `config_context.rbi` expose cog configuration interfaces and are the 
 #
 # #### Configure the LLM provider
 # - `provider(symbol)` - Set the agent provider (e.g., `:claude`)
-# - `use_default_provider!` - Use the default provider (`:claude`)
+# - `use_default_provider!` - Use the default provider (`:pi`)
 #
 # #### Configure the base command used to run the coding agent
 # - `command(string_or_array)` - Set the base command for invoking the agent

--- a/internal/documentation/comments/doc-comments.md
+++ b/internal/documentation/comments/doc-comments.md
@@ -70,7 +70,7 @@ These files provide the primary interface between users and Roast. The documenta
 # Configure the cog to use a specified provider when invoking an agent
 #
 # The provider is the source of the agent tool itself.
-# If no provider is specified, Anthropic Claude Code (`:claude`) will be used as the default provider.
+# If no provider is specified, Pi (`:pi`) will be used as the default provider.
 #
 # A provider must be properly installed on your system in order for Roast to be able to use it.
 #

--- a/lib/roast/cogs/agent/config.rb
+++ b/lib/roast/cogs/agent/config.rb
@@ -5,12 +5,12 @@ module Roast
   module Cogs
     class Agent < Cog
       class Config < Cog::Config
-        VALID_PROVIDERS = [:claude, :pi].freeze #: Array[Symbol]
+        VALID_PROVIDERS = [:pi, :claude].freeze #: Array[Symbol]
 
         # Configure the cog to use a specified provider when invoking an agent
         #
         # The provider is the source of the agent tool itself.
-        # If no provider is specified, Anthropic Claude Code (`:claude`) will be used as the default provider.
+        # If no provider is specified, Pi (`:pi`) will be used as the default provider.
         #
         # A provider must be properly installed on your system in order for Roast to be able to use it.
         #
@@ -24,7 +24,7 @@ module Roast
 
         # Configure the cog to use the default provider when invoking an agent
         #
-        # The default provider used by Roast is Anthropic Claude Code (`:claude`).
+        # The default provider used by Roast is Pi (`:pi`).
         #
         # The provider must be properly installed on your system in order for Roast to be able to use it.
         #

--- a/lib/roast/cogs/agent/providers/claude/claude_invocation.rb
+++ b/lib/roast/cogs/agent/providers/claude/claude_invocation.rb
@@ -56,7 +56,9 @@ module Roast
             #: (Agent::Config, String, String?, ?fork_session: bool) -> void
             def initialize(config, prompt, session, fork_session: true)
               @base_command = config.valid_command #: (String | Array[String])?
-              @model = config.valid_model #: String?
+              # The Claude CLI expects a bare model name, while Pi expects a fully-qualified
+              # `anthropic/<model>` id. Strip the prefix so the same model string works for either provider.
+              @model = config.valid_model&.delete_prefix("anthropic/") #: String?
               @append_system_prompt = config.valid_append_system_prompt #: String?
               @replace_system_prompt = config.valid_replace_system_prompt #: String?
               @apply_permissions = config.apply_permissions? #: bool

--- a/sorbet/rbi/shims/lib/roast/config_context.rbi
+++ b/sorbet/rbi/shims/lib/roast/config_context.rbi
@@ -141,7 +141,7 @@ module Roast
     #
     # #### Configure the agent provider
     # - `provider(symbol)` - Set the agent provider (e.g., `:claude`)
-    # - `use_default_provider!` - Use the default provider (`:claude`)
+    # - `use_default_provider!` - Use the default provider (`:pi`)
     #
     # #### Configure the base command used to run the coding agent
     # - `command(string_or_array)` - Set the base command for invoking the agent

--- a/test/roast/cogs/agent/providers/claude/claude_invocation_test.rb
+++ b/test/roast/cogs/agent/providers/claude/claude_invocation_test.rb
@@ -209,6 +209,17 @@ module Roast
           assert_equal "claude-opus-4-5-20251101", command[model_index + 1]
         end
 
+        test "command_line strips the anthropic/ prefix from the model" do
+          @config.model("anthropic/claude-opus-4-5-20251101")
+          invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil)
+
+          command = invocation.send(:command_line)
+
+          model_index = command.index("--model")
+          assert model_index
+          assert_equal "claude-opus-4-5-20251101", command[model_index + 1]
+        end
+
         test "command_line includes replace_system_prompt when configured" do
           @config.replace_system_prompt("Custom system prompt")
           invocation = Claude::ClaudeInvocation.new(@config, "Test prompt", nil)

--- a/tutorial/02_chaining_cogs/README.md
+++ b/tutorial/02_chaining_cogs/README.md
@@ -127,8 +127,29 @@ execute do
 end
 ```
 
-The `agent` cog is backed by a locally installed coding agent -- Anthropic's Claude Code is the default provider.
-You'll need to have Claude Code installed and configured correctly for this cog to run.
+The `agent` cog is backed by a locally installed coding agent -- Pi is the default provider.
+You'll need to have Pi installed and configured correctly for this cog to run.
+Roast also supports Claude code, which must be set explicitly in provider or an environment variable.
+
+### Specifying a Model
+
+Use a fully-qualified `provider/model` id:
+
+```ruby
+config do
+  agent do
+    model "anthropic/claude-haiku-4-5-20251001"
+  end
+end
+```
+
+Pi requires this qualified form. Claude Code expects a bare model name, so Roast strips the leading
+`anthropic/` prefix automatically when the `:claude` provider is used. Because of this, the same `model`
+string is portable across providers -- you can switch the agent provider without rewriting it.
+
+A bare name like `"claude-haiku-4-5-20251001"` (or a shorthand like `"haiku"`) still works when you've set
+`provider :claude`, but it will fail on the default Pi provider, which can't resolve an unqualified model name.
+Prefer the qualified form unless you have a reason not to.
 
 ### When to Use Agent vs Chat
 

--- a/tutorial/02_chaining_cogs/code_review.rb
+++ b/tutorial/02_chaining_cogs/code_review.rb
@@ -8,8 +8,8 @@
 
 config do
   agent do
-    model "claude-haiku-4-5-20251001"
-    provider :claude
+    model "anthropic/claude-haiku-4-5-20251001"
+    provider :pi
   end
 
   chat do

--- a/tutorial/02_chaining_cogs/session_resumption.rb
+++ b/tutorial/02_chaining_cogs/session_resumption.rb
@@ -13,6 +13,7 @@ config do
     model "gpt-5.4-nano"
   end
   agent do
+    provider :claude
     model "haiku"
     no_display!
     show_stats!

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -15,7 +15,7 @@ run coding agents, process data, and so much more.
 - Ruby installed (3.4.2+)
 - Roast gem installed
 - API keys for your AI provider (see [Configuration](https://github.com/Shopify/roast/blob/main/README.md#configuration) for setup)
-- Claude Code CLI installed and configured (to use coding agents)
+- Pi CLI installed and configured for default agent examples; Claude Code CLI installed and configured for examples that set `provider :claude`
 
 ## How to Use This Tutorial
 


### PR DESCRIPTION
Closes https://github.com/Shopify/roast/issues/997

Makes Pi the built in default agent provider and applies doc updates to reflect that change. 