### PR TITLE
Fix 1 stale doc comment(s) across 1 file(s)

### DIFF
--- a/lib/roast/cog/output.rb
+++ b/lib/roast/cog/output.rb
@@ -249,7 +249,7 @@ module Roast
           candidates.compact.uniq
         end
 
-        # Normalize a number string by removing separators and currency codes and validating format
+        # Normalize a number string by removing separators and currency symbols and validating format
         #
         #: (String) -> String?
         def normalize_number_string(raw)


### PR DESCRIPTION
Automated doc-comment audit on top of `07-10/doc-comment-audit-workflow` (base `a5f0059424`).

### `lib/roast/cog/output.rb`

- **Roast::Cog::Output::WithNumber#normalize_number_string** (confidence 0.9)
  - The comment says the method removes 'currency codes', but the regex `[\s$¢£€¥,_]` only strips whitespace, the currency symbols $¢£€¥, commas, and underscores — no letters are stripped, so alphabetic currency codes like 'USD' or 'EUR' are not removed.
  - evidence: lib/roast/cog/output.rb:255-261 (normalize_number_string implementation, regex on line 257)

