### PR TITLE
Fix 2 stale comment(s) across 1 file(s)

### DIFF
--- a/lib/roast/cog/output.rb
+++ b/lib/roast/cog/output.rb
@@ -249,11 +249,11 @@ module Roast
           candidates.compact.uniq
         end
 
-        # Normalize a number string by removing separators and currency codes and validating format
+        # Normalize a number string by removing separators and currency symbols and validating format
         #
         #: (String) -> String?
         def normalize_number_string(raw)
-          # Remove common digit separators and currency codes
+          # Remove common digit separators and currency symbols
           normalized = raw.strip.gsub(/[\s$¢£€¥,_]/, "")
 
           # Validate it looks like a number (optional minus, digits, optional decimal, optional scientific notation)


### PR DESCRIPTION
Automated comment audit on top of `07-10/doc-comment-audit-workflow` (base `2c10411077`).

### `lib/roast/cog/output.rb`

- **Roast::Cog::Output::WithNumber#normalize_number_string** (confidence 0.9)
  - "currency codes" is wrong terminology: the method's `gsub(/[\s$¢£€¥,_]/, "")` strips currency symbols ($, ¢, £, €, ¥) and separator characters (whitespace, comma, underscore), not alphabetic currency codes like USD or EUR. The neighboring comment at output.rb:242 correctly calls these "currency symbols".
  - evidence: lib/roast/cog/output.rb:252 (comment), lib/roast/cog/output.rb:255-261 (implementation), lib/roast/cog/output.rb:242 (sibling comment using correct term "currency symbols")
- **inline @ L256** (confidence 0.9)
  - The comment says the code removes 'currency codes', but the regex `/[\s$¢£€¥,_]/` (line 257) only matches whitespace, digit separators (comma, underscore), and currency *symbols* ($¢£€¥). It contains no letters, so it never strips alphabetic currency codes like USD or EUR.
  - evidence: lib/roast/cog/output.rb:256-257

